### PR TITLE
refactor: extract sidebar components and optimize canvas performance

### DIFF
--- a/frontend/src/features/diagram/components/Sidebar.tsx
+++ b/frontend/src/features/diagram/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef } from "react";
-import type { stereotype } from "../../../types/diagram.types"; 
+import type { stereotype } from "../../../types/diagram.types";
 import {
   Box,
   FileCode,
@@ -12,13 +12,16 @@ import {
   MousePointer2,
 } from "lucide-react";
 
-import { DraggableItem, StaticItem } from "./SidebarItem";
+import { DraggableItem, ClickableItem } from "./SidebarItem";
+import { useDiagramStore } from "../../../store/diagramStore";
 
 export default function Sidebar() {
   const [openSections, setOpenSections] = useState<{ [key: string]: boolean }>({
     structure: true,
     relationships: true,
   });
+
+  const { activeConnectionMode, setConnectionMode } = useDiagramStore();
 
   const ghostRef = useRef<HTMLDivElement>(null);
 
@@ -85,38 +88,36 @@ export default function Sidebar() {
         </div>
 
         {/* SECTION: RELATIONSHIPS */}
-        <div className="mb-2">
-          <button
-            onClick={() => toggleSection("relationships")}
-            className="flex items-center w-full p-2 text-xs font-bold uppercase text-slate-500 hover:text-slate-300 transition-colors mb-1"
-          >
-            {openSections["relationships"] ? (
-              <ChevronDown className="w-4 h-4 mr-1" />
-            ) : (
-              <ChevronRight className="w-4 h-4 mr-1" />
-            )}
-            Relationships
-          </button>
-
-          {openSections["relationships"] && (
-            <div className="grid grid-cols-1 gap-2 pl-2 opacity-70">
-              <StaticItem
-                label="Association"
-                icon={<ArrowRight className="w-4 h-4" />}
-              />
-              <StaticItem
-                label="Inheritance"
-                icon={<ArrowUpFromLine className="w-4 h-4" />}
-              />
-              <StaticItem
-                label="Implementation"
-                icon={
-                  <GitCommitHorizontal className="w-4 h-4 border-b border-dashed border-transparent" />
-                }
-              />
-            </div>
-          )}
-        </div>
+        {openSections["relationships"] && (
+          <div className="grid grid-cols-1 gap-2 pl-2">
+            <ClickableItem
+              label="Association"
+              icon={<ArrowRight className="w-4 h-4" />}
+              isActive={activeConnectionMode === "association"}
+              onClick={() => setConnectionMode("association")}
+            />
+            <ClickableItem
+              label="Inheritance"
+              icon={<ArrowUpFromLine className="w-4 h-4" />}
+              isActive={activeConnectionMode === "inheritance"}
+              onClick={() => setConnectionMode("inheritance")}
+            />
+            <ClickableItem
+              label="Implementation"
+              icon={<GitCommitHorizontal className="w-4 h-4" />}
+              isActive={activeConnectionMode === "implementation"}
+              onClick={() => setConnectionMode("implementation")}
+            />
+            <ClickableItem
+              label="Dependency"
+              icon={
+                <ArrowRight className="w-4 h-4 border-b border-dashed border-transparent" />
+              }
+              isActive={activeConnectionMode === "dependency"}
+              onClick={() => setConnectionMode("dependency")}
+            />
+          </div>
+        )}
       </div>
 
       {/* FOOTER */}

--- a/frontend/src/features/diagram/components/SidebarItem.tsx
+++ b/frontend/src/features/diagram/components/SidebarItem.tsx
@@ -7,10 +7,13 @@ interface DraggableItemProps {
   onDragStart: (event: React.DragEvent, nodeType: stereotype) => void;
 }
 
-interface StaticItemProps {
+interface ClickableItemProps {
   label: string;
   icon: React.ReactNode;
+  isActive?: boolean;
+  onClick: () => void;
 }
+
 
 
 export function DraggableItem({ label, type, icon, onDragStart }: DraggableItemProps) {
@@ -30,11 +33,22 @@ export function DraggableItem({ label, type, icon, onDragStart }: DraggableItemP
   );
 }
 
-export function StaticItem({ label, icon }: StaticItemProps) {
+export function ClickableItem({ label, icon, isActive, onClick }: ClickableItemProps) {
   return (
-    <div className="flex items-center gap-3 p-2 rounded-md border border-transparent hover:bg-slate-800/50 cursor-not-allowed transition-all">
-      <div className="p-1.5 text-slate-500">{icon}</div>
-      <span className="text-sm text-slate-500">{label}</span>
+    <div
+      onClick={onClick}
+      className={`flex items-center gap-3 p-2 rounded-md border cursor-pointer transition-all ${
+        isActive
+          ? "bg-blue-900/40 border-blue-500 shadow-sm" // Estilo ACTIVO
+          : "border-transparent hover:bg-slate-800"    // Estilo INACTIVO
+      }`}
+    >
+      <div className={`p-1.5 rounded ${isActive ? "text-blue-400" : "text-slate-500"}`}>
+        {icon}
+      </div>
+      <span className={`text-sm ${isActive ? "text-white font-medium" : "text-slate-500"}`}>
+        {label}
+      </span>
     </div>
   );
 }

--- a/frontend/src/types/diagram.types.ts
+++ b/frontend/src/types/diagram.types.ts
@@ -1,7 +1,5 @@
-/**
- * Shared Domain Types.
- * Matches the JSON structure expected from the Backend.
- */
+export type stereotype = 'class' | 'interface' | 'abstract';
+export type UmlRelationType = 'association' | 'inheritance' | 'implementation' | 'dependency';
 
 export interface UmlClassData {
   label: string;
@@ -10,7 +8,6 @@ export interface UmlClassData {
   stereotype: stereotype; 
 }
 
-export type stereotype = 'class' | 'interface' | 'abstract';
 
 // UML Class Node Type for React Flow
 export interface UmlClassNode {


### PR DESCRIPTION
- Extract 'DraggableItem' and 'StaticItem' to new 'SidebarItem.tsx' component for better maintainability.
- Refactor 'Sidebar.tsx' to use isolated sub-components and clean up render logic.
- Optimize 'DiagramCanvas' drag-and-drop handlers using 'useRef' to access current nodes state without triggering re-renders (fixes ESLint dependency warnings).
- Stabilize 'getCenteredPosition' helper with useCallback.