### PR TITLE
feat(history): implement undo/redo with zundo middleware

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "reactflow": "^11.11.4",
+        "zundo": "^2.3.0",
         "zustand": "^5.0.9"
       },
       "devDependencies": {
@@ -9096,11 +9097,30 @@
         "zod": "^3.25.0 || ^4.0.0"
       }
     },
+    "node_modules/zundo": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/zundo/-/zundo-2.3.0.tgz",
+      "integrity": "sha512-4GXYxXA17SIKYhVbWHdSEU04P697IMyVGXrC2TnzoyohEAWytFNOKqOp5gTGvaW93F/PM5Y0evbGtOPF0PWQwQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/charkour"
+      },
+      "peerDependencies": {
+        "zustand": "^4.3.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zustand": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/zustand": {
       "version": "5.0.9",
       "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.9.tgz",
       "integrity": "sha512-ALBtUj0AfjJt3uNRQoL1tL2tMvj6Gp/6e39dnfT6uzpelGru8v1tPOGBzayOWbPJvujM8JojDk3E1LxeFisBNg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.20.0"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "frontend",
   "private": true,
   "version": "0.0.0",
-  "main": "dist-electron/main.js",  
+  "main": "dist-electron/main.js",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -17,6 +17,7 @@
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "reactflow": "^11.11.4",
+    "zundo": "^2.3.0",
     "zustand": "^5.0.9"
   },
   "devDependencies": {
@@ -59,7 +60,7 @@
           ]
         }
       ],
-      "icon": "public/logo.png" 
+      "icon": "public/logo.png"
     }
   }
 }

--- a/frontend/src/features/diagram/components/Header.tsx
+++ b/frontend/src/features/diagram/components/Header.tsx
@@ -1,5 +1,6 @@
 import { useRef, useState, useEffect } from "react";
 import { useReactFlow } from "reactflow";
+import { useStore } from "zustand";
 import {
   Box,
   Download,
@@ -20,28 +21,43 @@ import {
   Cloud,
 } from "lucide-react";
 import { useDiagramStore } from "../../../store/diagramStore";
-import { ExportService } from "../services/export.service"; 
+import { ExportService } from "../services/export.service";
 
 export default function Header() {
-  const { zoomIn, zoomOut, fitView, toObject, setViewport, getNodes } = useReactFlow();
-  
-  const { 
-    diagramName, 
-    diagramId, 
-    setDiagramName, 
-    loadDiagram, 
-    showMiniMap, 
-    toggleMiniMap 
+  const { zoomIn, zoomOut, fitView, toObject, setViewport, getNodes } =
+    useReactFlow();
+  const { undo, redo } = useDiagramStore.temporal.getState();
+
+  // 3. Suscripción REACTIVA para habilitar/deshabilitar botones
+  const canUndo = useStore(
+    useDiagramStore.temporal,
+    (state) => state.pastStates.length > 0,
+  );
+  const canRedo = useStore(
+    useDiagramStore.temporal,
+    (state) => state.futureStates.length > 0,
+  );
+
+  const {
+    diagramName,
+    diagramId,
+    setDiagramName,
+    loadDiagram,
+    showMiniMap,
+    toggleMiniMap,
   } = useDiagramStore();
-  
-  const [isDarkMode, setIsDarkMode] = useState(true); 
+
+  const [isDarkMode, setIsDarkMode] = useState(true);
   const [isExportMenuOpen, setIsExportMenuOpen] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const exportMenuRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
-      if (exportMenuRef.current && !exportMenuRef.current.contains(event.target as Node)) {
+      if (
+        exportMenuRef.current &&
+        !exportMenuRef.current.contains(event.target as Node)
+      ) {
         setIsExportMenuOpen(false);
       }
     };
@@ -56,14 +72,16 @@ export default function Header() {
   };
 
   const handleExportImage = async () => {
-    const viewportEl = document.querySelector('.react-flow__viewport') as HTMLElement;
+    const viewportEl = document.querySelector(
+      ".react-flow__viewport",
+    ) as HTMLElement;
     if (!viewportEl) return;
 
     try {
       const nodes = getNodes();
       await ExportService.downloadPng(viewportEl, nodes, diagramName);
     } catch (error) {
-      console.error('Error exportando imagen:', error);
+      console.error("Error exportando imagen:", error);
       alert("No se pudo generar la imagen. Intenta de nuevo.");
     }
     setIsExportMenuOpen(false);
@@ -82,29 +100,29 @@ export default function Header() {
       try {
         const content = e.target?.result as string;
         const parsedData = JSON.parse(content);
-        
+
         loadDiagram(parsedData);
-        
+
         if (parsedData.viewport) {
           const { x, y, zoom } = parsedData.viewport;
           setViewport({ x, y, zoom });
         } else {
           setTimeout(() => fitView({ duration: 800 }), 100);
         }
-
       } catch (error) {
         console.error("Error loading file:", error);
-        alert("Error al leer el archivo. Asegúrate de que sea un .json o .luml válido.");
+        alert(
+          "Error al leer el archivo. Asegúrate de que sea un .json o .luml válido.",
+        );
       }
     };
     reader.readAsText(file);
-    event.target.value = ""; 
+    event.target.value = "";
   };
 
   return (
     <header className="h-14 bg-surface-primary border-b border-surface-border flex items-center justify-between px-4 z-20 relative shadow-md font-sans">
-      
-      {/* SECCIÓN IZQUIERDA: Logo y Título */}
+      {/* LEFT SECTION : Logo y Title */}
       <div className="flex items-center gap-4">
         <div className="flex items-center gap-2 font-bold text-lg select-none">
           <Box className="w-6 h-6 text-uml-class-border fill-uml-class-bg/20" />
@@ -122,27 +140,61 @@ export default function Header() {
         />
       </div>
 
-      {/* SECCIÓN CENTRAL: Toolbar */}
+      {/* CENTER SECTION: Toolbar */}
       <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 flex items-center gap-1 bg-surface-secondary p-1 rounded-lg border border-surface-border shadow-lg">
-        <IconButton onClick={() => {}} icon={<Undo className="w-4 h-4" />} tooltip="Undo" disabled />
-        <IconButton onClick={() => {}} icon={<Redo className="w-4 h-4" />} tooltip="Redo" disabled />
+        <IconButton
+          onClick={() => undo()}
+          icon={<Undo className="w-4 h-4" />}
+          tooltip="Undo (Ctrl+Z)"
+          disabled={!canUndo}
+        />
+
+        <IconButton
+          onClick={() => redo()}
+          icon={<Redo className="w-4 h-4" />}
+          tooltip="Redo (Ctrl+Y)"
+          disabled={!canRedo}
+        />
         <div className="w-px h-4 bg-surface-border mx-1" />
         <IconButton
           onClick={toggleMiniMap}
-          icon={<Map className={`w-4 h-4 transition-colors ${showMiniMap ? "text-uml-class-border fill-uml-class-bg" : ""}`} />}
+          icon={
+            <Map
+              className={`w-4 h-4 transition-colors ${showMiniMap ? "text-uml-class-border fill-uml-class-bg" : ""}`}
+            />
+          }
           tooltip={showMiniMap ? "Hide MiniMap" : "Show MiniMap"}
         />
         <div className="w-px h-4 bg-surface-border mx-1" />
-        <IconButton onClick={() => zoomOut()} icon={<ZoomOut className="w-4 h-4" />} tooltip="Zoom Out" />
-        <IconButton onClick={() => fitView({ duration: 800 })} icon={<Maximize className="w-4 h-4" />} tooltip="Fit View" />
-        <IconButton onClick={() => zoomIn()} icon={<ZoomIn className="w-4 h-4" />} tooltip="Zoom In" />
+        <IconButton
+          onClick={() => zoomOut()}
+          icon={<ZoomOut className="w-4 h-4" />}
+          tooltip="Zoom Out"
+        />
+        <IconButton
+          onClick={() => fitView({ duration: 800 })}
+          icon={<Maximize className="w-4 h-4" />}
+          tooltip="Fit View"
+        />
+        <IconButton
+          onClick={() => zoomIn()}
+          icon={<ZoomIn className="w-4 h-4" />}
+          tooltip="Zoom In"
+        />
       </div>
 
-      {/* SECCIÓN DERECHA: Acciones */}
+      {/* RIGHT SECTION: Actions */}
       <div className="flex items-center gap-2">
         <div className="flex items-center gap-1 mr-2">
-          <button onClick={() => setIsDarkMode(!isDarkMode)} className="p-2 text-text-secondary hover:text-text-primary hover:bg-surface-hover rounded-md transition-colors">
-            {isDarkMode ? <Moon className="w-4 h-4" /> : <Sun className="w-4 h-4" />}
+          <button
+            onClick={() => setIsDarkMode(!isDarkMode)}
+            className="p-2 text-text-secondary hover:text-text-primary hover:bg-surface-hover rounded-md transition-colors"
+          >
+            {isDarkMode ? (
+              <Moon className="w-4 h-4" />
+            ) : (
+              <Sun className="w-4 h-4" />
+            )}
           </button>
           <button className="p-2 text-text-secondary hover:text-text-primary hover:bg-surface-hover rounded-md transition-colors">
             <Languages className="w-4 h-4" />
@@ -151,9 +203,18 @@ export default function Header() {
 
         <div className="h-5 w-px bg-surface-border mx-1" />
 
-        <input type="file" ref={fileInputRef} onChange={handleFileChange} accept=".json,.luml" className="hidden" />
+        <input
+          type="file"
+          ref={fileInputRef}
+          onChange={handleFileChange}
+          accept=".json,.luml"
+          className="hidden"
+        />
 
-        <button onClick={handleImportClick} className="flex items-center gap-2 px-3 py-1.5 text-sm font-medium text-text-secondary hover:text-text-primary hover:bg-surface-hover rounded-md transition-colors border border-transparent hover:border-surface-border">
+        <button
+          onClick={handleImportClick}
+          className="flex items-center gap-2 px-3 py-1.5 text-sm font-medium text-text-secondary hover:text-text-primary hover:bg-surface-hover rounded-md transition-colors border border-transparent hover:border-surface-border"
+        >
           <FolderOpen className="w-4 h-4" /> Import
         </button>
 
@@ -161,36 +222,49 @@ export default function Header() {
           <button
             onClick={() => setIsExportMenuOpen(!isExportMenuOpen)}
             className={`flex items-center gap-2 px-3 py-1.5 text-sm font-medium transition-colors border rounded-md 
-              ${isExportMenuOpen 
-                ? "bg-surface-hover text-text-primary border-surface-border" 
-                : "text-text-secondary hover:text-text-primary hover:bg-surface-hover border-transparent hover:border-surface-border"
+              ${
+                isExportMenuOpen
+                  ? "bg-surface-hover text-text-primary border-surface-border"
+                  : "text-text-secondary hover:text-text-primary hover:bg-surface-hover border-transparent hover:border-surface-border"
               }`}
           >
             <Download className="w-4 h-4" />
             Export
-            <ChevronDown className={`w-3 h-3 transition-transform ${isExportMenuOpen ? "rotate-180" : ""}`} />
+            <ChevronDown
+              className={`w-3 h-3 transition-transform ${isExportMenuOpen ? "rotate-180" : ""}`}
+            />
           </button>
 
           {/* DROPDOWN */}
           {isExportMenuOpen && (
             <div className="absolute top-full right-0 mt-2 w-48 bg-surface-primary border border-surface-border rounded-md shadow-xl py-1 z-50 animate-in fade-in zoom-in-95 duration-100 flex flex-col">
-              
-              <button onClick={handleExportJson} className="flex items-center gap-3 px-4 py-2 text-sm text-text-secondary hover:text-text-primary hover:bg-surface-hover text-left transition-colors">
+              <button
+                onClick={handleExportJson}
+                className="flex items-center gap-3 px-4 py-2 text-sm text-text-secondary hover:text-text-primary hover:bg-surface-hover text-left transition-colors"
+              >
                 <FileJson className="w-4 h-4 text-uml-class-border" />
                 <span>Save as .luml</span>
               </button>
 
-              <button onClick={handleExportImage} className="flex items-center gap-3 px-4 py-2 text-sm text-text-secondary hover:text-text-primary hover:bg-surface-hover text-left transition-colors">
+              <button
+                onClick={handleExportImage}
+                className="flex items-center gap-3 px-4 py-2 text-sm text-text-secondary hover:text-text-primary hover:bg-surface-hover text-left transition-colors"
+              >
                 <ImageIcon className="w-4 h-4 text-purple-400" />
                 <span>Export to PNG</span>
               </button>
 
               <div className="h-px bg-surface-border my-1 mx-2" />
 
-              <button disabled className="flex items-center gap-3 px-4 py-2 text-sm text-text-muted cursor-not-allowed opacity-50 text-left">
+              <button
+                disabled
+                className="flex items-center gap-3 px-4 py-2 text-sm text-text-muted cursor-not-allowed opacity-50 text-left"
+              >
                 <Cloud className="w-4 h-4" />
                 <span>Save to Cloud</span>
-                <span className="ml-auto text-[10px] bg-surface-secondary px-1.5 py-0.5 rounded border border-surface-border uppercase tracking-wider font-bold">Soon</span>
+                <span className="ml-auto text-[10px] bg-surface-secondary px-1.5 py-0.5 rounded border border-surface-border uppercase tracking-wider font-bold">
+                  Soon
+                </span>
               </button>
             </div>
           )}

--- a/frontend/src/store/diagramStore.ts
+++ b/frontend/src/store/diagramStore.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { temporal } from "zundo";
 import {
   addEdge,
   applyNodeChanges,
@@ -98,195 +99,232 @@ interface DiagramStoreState {
   changeEdgeType: (edgeId: string, newType: UmlRelationType) => void;
   reverseEdge: (edgeId: string) => void;
   recalculateNodeConnections: (nodeId: string) => void;
+
+  triggerHistorySnapshot: () => void;
 }
 
-export const useDiagramStore = create<DiagramStoreState>((set, get) => ({
-  diagramId: crypto.randomUUID(),
-  diagramName: "Untitled Diagram",
-  nodes: [],
-  edges: [],
-  activeConnectionMode: "association",
-  showMiniMap: false,
+export const useDiagramStore = create<DiagramStoreState>()(
+  temporal(
+    (set, get) => ({
+      diagramId: crypto.randomUUID(),
+      diagramName: "Untitled Diagram",
+      nodes: [],
+      edges: [],
+      activeConnectionMode: "association",
+      showMiniMap: false,
 
-  setDiagramName: (name) => set({ diagramName: name }),
+      setDiagramName: (name) => set({ diagramName: name }),
 
-  onNodesChange: (changes) =>
-    set({ nodes: applyNodeChanges(changes, get().nodes) }),
+      onNodesChange: (changes) =>
+        set({ nodes: applyNodeChanges(changes, get().nodes) }),
 
-  onEdgesChange: (changes) =>
-    set({ edges: applyEdgeChanges(changes, get().edges) }),
+      onEdgesChange: (changes) =>
+        set({ edges: applyEdgeChanges(changes, get().edges) }),
 
-  onConnect: (connection) => {
-    const { activeConnectionMode, nodes } = get();
-    const sourceNode = nodes.find((n) => n.id === connection.source);
-    let edgeOptions;
-    let edgeData = {};
+      onConnect: (connection) => {
+        const { activeConnectionMode, nodes } = get();
+        const sourceNode = nodes.find((n) => n.id === connection.source);
+        let edgeOptions;
+        let edgeData = {};
 
-    if (sourceNode?.type === "umlNote") {
-      edgeOptions = getNoteEdgeOptions();
-      edgeData = { type: "note" };
-    } else {
-      edgeOptions = getEdgeOptions(activeConnectionMode);
-      edgeData = { type: activeConnectionMode };
-    }
-
-    set({
-      edges: addEdge(
-        { ...connection, ...edgeOptions, data: edgeData },
-        get().edges,
-      ),
-    });
-  },
-
-  addNode: (position, stereotype = "class") => {
-    const { nodes } = get();
-    if (checkCollision(position, nodes)) return;
-    const newNode: Node<UmlClassData> = {
-      id: crypto.randomUUID(),
-      type: stereotype === "note" ? "umlNote" : "umlClass",
-      position,
-      data: {
-        label: stereotype === "note" ? "Nota" : `New ${stereotype}`,
-        attributes: [],
-        methods: [],
-        stereotype: stereotype,
-      },
-    };
-    set({ nodes: [...nodes, newNode] });
-  },
-
-  updateNodeData: (nodeId, newData) =>
-    set({
-      nodes: get().nodes.map((n) =>
-        n.id === nodeId ? { ...n, data: { ...n.data, ...newData } } : n,
-      ),
-    }),
-
-  deleteNode: (nodeId) =>
-    set({
-      nodes: get().nodes.filter((n) => n.id !== nodeId),
-      edges: get().edges.filter(
-        (e) => e.source !== nodeId && e.target !== nodeId,
-      ),
-    }),
-
-  duplicateNode: (nodeId) => {
-    const n = get().nodes.find((x) => x.id === nodeId);
-    if (n)
-      set({
-        nodes: [
-          ...get().nodes,
-          {
-            ...n,
-            id: crypto.randomUUID(),
-            position: { x: n.position.x + 20, y: n.position.y + 20 },
-          },
-        ],
-      });
-  },
-
-  setConnectionMode: (mode) => set({ activeConnectionMode: mode }),
-
-  loadDiagram: (data) => {
-    const hydratedEdges = data.edges.map((edge) => {
-      const type = edge.data?.type || "association";
-
-      let options;
-      if (type === "note") {
-        options = getNoteEdgeOptions();
-      } else {
-        options = getEdgeOptions(type as UmlRelationType);
-      }
-      return {
-        ...edge,
-        ...options,
-        data: { ...edge.data, type },
-      };
-    }) as Edge[];
-
-    set({
-      diagramId: data.id || crypto.randomUUID(),
-      diagramName: data.name || "Imported",
-      nodes: data.nodes,
-      edges: hydratedEdges,
-    });
-  },
-
-  toggleMiniMap: () => set((s) => ({ showMiniMap: !s.showMiniMap })),
-
-  deleteEdge: (edgeId) => {
-    set({ edges: get().edges.filter((e) => e.id !== edgeId) });
-  },
-
-  changeEdgeType: (edgeId, newType) => {
-    const newOptions = getEdgeOptions(newType);
-    set({
-      edges: get().edges.map((e) =>
-        e.id === edgeId
-          ? {
-              ...e,
-              ...newOptions,
-              style: { ...e.style, ...newOptions.style },
-              data: { ...e.data, type: newType },
-            }
-          : e,
-      ),
-    });
-  },
-
-  reverseEdge: (edgeId) => {
-    set({
-      edges: get().edges.map((e) => {
-        if (e.id === edgeId) {
-          return {
-            ...e,
-            source: e.target,
-            target: e.source,
-            sourceHandle: e.targetHandle,
-            targetHandle: e.sourceHandle,
-          };
+        if (sourceNode?.type === "umlNote") {
+          edgeOptions = getNoteEdgeOptions();
+          edgeData = { type: "note" };
+        } else {
+          edgeOptions = getEdgeOptions(activeConnectionMode);
+          edgeData = { type: activeConnectionMode };
         }
-        return e;
-      }),
-    });
-  },
 
-  recalculateNodeConnections: (nodeId: string) => {
-    const { nodes, edges } = get();
-    const movedNode = nodes.find((n) => n.id === nodeId);
-    if (!movedNode) return;
+        set({
+          edges: addEdge(
+            { ...connection, ...edgeOptions, data: edgeData },
+            get().edges,
+          ),
+        });
+      },
 
-    const newEdges = edges.map((edge) => {
-      const isSource = edge.source === nodeId;
-      const isTarget = edge.target === nodeId;
+      addNode: (position, stereotype = "class") => {
+        const { nodes } = get();
+        if (checkCollision(position, nodes)) return;
+        const newNode: Node<UmlClassData> = {
+          id: crypto.randomUUID(),
+          type: stereotype === "note" ? "umlNote" : "umlClass",
+          position,
+          data: {
+            label: stereotype === "note" ? "Nota" : `New ${stereotype}`,
+            attributes: [],
+            methods: [],
+            stereotype: stereotype,
+          },
+        };
+        set({ nodes: [...nodes, newNode] });
+      },
 
-      if (!isSource && !isTarget) return edge;
+      updateNodeData: (nodeId, newData) =>
+        set({
+          nodes: get().nodes.map((n) =>
+            n.id === nodeId ? { ...n, data: { ...n.data, ...newData } } : n,
+          ),
+        }),
 
-      const sourceNode = isSource
-        ? movedNode
-        : nodes.find((n) => n.id === edge.source);
-      const targetNode = isTarget
-        ? movedNode
-        : nodes.find((n) => n.id === edge.target);
+      deleteNode: (nodeId) =>
+        set({
+          nodes: get().nodes.filter((n) => n.id !== nodeId),
+          edges: get().edges.filter(
+            (e) => e.source !== nodeId && e.target !== nodeId,
+          ),
+        }),
 
-      if (!sourceNode || !targetNode) return edge;
+      duplicateNode: (nodeId) => {
+        const n = get().nodes.find((x) => x.id === nodeId);
+        if (n)
+          set({
+            nodes: [
+              ...get().nodes,
+              {
+                ...n,
+                id: crypto.randomUUID(),
+                position: { x: n.position.x + 20, y: n.position.y + 20 },
+              },
+            ],
+          });
+      },
 
-      const { sourceHandle, targetHandle } = getSmartEdgeHandles(
-        sourceNode,
-        targetNode,
-      );
+      setConnectionMode: (mode) => set({ activeConnectionMode: mode }),
 
-      return {
-        ...edge,
-        sourceHandle,
-        targetHandle,
-      };
-    });
+      loadDiagram: (data) => {
+        const hydratedEdges = data.edges.map((edge) => {
+          const type = edge.data?.type || "association";
 
-    set({ edges: newEdges });
-  },
+          let options;
+          if (type === "note") {
+            options = getNoteEdgeOptions();
+          } else {
+            options = getEdgeOptions(type as UmlRelationType);
+          }
+          return {
+            ...edge,
+            ...options,
+            data: { ...edge.data, type },
+          };
+        }) as Edge[];
 
-  clearCanvas: () => {
-    set({ nodes: [], edges: [] });
-  },
-}));
+        set({
+          diagramId: data.id || crypto.randomUUID(),
+          diagramName: data.name || "Imported",
+          nodes: data.nodes,
+          edges: hydratedEdges,
+        });
+      },
+
+      toggleMiniMap: () => set((s) => ({ showMiniMap: !s.showMiniMap })),
+
+      deleteEdge: (edgeId) => {
+        set({ edges: get().edges.filter((e) => e.id !== edgeId) });
+      },
+
+      changeEdgeType: (edgeId, newType) => {
+        const newOptions = getEdgeOptions(newType);
+        set({
+          edges: get().edges.map((e) =>
+            e.id === edgeId
+              ? {
+                  ...e,
+                  ...newOptions,
+                  style: { ...e.style, ...newOptions.style },
+                  data: { ...e.data, type: newType },
+                }
+              : e,
+          ),
+        });
+      },
+
+      reverseEdge: (edgeId) => {
+        set({
+          edges: get().edges.map((e) => {
+            if (e.id === edgeId) {
+              return {
+                ...e,
+                source: e.target,
+                target: e.source,
+                sourceHandle: e.targetHandle,
+                targetHandle: e.sourceHandle,
+              };
+            }
+            return e;
+          }),
+        });
+      },
+
+      recalculateNodeConnections: (nodeId: string) => {
+        const { nodes, edges } = get();
+        const movedNode = nodes.find((n) => n.id === nodeId);
+        if (!movedNode) return;
+
+        const newEdges = edges.map((edge) => {
+          const isSource = edge.source === nodeId;
+          const isTarget = edge.target === nodeId;
+
+          if (!isSource && !isTarget) return edge;
+
+          const sourceNode = isSource
+            ? movedNode
+            : nodes.find((n) => n.id === edge.source);
+          const targetNode = isTarget
+            ? movedNode
+            : nodes.find((n) => n.id === edge.target);
+
+          if (!sourceNode || !targetNode) return edge;
+
+          const { sourceHandle, targetHandle } = getSmartEdgeHandles(
+            sourceNode,
+            targetNode,
+          );
+
+          return {
+            ...edge,
+            sourceHandle,
+            targetHandle,
+          };
+        });
+
+        set({ edges: newEdges });
+      },
+
+      triggerHistorySnapshot: () =>
+        set((state) => ({ nodes: [...state.nodes] })),
+
+      clearCanvas: () => {
+        set({ nodes: [], edges: [] });
+      },
+    }),
+    {
+      limit: 50,
+      partialize: (state) => {
+        const { nodes, edges } = state;
+        const cleanNodes = nodes.map((n) => ({
+          id: n.id,
+          type: n.type,
+          position: n.position, 
+          data: n.data,         
+        }));
+
+        const cleanEdges = edges.map((e) => ({
+          id: e.id,
+          source: e.source,
+          target: e.target,
+          sourceHandle: e.sourceHandle,
+          targetHandle: e.targetHandle,
+          type: e.type,
+          data: e.data,
+          animated: e.animated,
+        }));
+
+        return { nodes: cleanNodes, edges: cleanEdges };
+      },
+      equality: (pastState, currentState) => {
+        return JSON.stringify(pastState) === JSON.stringify(currentState);
+      },
+    },
+  ),
+);


### PR DESCRIPTION
- feat(store): integrate zundo for state history management.
- feat(ui): connect header undo/redo buttons to store history.
- fix(ux): implement 'pause/resume' logic during node drag to prevent history flooding.
- chore(store): configure partialize and equality checks to ignore trivial state changes.