### PR TITLE
feat: implement documentation notes

### DIFF
--- a/frontend/src/features/diagram/components/DiagramCanvas.tsx
+++ b/frontend/src/features/diagram/components/DiagramCanvas.tsx
@@ -7,13 +7,17 @@ import {
   NODE_WIDTH,
 } from "../../../store/diagramStore";
 import UmlClassNode from "./nodes/UmlClassNode";
+import UmlNoteNode from "./nodes/UmlNoteNode";
 import ContextMenu from "./ContextMenu";
 import { useContextMenu } from "../hooks/useContextMenu";
 import { useState, useCallback, useRef, useEffect } from "react";
 import ClassEditorModal from "./ClassEditorModal";
 import type { stereotype } from "../../../types/diagram.types";
 
-const nodeTypes = { umlClass: UmlClassNode };
+const nodeTypes = { 
+  umlClass: UmlClassNode,
+   umlNote: UmlNoteNode
+ };
 export default function DiagramCanvas() {
   const {
     nodes,
@@ -67,9 +71,7 @@ export default function DiagramCanvas() {
   const onDrop = useCallback(
     (event: React.DragEvent) => {
       event.preventDefault();
-      const type = event.dataTransfer.getData(
-        "application/reactflow"
-      ) as stereotype;
+      const type = event.dataTransfer.getData("application/reactflow") as stereotype;
 
       if (!type) return;
 

--- a/frontend/src/features/diagram/components/Sidebar.tsx
+++ b/frontend/src/features/diagram/components/Sidebar.tsx
@@ -10,6 +10,7 @@ import {
   ArrowUpFromLine,
   GitCommitHorizontal,
   MousePointer2,
+  StickyNote
 } from "lucide-react";
 
 import { DraggableItem, ClickableItem } from "./SidebarItem";
@@ -83,6 +84,13 @@ export default function Sidebar() {
                 type="abstract"
                 onDragStart={onDragStart}
               />
+              <div className="h-px bg-slate-800 my-1" /> 
+              <DraggableItem 
+                label="Note / Comment" 
+                icon={<StickyNote className="w-4 h-4 text-yellow-200" />} 
+                type="note" 
+                onDragStart={onDragStart} 
+              />
             </div>
           )}
         </div>
@@ -115,7 +123,7 @@ export default function Sidebar() {
                   <div className="w-2 h-2 rounded-full bg-green-500 shadow-[0_0_4px_rgba(34,197,94,0.8)]"></div>
                 </div>
               </div>
-              
+
               <ClickableItem
                 label="Association"
                 icon={<ArrowRight className="w-4 h-4" />}

--- a/frontend/src/features/diagram/components/nodes/UmlNoteNode.tsx
+++ b/frontend/src/features/diagram/components/nodes/UmlNoteNode.tsx
@@ -1,0 +1,70 @@
+import { memo, useState } from "react";
+import { Handle, Position, type NodeProps } from "reactflow";
+import { StickyNote } from "lucide-react";
+import type { UmlClassData } from "../../../../types/diagram.types";
+import { useDiagramStore } from "../../../../store/diagramStore";
+
+const UmlNoteNode = ({ id, data }: NodeProps<UmlClassData>) => {
+  const updateNodeData = useDiagramStore((s) => s.updateNodeData);
+  
+  const [editingTitle, setEditingTitle] = useState(false);
+  const [editingContent, setEditingContent] = useState(false);
+
+  const handleStyle = "w-3 h-3 !bg-yellow-500 border border-white opacity-0 group-hover:opacity-100 transition-opacity";
+
+  return (
+    <div className="bg-yellow-50 border border-yellow-400 rounded-sm w-56 shadow-md overflow-visible relative group flex flex-col font-sans">
+      
+      <Handle type="source" position={Position.Bottom} className={handleStyle} />
+      <Handle type="source" position={Position.Top} className={handleStyle} />
+      <Handle type="source" position={Position.Left} className={handleStyle} />
+      <Handle type="source" position={Position.Right} className={handleStyle} />
+
+      <div 
+        className="bg-yellow-200 p-2 border-b border-yellow-300 rounded-t-sm flex items-center justify-between"
+        onDoubleClick={() => setEditingTitle(true)}
+      >
+        {editingTitle ? (
+           <input
+             autoFocus
+             className="w-full bg-transparent font-bold text-sm text-yellow-900 outline-none placeholder-yellow-700/50"
+             value={data.label}
+             onChange={(e) => updateNodeData(id, { label: e.target.value })}
+             onBlur={() => setEditingTitle(false)}
+             onKeyDown={(e) => e.key === "Enter" && setEditingTitle(false)}
+             placeholder="Título..."
+           />
+        ) : (
+           <div className="font-bold text-sm text-yellow-900 truncate w-full pr-4">
+             {data.label}
+           </div>
+        )}
+        
+        {!editingTitle && <StickyNote className="w-3 h-3 text-yellow-600 shrink-0" />}
+      </div>
+
+      <div 
+        className="p-2 min-h-20 cursor-text"
+        onClick={() => !editingContent && setEditingContent(true)}
+      >
+        {editingContent ? (
+          <textarea
+            autoFocus
+            className="w-full h-full min-h-20 bg-transparent resize-none outline-none text-xs text-slate-700 leading-relaxed font-mono"
+            value={data.content || ""}
+            onChange={(e) => updateNodeData(id, { content: e.target.value })}
+            onBlur={() => setEditingContent(false)}
+            placeholder="Detalles de la nota..."
+          />
+        ) : (
+          <div className="text-xs text-slate-700 leading-relaxed whitespace-pre-wrap font-mono">
+             {data.content || <span className="opacity-40 italic">Clic para escribir...</span>}
+          </div>
+        )}
+      </div>
+
+    </div>
+  );
+};
+
+export default memo(UmlNoteNode);

--- a/frontend/src/types/diagram.types.ts
+++ b/frontend/src/types/diagram.types.ts
@@ -1,8 +1,9 @@
-export type stereotype = 'class' | 'interface' | 'abstract';
+export type stereotype = 'class' | 'interface' | 'abstract' | 'note';
 export type UmlRelationType = 'association' | 'inheritance' | 'implementation' | 'dependency';
 
 export interface UmlClassData {
   label: string;
+  content?: string;
   attributes: string[];
   methods: string[];
   stereotype: stereotype; 


### PR DESCRIPTION
- Feat Note Node: Add 'UmlNoteNode' with separate editable title and content (Post-it style).
- Logic Relations: Update store to force 'documentation' edges (dotted yellow) when connecting from a Note.
- Refactor Sidebar: Extract items to 'SidebarItem.tsx' and add visual Connection Legend (Blue/Source, Green/Target).
- Optimize Canvas: Fix 'overflow-visible' on nodes and force handle colors for better UX.
- Performance: Implement 'useRef' pattern in DiagramCanvas to prevent drag-and-drop re-renders.
- Update Types: Add 'note' stereotype and optional 'content' field to data model.