### PR TITLE
feat(editor): implement context-aware interaction and architectural r…

### DIFF
--- a/frontend/src/features/diagram/components/ContextMenu.tsx
+++ b/frontend/src/features/diagram/components/ContextMenu.tsx
@@ -1,0 +1,52 @@
+import { memo } from 'react';
+
+interface MenuOption {
+  label: string;
+  onClick: () => void;
+  icon?: string; 
+  danger?: boolean; 
+}
+
+interface ContextMenuProps {
+  x: number;
+  y: number;
+  options: MenuOption[];
+  onClose: () => void;
+}
+
+const ContextMenu = ({ x, y, options, onClose }: ContextMenuProps) => {
+  return (
+    <>
+      <div 
+        className="fixed inset-0 z-40" 
+        onClick={onClose} 
+        onContextMenu={(e) => { e.preventDefault(); onClose(); }} 
+      />
+
+      <div
+        className="fixed z-50 min-w-40 bg-slate-900 border border-slate-700 rounded-lg shadow-xl py-1 overflow-hidden"
+        style={{ top: y, left: x }}
+      >
+        {options.map((opt, index) => (
+          <button
+            key={index}
+            onClick={() => {
+              opt.onClick();
+              onClose();
+            }}
+            className={`
+              w-full px-4 py-2 text-left text-sm transition-colors
+              ${opt.danger 
+                ? 'text-red-400 hover:bg-red-500/10' 
+                : 'text-slate-200 hover:bg-blue-600 hover:text-white'}
+            `}
+          >
+            {opt.label}
+          </button>
+        ))}
+      </div>
+    </>
+  );
+};
+
+export default memo(ContextMenu);

--- a/frontend/src/features/diagram/components/DiagramCanvas.tsx
+++ b/frontend/src/features/diagram/components/DiagramCanvas.tsx
@@ -1,19 +1,58 @@
-import ReactFlow, { Background, Controls, useReactFlow } from 'reactflow';
+// src/features/diagram/components/DiagramCanvas.tsx
+import { useState, useCallback } from 'react';
+import ReactFlow, { Background, Controls, useReactFlow, type Node } from 'reactflow';
 import 'reactflow/dist/style.css';
 import { useDiagramStore } from '../../../store/diagramStore';
+import type { UmlClassData } from '../../../types/diagram.types';
 import UmlClassNode from './UmlClassNode';
+import ContextMenu from './ContextMenu';
 
 const nodeTypes = { umlClass: UmlClassNode };
 
 export default function DiagramCanvas() {
-  const { nodes, edges, onNodesChange, onEdgesChange, onConnect, addNode } = useDiagramStore();
-  const { screenToFlowPosition } = useReactFlow();
+  const { 
+    nodes, edges, onNodesChange, onEdgesChange, onConnect, 
+    addNode, deleteNode, duplicateNode, clearCanvas 
+  } = useDiagramStore();
 
-  const handleContextMenu = (event: React.MouseEvent) => {
+  const { screenToFlowPosition } = useReactFlow();
+  const [menu, setMenu] = useState<{ x: number; y: number; type: 'pane' | 'node'; nodeId?: string } | null>(null);
+
+  const onPaneContextMenu = useCallback((event: React.MouseEvent) => {
     event.preventDefault();
-    const position = screenToFlowPosition({ x: event.clientX, y: event.clientY });
-    addNode(position);
-  };
+    setMenu({ x: event.clientX, y: event.clientY, type: 'pane' });
+  }, []);
+
+  const onNodeContextMenu = useCallback((event: React.MouseEvent, node: Node<UmlClassData>) => {
+    event.preventDefault();
+    setMenu({ x: event.clientX, y: event.clientY, type: 'node', nodeId: node.id });
+  }, []);
+
+  const closeMenu = () => setMenu(null);
+
+  const menuOptions = menu?.type === 'pane' 
+    ? [
+        { 
+          label: 'Add Class', 
+          onClick: () => addNode(screenToFlowPosition({ x: menu.x, y: menu.y })) 
+        },
+        { 
+          label: 'Clean Canvas', 
+          onClick: () => clearCanvas(), 
+          danger: true 
+        },
+      ]
+    : [
+        { 
+          label: 'Duplicate', 
+          onClick: () => { if (menu?.nodeId) duplicateNode(menu.nodeId); } 
+        },
+        { 
+          label: 'Delete', 
+          onClick: () => { if (menu?.nodeId) deleteNode(menu.nodeId); }, 
+          danger: true 
+        },
+      ];
 
   return (
     <div className="w-screen h-screen bg-gray-50">
@@ -23,13 +62,19 @@ export default function DiagramCanvas() {
         onNodesChange={onNodesChange}
         onEdgesChange={onEdgesChange}
         onConnect={onConnect}
-        onPaneContextMenu={handleContextMenu}
         nodeTypes={nodeTypes}
+        onPaneContextMenu={onPaneContextMenu}
+        onNodeContextMenu={onNodeContextMenu}
+        onPaneClick={closeMenu}
         fitView
       >
         <Background/>
         <Controls />
       </ReactFlow>
+
+      {menu && (
+        <ContextMenu x={menu.x} y={menu.y} options={menuOptions} onClose={closeMenu} />
+      )}
     </div>
   );
 }

--- a/frontend/src/features/diagram/components/DiagramEditor.tsx
+++ b/frontend/src/features/diagram/components/DiagramEditor.tsx
@@ -1,5 +1,5 @@
 import { ReactFlowProvider } from 'reactflow';
-import DiagramCanvas from './DiagramCanvas';
+import DiagramCanvas from './DiagramCanvas'; 
 
 export default function DiagramEditor() {
   return (


### PR DESCRIPTION
…efactor

- Desacoplado DiagramCanvas de DiagramEditor para corregir el scope del ReactFlowProvider
- Implementado ContextMenu genérico con soporte para Pane (Canvas) y Nodes
- Agregadas acciones deleteNode (con limpieza de edges), duplicateNode y clearCanvas al store
- Refinada lógica de colisiones mediante validación de Bounding Box (Rectangular)
- Implementado auto-edit UX: activación inmediata de edición al crear nuevos nodos
- Tipado estricto de eventos de React Flow eliminando el uso de 'any'

Ref: RoadMap-Phase2-Interaction-Complete