### PR TITLE
refactor(store): decouple logic into utilities and factories

### DIFF
--- a/frontend/src/config/theme.config.ts
+++ b/frontend/src/config/theme.config.ts
@@ -61,3 +61,6 @@ export const edgeConfig = {
     },
   },
 };
+
+export const NODE_WIDTH = 250;
+export const NODE_HEIGHT = 200;

--- a/frontend/src/features/diagram/components/DiagramCanvas.tsx
+++ b/frontend/src/features/diagram/components/DiagramCanvas.tsx
@@ -8,12 +8,7 @@ import ReactFlow, {
   type Node,
 } from "reactflow";
 import "reactflow/dist/style.css";
-import {
-  useDiagramStore,
-  checkCollision,
-  NODE_HEIGHT,
-  NODE_WIDTH,
-} from "../../../store/diagramStore";
+import { useDiagramStore } from "../../../store/diagramStore";
 import UmlClassNode from "./nodes/UmlClassNode";
 import UmlNoteNode from "./nodes/UmlNoteNode";
 import ContextMenu from "./ContextMenu";
@@ -21,13 +16,14 @@ import { useContextMenu } from "../hooks/useContextMenu";
 import { useState, useCallback, useRef, useEffect, useMemo } from "react";
 import ClassEditorModal from "./ClassEditorModal";
 import type { stereotype } from "../../../types/diagram.types";
-
+import { NODE_WIDTH, NODE_HEIGHT } from "../../../config/theme.config";
 import {
   canvasConfig,
   miniMapColors,
   edgeConfig,
 } from "../../../config/theme.config";
 import ConfirmationModal from "../../../components/shared/ConfirmationModal";
+import { checkCollision } from "../../../util/geometry";
 
 const nodeTypes = {
   umlClass: UmlClassNode,

--- a/frontend/src/store/diagramStore.ts
+++ b/frontend/src/store/diagramStore.ts
@@ -4,13 +4,11 @@ import {
   addEdge,
   applyNodeChanges,
   applyEdgeChanges,
-  MarkerType,
   type Node,
   type Edge,
   type OnNodesChange,
   type OnEdgesChange,
   type OnConnect,
-  type DefaultEdgeOptions,
 } from "reactflow";
 
 import type {
@@ -19,58 +17,8 @@ import type {
   UmlRelationType,
   DiagramState as SavedDiagramState,
 } from "../types/diagram.types";
-
-import { edgeConfig } from "../config/theme.config";
-import { getSmartEdgeHandles } from "../util/geometry";
-
-export const NODE_WIDTH = 250;
-export const NODE_HEIGHT = 200;
-
-const getEdgeOptions = (type: UmlRelationType): DefaultEdgeOptions => {
-  const config = edgeConfig.types[type] || edgeConfig.types.association;
-
-  return {
-    ...edgeConfig.base,
-    style: { ...edgeConfig.base.style, ...config.style },
-    zIndex: config.zIndex,
-    markerEnd: {
-      type:
-        type === "inheritance" || type === "implementation"
-          ? MarkerType.ArrowClosed
-          : MarkerType.Arrow,
-      ...config.marker,
-    },
-  };
-};
-
-const getNoteEdgeOptions = (): DefaultEdgeOptions => {
-  const config = edgeConfig.types.note;
-  return {
-    ...edgeConfig.base,
-    style: { ...edgeConfig.base.style, ...config.style },
-    zIndex: config.zIndex,
-    markerEnd: {
-      type: MarkerType.Arrow,
-      ...config.marker,
-    },
-  };
-};
-
-export const checkCollision = (
-  position: { x: number; y: number },
-  nodes: Node[],
-) => {
-  return nodes.some((node) => {
-    const nodeW = node.width || NODE_WIDTH;
-    const nodeH = node.height || NODE_HEIGHT;
-    return (
-      position.x < node.position.x + nodeW &&
-      position.x + NODE_WIDTH > node.position.x &&
-      position.y < node.position.y + nodeH &&
-      position.y + NODE_HEIGHT > node.position.y
-    );
-  });
-};
+import { getEdgeOptions, getNoteEdgeOptions } from "../util/edgeFactory";
+import { getSmartEdgeHandles, checkCollision } from "../util/geometry";
 
 interface DiagramStoreState {
   diagramId: string;
@@ -122,21 +70,24 @@ export const useDiagramStore = create<DiagramStoreState>()(
         set({ edges: applyEdgeChanges(changes, get().edges) }),
 
       onConnect: (connection) => {
-        const { activeConnectionMode, nodes, edges } = get();  
+        const { activeConnectionMode, nodes, edges } = get();
         const sourceNode = nodes.find((n) => n.id === connection.source);
         const targetNode = nodes.find((n) => n.id === connection.target);
 
         if (sourceNode?.type === "umlNote") {
-          
           if (targetNode?.type === "umlNote") return;
 
           const isDuplicate = edges.some(
-            (e) => e.source === connection.source && e.target === connection.target
+            (e) =>
+              e.source === connection.source && e.target === connection.target,
           );
           if (isDuplicate) return;
 
-          if (connection.targetHandle === "right" || connection.targetHandle === "bottom") {
-             return;
+          if (
+            connection.targetHandle === "right" ||
+            connection.targetHandle === "bottom"
+          ) {
+            return;
           }
         }
 

--- a/frontend/src/util/edgeFactory.ts
+++ b/frontend/src/util/edgeFactory.ts
@@ -1,0 +1,34 @@
+import { edgeConfig } from "../config/theme.config";
+import { MarkerType } from "reactflow";
+import type { UmlRelationType } from "../types/diagram.types";
+import type { DefaultEdgeOptions } from "reactflow";
+
+export const getEdgeOptions = (type: UmlRelationType): DefaultEdgeOptions => {
+  const config = edgeConfig.types[type] || edgeConfig.types.association;
+
+  return {
+    ...edgeConfig.base,
+    style: { ...edgeConfig.base.style, ...config.style },
+    zIndex: config.zIndex,
+    markerEnd: {
+      type:
+        type === "inheritance" || type === "implementation"
+          ? MarkerType.ArrowClosed
+          : MarkerType.Arrow,
+      ...config.marker,
+    },
+  };
+};
+
+export const getNoteEdgeOptions = (): DefaultEdgeOptions => {
+  const config = edgeConfig.types.note;
+  return {
+    ...edgeConfig.base,
+    style: { ...edgeConfig.base.style, ...config.style },
+    zIndex: config.zIndex,
+    markerEnd: {
+      type: MarkerType.Arrow,
+      ...config.marker,
+    },
+  };
+};

--- a/frontend/src/util/geometry.ts
+++ b/frontend/src/util/geometry.ts
@@ -1,5 +1,6 @@
 import { Position } from "reactflow";
 import type { Node } from "reactflow";
+import { NODE_WIDTH, NODE_HEIGHT } from "../config/theme.config";
 
 const VALID_SOURCE_HANDLES = [
   { id: "right", position: Position.Right },
@@ -53,4 +54,19 @@ const getHandlePosition = (node: Node, position: Position) => {
     default:
       return { x: x + w / 2, y: y + h / 2 };
   }
+};
+export const checkCollision = (
+  position: { x: number; y: number },
+  nodes: Node[],
+) => {
+  return nodes.some((node) => {
+    const nodeW = node.width || NODE_WIDTH;
+    const nodeH = node.height || NODE_HEIGHT;
+    return (
+      position.x < node.position.x + nodeW &&
+      position.x + NODE_WIDTH > node.position.x &&
+      position.y < node.position.y + nodeH &&
+      position.y + NODE_HEIGHT > node.position.y
+    );
+  });
 };


### PR DESCRIPTION
- refactor(store): extract edge configuration logic to 'edgeFactory'.
- refactor(math): move collision detection and geometry to 'geometry.ts'.
- refactor(config): centralize node constants in 'theme.config'.
- cleanup: remove unused constants and helper functions from diagramStore.
- maint: update imports to use new utility modules.