### PR TITLE
feat: add support for UML stereotypes (interface and abstract classes).

### DIFF
--- a/frontend/src/features/diagram/components/DiagramCanvas.tsx
+++ b/frontend/src/features/diagram/components/DiagramCanvas.tsx
@@ -7,8 +7,9 @@ import { useContextMenu } from "../hooks/useContextMenu";
 import { useState } from "react";
 import ClassEditorModal from "./ClassEditorModal";
 
-const nodeTypes = { umlClass: UmlClassNode };
 
+
+const nodeTypes = { umlClass: UmlClassNode };
 export default function DiagramCanvas() {
   const {
     nodes,
@@ -38,7 +39,17 @@ export default function DiagramCanvas() {
           {
             label: "Add Class",
             onClick: () =>
-              addNode(screenToFlowPosition({ x: menu.x, y: menu.y })),
+              addNode(screenToFlowPosition({ x: menu.x, y: menu.y }), 'class'),
+          },
+          {
+            label: "Add Interface",
+            onClick: () =>
+              addNode(screenToFlowPosition({ x: menu.x, y: menu.y }), 'interface'),
+          },
+          {
+            label: "Add Abstract Class",
+            onClick: () =>
+              addNode(screenToFlowPosition({ x: menu.x, y: menu.y }), 'abstract'),
           },
           {
             label: "Clean Canvas",
@@ -88,7 +99,6 @@ export default function DiagramCanvas() {
         <Background />
         <Controls />
       </ReactFlow>
-
       {menu && (
         <ContextMenu
           x={menu.x}

--- a/frontend/src/features/diagram/components/nodes/UmlClassNode.tsx
+++ b/frontend/src/features/diagram/components/nodes/UmlClassNode.tsx
@@ -2,26 +2,25 @@ import { memo, useState, useEffect } from "react";
 import { Handle, Position, type NodeProps } from "reactflow";
 import type { UmlClassData } from "../../../../types/diagram.types";
 import { useDiagramStore } from "../../../../store/diagramStore";
-/**
- * UmlClassNode Component
- * * Represents a standard UML Class box in the visual editor.
- * It consumes the "UmlClassData" contract we defined earlier.
- */
 
 const UmlClassNode = ({ id, data }: NodeProps<UmlClassData>) => {
- const updateNodeData = useDiagramStore((s) => s.updateNodeData);
+  const updateNodeData = useDiagramStore((s) => s.updateNodeData);
   const [isEditing, setIsEditing] = useState(false);
 
   useEffect(() => {
-    if (data.label === 'NewClass') {
+    if (data.label === "NewClass") {
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setIsEditing(true);
     }
-  }, []); 
+  }, []);
 
   const handleLabelChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     updateNodeData(id, { label: e.target.value });
   };
+
+  const isInterface = data.stereotype === "interface";
+  const isAbstract = data.stereotype === "abstract";
+
   return (
     <div className="bg-white border-2 border-black rounded-sm w-64 shadow-md overflow-hidden">
       <Handle
@@ -50,6 +49,18 @@ const UmlClassNode = ({ id, data }: NodeProps<UmlClassData>) => {
         className="bg-yellow-100 p-2 border-b-2 border-black text-center cursor-pointer"
         onDoubleClick={() => setIsEditing(true)}
       >
+        {isInterface && (
+          <small className="block text-[10px] leading-tight mb-0.5 text-slate-700">
+            &lt;&lt;interface&gt;&gt;
+          </small>
+        )}
+        
+        {isAbstract && (
+          <small className="block text-[10px] leading-tight mb-0.5 text-slate-700 italic">
+            &lt;&lt;abstract&gt;&gt;
+          </small>
+        )}
+
         {isEditing ? (
           <input
             autoFocus

--- a/frontend/src/store/diagramStore.ts
+++ b/frontend/src/store/diagramStore.ts
@@ -11,7 +11,7 @@ import {
   type NodeChange,
 } from "reactflow";
 
-import type { UmlClassData } from "../types/diagram.types";
+import type { UmlClassData, stereotype } from "../types/diagram.types";
 
 // --- MOCKS (Initial Data) ---
 const initialNodes: Node<UmlClassData>[] = [
@@ -23,7 +23,7 @@ const initialNodes: Node<UmlClassData>[] = [
       label: "Persona",
       attributes: ["+ nombre: String", "+ edad: int"],
       methods: ["+ caminar(): void"],
-      stereotype: "Entity",
+      stereotype: 'class',
     },
   },
   {
@@ -34,6 +34,7 @@ const initialNodes: Node<UmlClassData>[] = [
       label: "Estudiante",
       attributes: ["+ codigo: String", "+ promedio: float"],
       methods: ["+ estudiar(): void"],
+      stereotype: 'interface',
     },
   },
 ];
@@ -49,7 +50,7 @@ interface DiagramState {
   onEdgesChange: OnEdgesChange;
   onConnect: OnConnect;
   updateNodeData: (nodeId: string, newData: Partial<UmlClassData>) => void;
-  addNode: (position: { x: number; y: number }) => void;
+  addNode: (position: { x: number; y: number }, stereotype?: stereotype ) => void;
   deleteNode: (nodeId: string) => void;
   duplicateNode: (nodeId: string) => void; 
   clearCanvas: () => void; 
@@ -77,7 +78,7 @@ export const useDiagramStore = create<DiagramState>((set, get) => ({
     });
   },
 
-  addNode: (position) => {
+  addNode: (position, stereotype = 'class') => {
     const { nodes } = get();
     const W = 260;
     const H = 200;
@@ -98,9 +99,10 @@ export const useDiagramStore = create<DiagramState>((set, get) => ({
       type: "umlClass",
       position,
       data: {
-        label: "NewClass",
+        label: `New ${stereotype}`,
         attributes: [],
         methods: [],
+        stereotype: stereotype,
       },
     };
 

--- a/frontend/src/types/diagram.types.ts
+++ b/frontend/src/types/diagram.types.ts
@@ -7,13 +7,15 @@ export interface UmlClassData {
   label: string;
   attributes: string[];
   methods: string[];
-  stereotype?: string; 
+  stereotype: stereotype; 
 }
+
+export type stereotype = 'class' | 'interface' | 'abstract';
 
 // UML Class Node Type for React Flow
 export interface UmlClassNode {
   id: string;
-  type: 'umlClass'; 
+  type: 'umlClass';
   position: { 
     x: number; 
     y: number; 


### PR DESCRIPTION
- Update UmlClassData type to include 'stereotype' property ('class' | 'interface' | 'abstract').
- Refactor UmlClassNode to visually render stereotypes:
    * Display '<<interface>>' label for interface types.
    * Apply italic font style for abstract classes.
- Update DiagramStore 'addNode' action to accept stereotype parameter.
- Expand Context Menu options to allow creating Classes, Interfaces, and Abstract classes directly.