### PR TITLE
fix(diagram): decouple drag logic and fix edge duplication

### DIFF
--- a/frontend/src/features/diagram/hooks/useNodeDragging.ts
+++ b/frontend/src/features/diagram/hooks/useNodeDragging.ts
@@ -1,0 +1,28 @@
+import { useCallback } from "react";
+import { type Node } from "reactflow";
+import { useDiagramStore } from "../../../store/diagramStore";
+
+export const useNodeDragging = () => {
+  const triggerHistorySnapshot = useDiagramStore((s) => s.triggerHistorySnapshot);
+  const recalculateNodeConnections = useDiagramStore((s) => s.recalculateNodeConnections);
+  
+  const temporal = useDiagramStore.temporal.getState();
+
+  const onNodeDragStart = useCallback(() => {
+
+    triggerHistorySnapshot();
+
+    temporal.pause();
+  }, [triggerHistorySnapshot, temporal]);
+
+  const onNodeDragStop = useCallback(
+    (_: React.MouseEvent, node: Node) => {
+      recalculateNodeConnections(node.id);
+
+      temporal.resume();
+    },
+    [recalculateNodeConnections, temporal]
+  );
+
+  return { onNodeDragStart, onNodeDragStop };
+};


### PR DESCRIPTION
- refactor(hooks): introduce 'useNodeDragging' to isolate history and connection logic.
- refactor(canvas): delegate drag start/stop events to the new hook.
- fix(geometry): implement strict edge deduplication in 'updateSyncedEdges'.
- perf(ux): optimize history snapshots during node movement.