### PR TITLE
feat(canvas): implement infinite dot-grid canvas and navigation

### DIFF
--- a/src/main/java/org/libreuml/ui/canvas/CanvasNavigator.java
+++ b/src/main/java/org/libreuml/ui/canvas/CanvasNavigator.java
@@ -1,0 +1,74 @@
+package org.libreuml.ui.canvas;
+
+import javafx.scene.image.PixelWriter;
+import javafx.scene.image.WritableImage;
+import javafx.scene.input.MouseEvent;
+import javafx.scene.layout.*;
+import javafx.scene.paint.Color;
+import javafx.scene.Cursor;
+
+public class CanvasNavigator {
+
+    private final Pane canvas;
+    private double dragStartX;
+    private double dragStartY;
+
+    public CanvasNavigator(Pane canvas) {
+        this.canvas = canvas;
+        initializeDots();
+        initializeEvents();
+    }
+
+    private void initializeDots() {
+        double spacing = 20.0;
+        WritableImage pattern = new WritableImage((int) spacing, (int) spacing);
+        PixelWriter writer = pattern.getPixelWriter();
+
+        Color dotColor = Color.web("#505050");
+
+        writer.setColor(0, 0, dotColor);
+        writer.setColor(0, 1, dotColor);
+        writer.setColor(1, 0, dotColor);
+        writer.setColor(1, 1, dotColor);
+
+        BackgroundImage gridImg = new BackgroundImage(
+                pattern,
+                BackgroundRepeat.REPEAT, BackgroundRepeat.REPEAT,
+                BackgroundPosition.DEFAULT, BackgroundSize.DEFAULT
+        );
+
+        canvas.setBackground(new Background(
+                new BackgroundFill[] {
+                        new BackgroundFill(Color.web("#1e1e1e"), null, null)
+                },
+                new BackgroundImage[] {
+                        gridImg
+                }
+        ));
+    }
+
+    private void initializeEvents() {
+        canvas.setOnMousePressed(this::onMousePressed);
+        canvas.setOnMouseDragged(this::onMouseDragged);
+        canvas.setOnMouseReleased(e -> canvas.setCursor(Cursor.DEFAULT));
+    }
+
+
+
+    private void onMousePressed(MouseEvent event) {
+        this.dragStartX = event.getSceneX() - canvas.getTranslateX();
+        this.dragStartY = event.getSceneY() - canvas.getTranslateY();
+        canvas.setCursor(Cursor.CLOSED_HAND);
+    }
+
+    private void onMouseDragged(MouseEvent event) {
+        double newX = event.getSceneX() - this.dragStartX;
+        double newY = event.getSceneY() - this.dragStartY;
+        canvas.setTranslateX(newX);
+        canvas.setTranslateY(newY);
+    }
+
+    public void onMouseReleased() {
+        canvas.setCursor(Cursor.DEFAULT);
+    }
+}

--- a/src/main/java/org/libreuml/ui/controller/MainController.java
+++ b/src/main/java/org/libreuml/ui/controller/MainController.java
@@ -2,15 +2,45 @@ package org.libreuml.ui.controller;
 
 import javafx.fxml.FXML;
 import javafx.scene.layout.Pane;
+import javafx.scene.layout.StackPane;
+import javafx.scene.shape.Rectangle;
+import org.libreuml.ui.canvas.CanvasNavigator; // Asegúrate de importar esto
 import org.springframework.stereotype.Component;
 
 @Component
 public class MainController {
 
     @FXML
-    private Pane canvasPane;
+    private StackPane viewport; // La ventana (necesita fx:id="viewport" en el FXML)
+
+    @FXML
+    private Pane canvasPane;    // El lienzo (necesita fx:id="canvasPane" en el FXML)
+
+    private CanvasNavigator navigator;
 
     public void initialize() {
+        // 1. EL LIENZO GIGANTE (Hijo)
+        // Le decimos que MIDA 50,000 sí o sí.
+        double gridSize = 50000;
+        canvasPane.setPrefSize(gridSize, gridSize);
+        canvasPane.setMinSize(gridSize, gridSize);
+        canvasPane.setMaxSize(gridSize, gridSize);
 
+        // 2. EL VISOR (Padre) - ¡ESTO ES LO QUE FALTABA!
+        // Le decimos al StackPane: "Tú no crezcas. Tú mide lo que quepa en la ventana (0 mínimo)".
+        // Esto evita que el padre intente igualar el tamaño del hijo gigante.
+        viewport.setMinSize(0, 0);
+        viewport.setMaxSize(Double.MAX_VALUE, Double.MAX_VALUE); // Opcional, para asegurar que crezca con la ventana
+
+        // 3. LA TIJERA (Clipping)
+        // Esto corta visualmente lo que sobresalga del visor para no tapar los menús.
+        Rectangle clip = new Rectangle();
+        clip.widthProperty().bind(viewport.widthProperty());
+        clip.heightProperty().bind(viewport.heightProperty());
+        viewport.setClip(clip);
+
+        // 4. INICIAR NAVEGACIÓN
+        this.navigator = new CanvasNavigator(canvasPane);
+        canvasPane.setOnMouseReleased(e -> navigator.onMouseReleased());
     }
 }

--- a/src/main/resources/css/style.css
+++ b/src/main/resources/css/style.css
@@ -27,12 +27,12 @@
 .menu-bar {
     -fx-background-color: -color-bg-app;
     -fx-border-color: -color-border;
-    -fx-border-width: 0 0 1 0; /* Solo borde inferior */
+    -fx-border-width: 0 0 1 0;
     -fx-padding: 5 10 5 10;
 }
 
 .menu-button:hover, .menu-button:showing, .menu-item:hover {
-    -fx-background-color: #3e3e42; /* Highlight sutil */
+    -fx-background-color: #3e3e42;
 }
 
 .menu-item .label {
@@ -68,14 +68,6 @@
     -fx-font-weight: bold;
 }
 
-.canvas-area {
-    -fx-background-color: -color-bg-canvas;
-
-    /* Truco para la Grilla de Puntos */
-    -fx-background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFklEQVQYV2NkYGA4AxIwMIAwcXAAQwUA9cQA9xg2mW8AAAAASUVORK5CYII=");
-    -fx-background-repeat: repeat;
-}
-
 .viewport {
     -fx-background-color: -color-bg-canvas;
 }
@@ -91,5 +83,5 @@
 .status-label {
     -fx-text-fill: -color-text-muted;
     -fx-font-size: 12px;
-    -fx-font-family: 'Consolas', 'Monospaced', monospace; /* Look técnico */
+    -fx-font-family: 'Consolas', 'Monospaced', monospace;
 }

--- a/src/main/resources/fxml/main-view.fxml
+++ b/src/main/resources/fxml/main-view.fxml
@@ -6,12 +6,11 @@
 <?import javafx.scene.control.Menu?>
 <?import javafx.scene.control.MenuBar?>
 <?import javafx.scene.control.MenuItem?>
-<?import javafx.scene.control.ScrollPane?>
 <?import javafx.scene.layout.BorderPane?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.Pane?>
+<?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
-
 
 <BorderPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="768.0" prefWidth="1024.0" stylesheets="@../css/style.css" xmlns="http://javafx.com/javafx/25" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.libreuml.ui.controller.MainController">
    <top>
@@ -43,13 +42,11 @@
          </children>
       </VBox>
    </left>
-   <center>
-      <ScrollPane prefHeight="200.0" prefWidth="200.0" BorderPane.alignment="CENTER">
-         <content>
-            <Pane fx:id="canvasPane" prefHeight="2000.0" prefWidth="2000.0" stylesheets="@../css/style.css" />
-         </content>
-      </ScrollPane>
-   </center>
+    <center>
+        <StackPane fx:id="viewport" prefHeight="200.0" prefWidth="200.0" BorderPane.alignment="CENTER">
+            <Pane fx:id="canvasPane" maxHeight="-Infinity" maxWidth="-Infinity" prefHeight="20000.0" prefWidth="20000.0" styleClass="canvas-area" />
+        </StackPane>
+    </center>
    <bottom>
       <HBox prefHeight="100.0" prefWidth="200.0" spacing="10.0" styleClass="status-bar" BorderPane.alignment="CENTER">
          <children>


### PR DESCRIPTION
- Implemented 'CanvasNavigator' to generate a high-performance dot-grid background programmatically.
- Configured infinite scrolling mechanics using a 50,000px canvas within a constrained viewport.
- Applied clipping mask to the viewport to ensure the canvas respects the main layout boundaries.
- Enabled smooth mouse-drag panning for canvas navigation.
- Fixed layout conflicts where the large canvas forced the window to expand.
- Cleaned up CSS styles to allow Java-based background rendering.