### PR TITLE
feat(ui): implement global spotlight search and sidebar enhancements

### DIFF
--- a/frontend/src/features/diagram/components/DiagramCanvas.tsx
+++ b/frontend/src/features/diagram/components/DiagramCanvas.tsx
@@ -18,6 +18,7 @@ import UmlNoteNode from "./nodes/UmlNoteNode";
 import ContextMenu from "./ContextMenu";
 import ClassEditorModal from "./ClassEditorModal";
 import ConfirmationModal from "../../../components/shared/ConfirmationModal";
+import SpotlightModal from "./SpotlightModal";
 
 // Hooks
 import { useContextMenu } from "../hooks/useContextMenu";
@@ -173,6 +174,9 @@ export default function DiagramCanvas() {
         }}
         onCancel={() => setIsClearModalOpen(false)}
       />
+
+        <SpotlightModal />
+
     </div>
   );
 }

--- a/frontend/src/features/diagram/components/Header.tsx
+++ b/frontend/src/features/diagram/components/Header.tsx
@@ -19,17 +19,18 @@ import {
   FileJson,
   Image as ImageIcon,
   Cloud,
+  Search,
 } from "lucide-react";
 import { useDiagramStore } from "../../../store/diagramStore";
 import { ExportService } from "../services/export.service";
 import { useThemeStore } from "../../../store/themeStore";
+import { useSpotlightStore } from "../hooks/useSpotlight";
 
 export default function Header() {
   const { zoomIn, zoomOut, fitView, toObject, setViewport, getNodes } =
     useReactFlow();
   const { undo, redo } = useDiagramStore.temporal.getState();
 
-  // 3. Suscripción REACTIVA para habilitar/deshabilitar botones
   const canUndo = useStore(
     useDiagramStore.temporal,
     (state) => state.pastStates.length > 0,
@@ -52,6 +53,7 @@ export default function Header() {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const exportMenuRef = useRef<HTMLDivElement>(null);
   const { isDarkMode, toggleTheme } = useThemeStore();
+  const { toggle: toggleSpotlight } = useSpotlightStore();
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -187,6 +189,17 @@ export default function Header() {
       {/* RIGHT SECTION: Actions */}
       <div className="flex items-center gap-2">
         <div className="flex items-center gap-1 mr-2">
+          <button
+          onClick={toggleSpotlight}
+          className="flex items-center gap-2 px-3 py-1.5 text-sm font-medium text-text-muted hover:text-text-primary hover:bg-surface-hover rounded-md transition-all border border-transparent hover:border-surface-border mr-1"
+          title="Search Nodes (Ctrl+K)"
+        >
+          <Search className="w-4 h-4" />
+          <span className="hidden lg:inline">Search</span>
+          <kbd className="hidden lg:inline-flex h-5 items-center gap-1 rounded border border-surface-border bg-surface-secondary px-1.5 font-mono text-[10px] font-medium text-text-muted">
+            <span className="text-xs">⌘K</span>
+          </kbd>
+        </button>
           <button
             onClick={toggleTheme}
             className="p-2 text-text-secondary hover:text-text-primary hover:bg-surface-hover rounded-md transition-colors"

--- a/frontend/src/features/diagram/components/Sidebar.tsx
+++ b/frontend/src/features/diagram/components/Sidebar.tsx
@@ -1,28 +1,28 @@
 import { useState } from "react";
-import { 
-  Box, 
-  CircleDot, 
-  BoxSelect, 
-  StickyNote, 
-  ArrowUpRight, 
-  GitCommitHorizontal, 
-  ArrowUp, 
+import {
+  Box,
+  CircleDot,
+  BoxSelect,
+  StickyNote,
+  ArrowUpRight,
+  GitCommitHorizontal,
+  ArrowUp,
   MoveRight,
   SquareChevronRight,
   SquareChevronLeft,
   PanelLeft,
   ChevronDown,
-  ChevronRight
+  ChevronRight,
 } from "lucide-react";
 import { useDiagramStore } from "../../../store/diagramStore";
 import type { stereotype, UmlRelationType } from "../../../types/diagram.types";
-import { edgeConfig } from "../../../config/theme.config"; 
+import { edgeConfig } from "../../../config/theme.config";
 
 export default function Sidebar() {
   const { activeConnectionMode, setConnectionMode } = useDiagramStore();
-  
+
   const [isExpanded, setIsExpanded] = useState(false);
-  
+
   const [isNodesOpen, setIsNodesOpen] = useState(true);
   const [isConnectionsOpen, setIsConnectionsOpen] = useState(true);
 
@@ -32,51 +32,57 @@ export default function Sidebar() {
   };
 
   return (
-    <aside 
+    <aside
       className={`
         relative bg-surface-primary border-r border-surface-border flex flex-col z-10 shadow-xl transition-all duration-300 ease-in-out
-        ${isExpanded ? "w-64" : "w-16"} /* w-16 es más limpio que w-20 para solo iconos */
+        ${isExpanded ? "w-64" : "w-16"}
       `}
     >
-      
       {/* ---  DINAMIC HEADER --- */}
-      <div className={`
+      <div
+        className={`
         h-14 flex items-center border-b border-surface-border/50 transition-all duration-300
         ${isExpanded ? "justify-between px-4" : "justify-center"}
-      `}>
-         
-         {isExpanded && (
-           <div className="flex items-center gap-2 animate-in fade-in duration-300">
-             <PanelLeft className="w-5 h-5 text-uml-class-border" />
-             <span className="font-bold text-text-primary tracking-tight">Toolbox</span>
-           </div>
-         )}
+      `}
+      >
+        {isExpanded && (
+          <div className="flex items-center gap-2 animate-in fade-in duration-300">
+            <PanelLeft className="w-5 h-5 text-uml-class-border" />
+            <span className="font-bold text-text-primary tracking-tight">
+              Toolbox
+            </span>
+          </div>
+        )}
 
-        
-         <button 
-           onClick={() => setIsExpanded(!isExpanded)}
-           className={`
+        <button
+          onClick={() => setIsExpanded(!isExpanded)}
+          className={`
              flex items-center justify-center 
              rounded-md text-text-secondary hover:text-text-primary hover:bg-surface-hover hover:scale-105
              transition-all duration-200
              ${isExpanded ? "p-1.5 bg-transparent border border-surface-border" : "w-8 h-8 bg-surface-secondary border border-surface-border"}
            `}
-           title={isExpanded ? "Collapse Sidebar" : "Expand Sidebar"}
-         >
-           {isExpanded ? <SquareChevronLeft className="w-5 h-5" /> : <SquareChevronRight className="w-5 h-5" />}
-         </button>
+          title={isExpanded ? "Collapse Sidebar" : "Expand Sidebar"}
+        >
+          {isExpanded ? (
+            <SquareChevronLeft className="w-5 h-5" />
+          ) : (
+            <SquareChevronRight className="w-5 h-5" />
+          )}
+        </button>
       </div>
-      
+
       <div className="flex flex-col py-2 overflow-y-auto overflow-x-hidden custom-scrollbar h-full select-none">
-        
-        {/* === SECCIÓN 1: NODOS === */}
-        <CollapsibleSection 
-          title="Nodes" 
-          isOpen={isNodesOpen} 
-          setIsOpen={setIsNodesOpen} 
+        {/* === SECTION 1: NODES === */}
+        <CollapsibleSection
+          title="Nodes"
+          isOpen={isNodesOpen}
+          setIsOpen={setIsNodesOpen}
           isSidebarExpanded={isExpanded}
         >
-          <div className={`flex flex-col gap-2 ${isExpanded ? "px-3" : "px-2"}`}>
+          <div
+            className={`flex flex-col gap-2 ${isExpanded ? "px-3" : "px-2"}`}
+          >
             <DraggableItem
               type="class"
               icon={<Box className={isExpanded ? "w-5 h-5" : "w-6 h-6"} />}
@@ -87,7 +93,9 @@ export default function Sidebar() {
             />
             <DraggableItem
               type="interface"
-              icon={<CircleDot className={isExpanded ? "w-5 h-5" : "w-6 h-6"} />} 
+              icon={
+                <CircleDot className={isExpanded ? "w-5 h-5" : "w-6 h-6"} />
+              }
               label="Interface"
               color="var(--color-uml-interface-border)"
               isExpanded={isExpanded}
@@ -95,7 +103,9 @@ export default function Sidebar() {
             />
             <DraggableItem
               type="abstract"
-              icon={<BoxSelect className={isExpanded ? "w-5 h-5" : "w-6 h-6"} />} 
+              icon={
+                <BoxSelect className={isExpanded ? "w-5 h-5" : "w-6 h-6"} />
+              }
               label="Abstract"
               color="var(--color-uml-abstract-border)"
               isExpanded={isExpanded}
@@ -103,7 +113,9 @@ export default function Sidebar() {
             />
             <DraggableItem
               type="note"
-              icon={<StickyNote className={isExpanded ? "w-5 h-5" : "w-6 h-6"} />} 
+              icon={
+                <StickyNote className={isExpanded ? "w-5 h-5" : "w-6 h-6"} />
+              }
               label="Note"
               color="var(--color-uml-note-border)"
               isExpanded={isExpanded}
@@ -114,21 +126,25 @@ export default function Sidebar() {
 
         {isExpanded && <div className="mx-4 my-2 h-px bg-surface-border/30" />}
 
-        {/* === SECCIÓN 2: RELACIONES === */}
-        <CollapsibleSection 
-          title="Connections" 
-          isOpen={isConnectionsOpen} 
-          setIsOpen={setIsConnectionsOpen} 
+        {/* === Section 2: relationships === */}
+        <CollapsibleSection
+          title="Connections"
+          isOpen={isConnectionsOpen}
+          setIsOpen={setIsConnectionsOpen}
           isSidebarExpanded={isExpanded}
         >
-          <div className={`flex flex-col gap-2 ${isExpanded ? "px-3" : "px-2"}`}>
-             <ConnectionItem
+          <div
+            className={`flex flex-col gap-2 ${isExpanded ? "px-3" : "px-2"}`}
+          >
+            <ConnectionItem
               mode="association"
               activeMode={activeConnectionMode}
               onClick={() => setConnectionMode("association")}
-              icon={<MoveRight className={isExpanded ? "w-5 h-5" : "w-6 h-6"} />}
+              icon={
+                <MoveRight className={isExpanded ? "w-5 h-5" : "w-6 h-6"} />
+              }
               label="Association"
-              color={edgeConfig.types.association.highlight} 
+              color={edgeConfig.types.association.highlight}
               isExpanded={isExpanded}
             />
 
@@ -146,7 +162,9 @@ export default function Sidebar() {
               mode="implementation"
               activeMode={activeConnectionMode}
               onClick={() => setConnectionMode("implementation")}
-              icon={<ArrowUpRight className={isExpanded ? "w-5 h-5" : "w-6 h-6"} />}
+              icon={
+                <ArrowUpRight className={isExpanded ? "w-5 h-5" : "w-6 h-6"} />
+              }
               label="Implementation"
               color={edgeConfig.types.implementation.highlight}
               isExpanded={isExpanded}
@@ -156,14 +174,48 @@ export default function Sidebar() {
               mode="dependency"
               activeMode={activeConnectionMode}
               onClick={() => setConnectionMode("dependency")}
-              icon={<GitCommitHorizontal className={isExpanded ? "w-5 h-5" : "w-6 h-6"} />}
+              icon={
+                <GitCommitHorizontal
+                  className={isExpanded ? "w-5 h-5" : "w-6 h-6"}
+                />
+              }
               label="Dependency"
               color={edgeConfig.types.dependency.highlight}
               isExpanded={isExpanded}
             />
           </div>
-        </CollapsibleSection>
 
+          {isExpanded && (
+            <div className="p-4 border-t border-surface-border bg-surface-secondary/30 animate-in fade-in slide-in-from-bottom-2 duration-300">
+              <div className="text-[10px] font-bold text-text-muted uppercase tracking-wider mb-2">
+                Connection Logic
+              </div>
+              <div className="flex flex-col gap-2">
+                {/* Source Legend */}
+                <div className="flex items-center gap-2">
+                  <div className="w-3 h-3 bg-blue-500 rounded-sm shadow-sm ring-1 ring-blue-500/30"></div>
+                  <span className="text-xs text-text-secondary">
+                    <span className="font-semibold text-text-primary">
+                      Blue
+                    </span>{" "}
+                    handles are Source
+                  </span>
+                </div>
+
+                {/* Target Legend */}
+                <div className="flex items-center gap-2">
+                  <div className="w-3 h-3 bg-green-500 rounded-sm shadow-sm ring-1 ring-green-500/30"></div>
+                  <span className="text-xs text-text-secondary">
+                    <span className="font-semibold text-text-primary">
+                      Green
+                    </span>{" "}
+                    handles are Target
+                  </span>
+                </div>
+              </div>
+            </div>
+          )}
+        </CollapsibleSection>
       </div>
     </aside>
   );
@@ -177,7 +229,13 @@ interface CollapsibleSectionProps {
   children: React.ReactNode;
 }
 
-function CollapsibleSection({ title, isOpen, setIsOpen, isSidebarExpanded, children }: CollapsibleSectionProps) {
+function CollapsibleSection({
+  title,
+  isOpen,
+  setIsOpen,
+  isSidebarExpanded,
+  children,
+}: CollapsibleSectionProps) {
   if (!isSidebarExpanded) {
     return (
       <div className="py-2 flex flex-col gap-1 items-center animate-in fade-in zoom-in duration-200">
@@ -189,7 +247,7 @@ function CollapsibleSection({ title, isOpen, setIsOpen, isSidebarExpanded, child
 
   return (
     <div className="flex flex-col">
-      <button 
+      <button
         onClick={() => setIsOpen(!isOpen)}
         className="flex items-center justify-between px-4 py-3 text-xs font-bold text-text-muted uppercase tracking-wider hover:text-text-primary transition-colors group"
       >
@@ -201,7 +259,7 @@ function CollapsibleSection({ title, isOpen, setIsOpen, isSidebarExpanded, child
         )}
       </button>
 
-      <div 
+      <div
         className={`overflow-hidden transition-all duration-300 ease-in-out ${isOpen ? "max-h-96 opacity-100 mb-2" : "max-h-0 opacity-0"}`}
       >
         {children}
@@ -209,8 +267,6 @@ function CollapsibleSection({ title, isOpen, setIsOpen, isSidebarExpanded, child
     </div>
   );
 }
-
-
 
 interface DraggableItemProps {
   type: stereotype;
@@ -221,7 +277,14 @@ interface DraggableItemProps {
   onDragStart: (event: React.DragEvent, type: stereotype) => void;
 }
 
-function DraggableItem({ type, icon, label, color, isExpanded, onDragStart }: DraggableItemProps) {
+function DraggableItem({
+  type,
+  icon,
+  label,
+  color,
+  isExpanded,
+  onDragStart,
+}: DraggableItemProps) {
   return (
     <div
       className={`
@@ -231,15 +294,18 @@ function DraggableItem({ type, icon, label, color, isExpanded, onDragStart }: Dr
       draggable
       onDragStart={(e) => onDragStart(e, type)}
     >
-      <div 
+      <div
         className="text-text-secondary group-hover:text-white transition-colors"
-        style={{ color: "var(--color-text-secondary)" }} 
+        style={{ color: "var(--color-text-secondary)" }}
       >
-        <span style={{ color: color }} className="group-hover:brightness-125 transition-all">
-            {icon}
+        <span
+          style={{ color: color }}
+          className="group-hover:brightness-125 transition-all"
+        >
+          {icon}
         </span>
       </div>
-      
+
       {isExpanded && (
         <span className="font-medium text-sm text-text-muted group-hover:text-text-primary transition-all whitespace-nowrap overflow-hidden animate-in fade-in slide-in-from-left-2 duration-200">
           {label}
@@ -259,7 +325,15 @@ interface ConnectionItemProps {
   isExpanded: boolean;
 }
 
-function ConnectionItem({ mode, activeMode, onClick, icon, label, color, isExpanded }: ConnectionItemProps) {
+function ConnectionItem({
+  mode,
+  activeMode,
+  onClick,
+  icon,
+  label,
+  color,
+  isExpanded,
+}: ConnectionItemProps) {
   const isActive = activeMode === mode;
 
   return (
@@ -270,23 +344,25 @@ function ConnectionItem({ mode, activeMode, onClick, icon, label, color, isExpan
         ${isExpanded ? "flex-row gap-3 px-3 py-2.5 justify-start" : "flex-col gap-1 p-2 justify-center"}
       `}
       style={{
-        borderColor: isActive ? color : color.replace(')', ', 0.3)'), 
-        backgroundColor: isActive ? color : 'transparent',
+        borderColor: isActive ? color : color.replace(")", ", 0.3)"),
+        backgroundColor: isActive ? color : "transparent",
       }}
     >
-      <div 
+      <div
         className="transition-colors shrink-0"
-        style={{ color: isActive ? '#0B0F1A' : color }} 
+        style={{ color: isActive ? "#0B0F1A" : color }}
       >
-         <span style={{ color: isActive ? '#111827' : color, fontWeight: 'bold' }}>
-            {icon}
-         </span>
+        <span
+          style={{ color: isActive ? "#111827" : color, fontWeight: "bold" }}
+        >
+          {icon}
+        </span>
       </div>
-      
+
       {isExpanded && (
-        <span 
+        <span
           className="font-medium text-sm transition-colors whitespace-nowrap overflow-hidden animate-in fade-in slide-in-from-left-2 duration-200"
-          style={{ color: isActive ? '#111827' : 'var(--color-text-muted)' }}
+          style={{ color: isActive ? "#111827" : "var(--color-text-muted)" }}
         >
           {label}
         </span>

--- a/frontend/src/features/diagram/components/SpotlightModal.tsx
+++ b/frontend/src/features/diagram/components/SpotlightModal.tsx
@@ -1,0 +1,111 @@
+import { Search, Box, CircleDot, BoxSelect, StickyNote, X } from "lucide-react";
+import { useSpotlight } from "../hooks/useSpotlight";
+
+export default function SpotlightModal() {
+  const {
+    isOpen,
+    setIsOpen,
+    searchTerm,
+    setSearchTerm,
+    filteredNodes,
+    onSelectNode,
+  } = useSpotlight();
+
+  if (!isOpen) return null;
+
+  // Helper for the icon based on type/stereotype
+  const getNodeIcon = (type: string, stereotype?: string) => {
+    if (type === "umlNote")
+      return <StickyNote className="w-4 h-4 text-uml-note-border" />;
+    if (stereotype === "interface")
+      return <CircleDot className="w-4 h-4 text-uml-interface-border" />;
+    if (stereotype === "abstract")
+      return <BoxSelect className="w-4 h-4 text-uml-abstract-border" />;
+    return <Box className="w-4 h-4 text-uml-class-border" />;
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-start justify-center pt-32 bg-black/40 backdrop-blur-sm animate-in fade-in duration-200">
+      {/* Modal Container */}
+      <div className="w-full max-w-xl bg-surface-primary border border-surface-border rounded-xl shadow-2xl overflow-hidden animate-in zoom-in-95 slide-in-from-top-4 duration-200">
+        {/* Header with Input */}
+        <div className="flex items-center gap-3 px-4 py-3 border-b border-surface-border bg-surface-secondary/50">
+          <Search className="w-5 h-5 text-text-muted" />
+          <input
+            autoFocus
+            type="text"
+            placeholder="Search classes, interfaces, notes..."
+            className="flex-1 bg-transparent border-none outline-none text-text-primary placeholder-text-muted text-lg"
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+          />
+          <div className="flex items-center gap-2">
+            <kbd className="hidden sm:inline-flex h-6 items-center gap-1 rounded border border-surface-border bg-surface-hover px-1.5 font-mono text-[10px] font-medium text-text-muted opacity-100">
+              <span className="text-xs">ESC</span>
+            </kbd>
+            <button
+              onClick={() => setIsOpen(false)}
+              className="text-text-muted hover:text-text-primary"
+            >
+              <X className="w-5 h-5" />
+            </button>
+          </div>
+        </div>
+
+        {/* Result List */}
+        <div className="max-h-96 overflow-y-auto custom-scrollbar p-2">
+          {filteredNodes.length > 0 ? (
+            filteredNodes.map((node) => (
+              <button
+                key={node.id}
+                onClick={() => onSelectNode(node.id)}
+                className="w-full flex items-center gap-3 px-3 py-3 rounded-lg hover:bg-surface-hover transition-colors group text-left"
+              >
+                <div className="p-2 rounded-md bg-surface-secondary border border-surface-border group-hover:border-uml-class-border/30 transition-colors">
+                  {getNodeIcon(node.type || "umlClass", node.data.stereotype)}
+                </div>
+
+                <div className="flex-1 truncate">
+                  <span className="block font-medium text-text-primary group-hover:text-uml-class-border transition-colors">
+                    {node.data.label || "Untitled"}
+                  </span>
+                  {node.type === "umlNote" && (
+                    <span className="text-xs text-text-muted truncate block max-w-md">
+                      {node.data.content || "Empty note..."}
+                    </span>
+                  )}
+                  {node.type !== "umlNote" && (
+                    <span className="text-xs text-text-muted font-mono">
+                      {node.data.stereotype || "class"}
+                    </span>
+                  )}
+                </div>
+
+                <span className="text-xs text-text-muted opacity-0 group-hover:opacity-100 transition-opacity">
+                  Jump to
+                </span>
+              </button>
+            ))
+          ) : (
+            <div className="py-12 text-center text-text-muted">
+              <p>No results found for "{searchTerm}"</p>
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="bg-surface-secondary px-4 py-2 border-t border-surface-border flex justify-between items-center text-xs text-text-muted">
+          <span>{filteredNodes.length} elements found</span>
+          <div className="flex gap-2">
+            <span>
+              Navigate <kbd>↑</kbd> <kbd>↓</kbd>
+            </span>
+            <span>
+              Select <kbd>↵</kbd>
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/diagram/hooks/useSpotlight.ts
+++ b/frontend/src/features/diagram/hooks/useSpotlight.ts
@@ -1,0 +1,75 @@
+import { useState, useEffect, useMemo, useCallback } from "react";
+import { useReactFlow } from "reactflow";
+import { create } from "zustand";
+import { useDiagramStore } from "../../../store/diagramStore";
+
+interface SpotlightState {
+  isOpen: boolean;
+  toggle: () => void;
+  setIsOpen: (open: boolean) => void;
+}
+
+export const useSpotlightStore = create<SpotlightState>((set) => ({
+  isOpen: false,
+  toggle: () => set((state) => ({ isOpen: !state.isOpen })),
+  setIsOpen: (open) => set({ isOpen: open }),
+}));
+
+export const useSpotlight = () => {
+  const { isOpen, setIsOpen } = useSpotlightStore();
+  const [searchTerm, setSearchTerm] = useState("");
+  const { fitView } = useReactFlow();
+  
+  const nodes = useDiagramStore((state) => state.nodes);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+        e.preventDefault();
+        setIsOpen(!isOpen); 
+        if (!isOpen) setSearchTerm(""); 
+      }
+      
+      if (e.key === "Escape" && isOpen) {
+        setIsOpen(false);
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, setIsOpen]);
+
+  const filteredNodes = useMemo(() => {
+    if (!searchTerm) return nodes;
+    
+    return nodes.filter((node) => {
+      const label = node.data.label?.toLowerCase() || "";
+      const content = node.data.content?.toLowerCase() || "";
+      const term = searchTerm.toLowerCase();
+      
+      return label.includes(term) || content.includes(term);
+    });
+  }, [nodes, searchTerm]);
+
+  const onSelectNode = useCallback((nodeId: string) => {
+    const targetNode = nodes.find((n) => n.id === nodeId);
+    if (!targetNode) return;
+
+    fitView({
+      nodes: [targetNode],
+      duration: 800,
+      padding: 1.5,
+    });
+    
+    setIsOpen(false);
+  }, [fitView, nodes, setIsOpen]);
+
+  return {
+    isOpen,
+    setIsOpen,
+    searchTerm,
+    setSearchTerm,
+    filteredNodes,
+    onSelectNode,
+  };
+};


### PR DESCRIPTION
- feat(search): add global 'Spotlight Search' modal with Ctrl+K shortcut.
- refactor(state): migrate spotlight visibility to global Zustand store.
- feat(header): add search button to trigger spotlight manually.
- feat(sidebar): add connection logic legend (blue/green handles) when expanded.
- fix(ux): mount SpotlightModal in DiagramCanvas to ensure keyboard listeners are active.