### PR TITLE
feat(menubar): implement VSCode-style menu, file logic and frameless window

### DIFF
--- a/frontend/electron/main.ts
+++ b/frontend/electron/main.ts
@@ -88,6 +88,19 @@ ipcMain.on("window-close", () => {
   mainWindow?.close();
 });
 
+ipcMain.handle("file:read", async (_, filePath) => {
+  try {
+    if (!fs.existsSync(filePath)) {
+        return { success: false, error: "File not found" };
+    }
+    const content = fs.readFileSync(filePath, "utf-8");
+    return { success: true, content };
+  } catch (error) {
+    console.error("Error reading file:", error);
+    return { success: false, error: String(error) };
+  }
+});
+
 ipcMain.handle("dialog:openFile", async () => {
   const { canceled, filePaths } = await dialog.showOpenDialog({
     properties: ["openFile"],

--- a/frontend/electron/preload.ts
+++ b/frontend/electron/preload.ts
@@ -19,4 +19,5 @@ contextBridge.exposeInMainWorld("electronAPI", {
   minimize: () => ipcRenderer.send('window-minimize'),
   toggleMaximize: () => ipcRenderer.send('window-maximize'),
   close: () => ipcRenderer.send('window-close'),
+readFile: (filePath: string) => ipcRenderer.invoke("file:read", filePath),
 });

--- a/frontend/src/components/ui/menubar/MenubarTrigger.tsx
+++ b/frontend/src/components/ui/menubar/MenubarTrigger.tsx
@@ -15,8 +15,9 @@ export function MenubarTrigger({ label, children }: MenubarTriggerProps) {
         setIsOpen(false);
       }
     };
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
+
+    document.addEventListener("mousedown", handleClickOutside, { capture: true });
+    return () => document.removeEventListener("mousedown", handleClickOutside, { capture: true });
   }, []);
 
   return (
@@ -24,7 +25,7 @@ export function MenubarTrigger({ label, children }: MenubarTriggerProps) {
       <button
         onClick={() => setIsOpen(!isOpen)}
         className={`
-          px-3 py-1 text-xs rounded transition-colors select-none
+          px-3 py-1 text-xs rounded transition-colors select-none outline-none
           ${isOpen 
             ? "bg-surface-hover text-text-primary" 
             : "text-text-secondary hover:bg-surface-hover hover:text-text-primary"
@@ -36,7 +37,7 @@ export function MenubarTrigger({ label, children }: MenubarTriggerProps) {
 
       {isOpen && (
         <div 
-          className="absolute top-full left-0 mt-1 min-w-50 bg-surface-primary border border-surface-border rounded-md shadow-xl py-1 z-50 animate-in fade-in zoom-in-95 duration-75"
+          className="absolute top-full left-0 mt-1 min-w-48 bg-surface-primary border border-surface-border rounded-md shadow-xl py-1 z-50 animate-in fade-in zoom-in-95 duration-75"
           onClick={() => setIsOpen(false)} 
         >
           {children}

--- a/frontend/src/features/diagram/components/menubar/AppMenubar.tsx
+++ b/frontend/src/features/diagram/components/menubar/AppMenubar.tsx
@@ -1,65 +1,56 @@
 import { Box } from "lucide-react";
 import { useDiagramStore } from "../../../../store/diagramStore";
-import WindowControls from "../../../../components/ui/menubar/WindowControls";
-import { FileMenu } from "./modules/FileMenu";
+import WindowControls from "../../../../components/ui/menubar/WindowControls"; 
 import { useDiagramActions } from "../../hooks/useDiagramActions";
 import UnsavedChangesModal from "../modals/UnsavedChangesModal";
+
+// Modules
+import { FileMenu } from "./modules/FileMenu";
+import { SettingsMenu } from "./modules/SettingsMenu"; 
 
 export default function AppMenubar() {
   const diagramName = useDiagramStore((s) => s.diagramName);
   const isDirty = useDiagramStore((s) => s.isDirty);
-
-  const actions = useDiagramActions();
+  
+  const actions = useDiagramActions(); 
   const { modalState } = actions;
 
   return (
     <>
       <header className="h-10 w-full bg-surface-primary border-b border-surface-border flex items-center justify-between select-none drag-region pl-3 pr-0 z-50 shrink-0">
-       
-        {/* LEFT SECTION: Logo + Menus */}
+        
+        {/* LEFT: Logo + Menus */}
         <div className="flex items-center gap-1 h-full">
-
           {/* Logo */}
           <div className="flex items-center gap-2 font-bold text-sm no-drag mr-4">
-            <Box className="w-4 h-4 text-uml-class-border fill-uml-class-bg/20" />
-            <span className="text-text-primary tracking-tight hidden sm:block">
-              LibreUML
-            </span>
+             <Box className="w-4 h-4 text-uml-class-border fill-uml-class-bg/20" />
+             <span className="text-text-primary tracking-tight hidden sm:block">LibreUML</span>
           </div>
-          {/* MENU'S BAR  */}
-          <div className="flex items-center h-full no-drag">
-            <FileMenu actions={actions} />
 
-            {/* Placeholders FOR Edit / View / Help */}
-            <button className="px-3 py-1 text-xs text-text-secondary hover:bg-surface-hover rounded transition-colors cursor-not-allowed opacity-50">
-              Edit
-            </button>
-            <button className="px-3 py-1 text-xs text-text-secondary hover:bg-surface-hover rounded transition-colors cursor-not-allowed opacity-50">
-              View
-            </button>
-            <button className="px-3 py-1 text-xs text-text-secondary hover:bg-surface-hover rounded transition-colors cursor-not-allowed opacity-50">
-              Help
-            </button>
+          {/* Menus */}
+          <div className="flex items-center h-full no-drag">
+              <FileMenu actions={actions} />
+              
+              {/* Edit / View placeholders... */}
+              
+              <SettingsMenu />
+              
+              <button className="px-3 py-1 text-xs text-text-secondary hover:bg-surface-hover rounded transition-colors cursor-not-allowed opacity-50">Help</button>
           </div>
         </div>
 
-        {/* CENTRAL SECTION: TITLE */}
+        {/* CENTER: Title */}
         <div className="absolute left-1/2 -translate-x-1/2 text-xs text-text-muted hidden md:flex items-center gap-2 pointer-events-none">
           <span>{diagramName}.luml</span>
-          {isDirty && (
-            <div
-              className="w-1.5 h-1.5 rounded-full bg-amber-400"
-              title="Unsaved"
-            />
-          )}
+          {isDirty && <div className="w-1.5 h-1.5 rounded-full bg-amber-400" title="Unsaved" />}
         </div>
 
-        {/* RIGHT SECTION: VIEW CONTROLLER */}
+        {/* RIGHT: Window Controls */}
         <WindowControls />
       </header>
 
-      {/* GLOBAL MODALS HANDLER BY HOOK */}
-      <UnsavedChangesModal
+      {/* Global Modals */}
+      <UnsavedChangesModal 
         isOpen={modalState.isOpen}
         fileName={modalState.fileName}
         onDiscard={modalState.onDiscard}

--- a/frontend/src/features/diagram/components/menubar/modules/FileMenu.tsx
+++ b/frontend/src/features/diagram/components/menubar/modules/FileMenu.tsx
@@ -1,4 +1,13 @@
-import { FilePlus, FolderOpen, Save, LogOut, XCircle } from "lucide-react";
+import { useRef } from "react";
+import { 
+  FilePlus, 
+  FolderOpen, 
+  Save, 
+  LogOut, 
+  XCircle, 
+  FileOutput, 
+  RotateCcw, 
+} from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { MenubarTrigger } from "../../../../../components/ui/menubar/MenubarTrigger";
 import { MenubarItem } from "../../../../../components/ui/menubar/MenubarItem";
@@ -10,48 +19,94 @@ interface FileMenuProps {
 
 export function FileMenu({ actions }: FileMenuProps) {
   const { t } = useTranslation();
-  const { handleNew, handleSave, handleCloseFile, handleExit } = actions;
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const { 
+    handleNew, 
+    handleOpen, 
+    handleWebImport,
+    handleSave, 
+    handleSaveAs, 
+    handleCloseFile, 
+    handleExit, 
+    hasFilePath ,
+    handleDiscardChangesAction,
+    isDirty
+  } = actions;
+
+  const onOpenClick = async () => {
+    const result = await handleOpen();
+    if (result === "TRIGGER_WEB_INPUT") {
+      fileInputRef.current?.click();
+    }
+  };
 
   return (
-    <MenubarTrigger label={t("header.file") || "File"}>
-      <MenubarItem
-        label={t("header.new") || "New Diagram"}
-        icon={<FilePlus className="w-4 h-4" />}
-        onClick={handleNew}
+    <>
+      <input
+        type="file"
+        ref={fileInputRef}
+        onChange={handleWebImport}
+        accept=".json,.luml"
+        className="hidden"
+        style={{ display: 'none' }}
       />
-      <MenubarItem
-        label={t("header.open") || "Open..."}
-        icon={<FolderOpen className="w-4 h-4" />}
-        shortcut="Ctrl+O"
-        disabled 
-      />
-      
-      <div className="h-px bg-surface-border my-1" />
-      
-      <MenubarItem
-        label={t("header.save") || "Save"}
-        icon={<Save className="w-4 h-4" />}
-        shortcut="Ctrl+S"
-        onClick={handleSave}
-      />
-      <MenubarItem
-        label="Save As..."
-        disabled
-      />
-      
-      <div className="h-px bg-surface-border my-1" />
-      
-      <MenubarItem
-        label="Close Editor"
-        icon={<XCircle className="w-4 h-4" />}
-        onClick={handleCloseFile}
-      />
-      <MenubarItem
-        label="Exit"
-        icon={<LogOut className="w-4 h-4" />}
-        onClick={handleExit}
-        danger
-      />
-    </MenubarTrigger>
+
+      <MenubarTrigger label={t("menubar.file.title") || "File"}>
+        
+        {/* NEW & OPEN */}
+        <MenubarItem
+          label={t("menubar.file.new") || "New Diagram"}
+          icon={<FilePlus className="w-4 h-4" />}
+          onClick={handleNew}
+        />
+        <MenubarItem
+          label={t("menubar.file.open") || "Open..."}
+          icon={<FolderOpen className="w-4 h-4" />}
+          shortcut="Ctrl+O"
+          onClick={onOpenClick}
+        />
+        
+        <div className="h-px bg-surface-border my-1" />
+        
+        {/* SAVE OPERATIONS */}
+        <MenubarItem
+          label={t("menubar.file.save") || "Save"}
+          icon={<Save className="w-4 h-4" />}
+          shortcut="Ctrl+S"
+          onClick={handleSave}
+          disabled={!hasFilePath} 
+        />
+        <MenubarItem
+          label={t("menubar.file.saveAs") || "Save As..."}
+          icon={<FileOutput className="w-4 h-4" />}
+          shortcut="Ctrl+Shift+S"
+          onClick={handleSaveAs}
+        />
+
+        {/* DISCARD CHANGES */}
+        <MenubarItem
+          label={t("menubar.file.discard") || "Discard Changes"}
+          icon={<RotateCcw className="w-4 h-4" />}
+          onClick={handleDiscardChangesAction} 
+          disabled={!hasFilePath || !isDirty}
+        />
+
+        <div className="h-px bg-surface-border my-1" />
+
+        {/* CLOSE & EXIT */}
+        <MenubarItem
+          label={t("menubar.file.close") || "Close Editor"}
+          icon={<XCircle className="w-4 h-4" />}
+          onClick={handleCloseFile}
+        />
+        <MenubarItem
+          label={t("menubar.file.exit") || "Exit"}
+          icon={<LogOut className="w-4 h-4" />}
+          onClick={handleExit}
+          danger
+        />
+      </MenubarTrigger>
+    </>
   );
 }

--- a/frontend/src/features/diagram/components/menubar/modules/SettingsMenu.tsx
+++ b/frontend/src/features/diagram/components/menubar/modules/SettingsMenu.tsx
@@ -1,0 +1,69 @@
+import { 
+  FileType, 
+  PlayCircle, 
+  SaveAll, 
+  Languages, 
+  Moon 
+} from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { MenubarTrigger } from "../../../../../components/ui/menubar/MenubarTrigger";
+import { MenubarItem } from "../../../../../components/ui/menubar/MenubarItem";
+
+export function SettingsMenu() {
+  const { t, i18n } = useTranslation();
+
+  const toggleLanguage = () => {
+    const newLang = i18n.language === 'en' ? 'es' : 'en';
+    i18n.changeLanguage(newLang);
+  };
+
+  return (
+    <MenubarTrigger label={t("menubar.settings.title") || "Settings"}>
+      
+      {/* --- GENERAL PREFERENCES --- */}
+      
+      {/* Auto Save Toggle */}
+      <MenubarItem
+        label={t("menubar.settings.autoSave") || "Auto Save"}
+        icon={<SaveAll className="w-4 h-4" />}
+        disabled // Logic incoming
+      />
+
+      {/* Startup Behavior */}
+      <MenubarItem
+        label={t("menubar.settings.startup") || "Startup: Restore Session"}
+        icon={<PlayCircle className="w-4 h-4" />}
+        disabled // Logic incoming
+      />
+
+      <div className="h-px bg-surface-border my-1" />
+
+      {/* --- SYSTEM INTEGRATION --- */}
+
+      {/* File Association */}
+      <MenubarItem
+        label={t("menubar.settings.fileAssoc") || "Associate .luml Files"}
+        icon={<FileType className="w-4 h-4" />}
+        disabled 
+      />
+
+      <div className="h-px bg-surface-border my-1" />
+
+      {/* --- APPEARANCE & LOCALIZATION --- */}
+
+      {/* Language Switcher */}
+      <MenubarItem
+        label={`${t("menubar.settings.language")}: ${i18n.language.toUpperCase()}`}
+        icon={<Languages className="w-4 h-4" />}
+        onClick={toggleLanguage}
+      />
+
+      {/* Theme Toggle (Placeholder) */}
+      <MenubarItem
+        label={t("menubar.settings.theme") || "Theme"}
+        icon={<Moon className="w-4 h-4" />}
+        disabled
+      />
+    </MenubarTrigger>
+  );
+}

--- a/frontend/src/features/diagram/hooks/useDiagramActions.ts
+++ b/frontend/src/features/diagram/hooks/useDiagramActions.ts
@@ -3,24 +3,34 @@ import { useReactFlow } from "reactflow";
 import { useDiagramStore } from "../../../store/diagramStore";
 import { StorageService } from "../../../services/storage.service";
 
-
 export const useDiagramActions = () => {
-  const { toObject, fitView } = useReactFlow();
-  
-  // Local state for modals
+  // HOOKS & LOCAL STATE
+
+  const { toObject, fitView, setViewport } = useReactFlow();
+
+  // State to control modals and pending actions
   const [showUnsavedModal, setShowUnsavedModal] = useState(false);
-  const [pendingAction, setPendingAction] = useState<"closeFile" | "exit" | null>(null);
+  const [pendingAction, setPendingAction] = useState<
+    "closeFile" | "exit" | "open" | "revert" | null
+  >(null);
 
-
+  // Store Access (Lazy)
   const storeApi = useDiagramStore.getState;
   const temporalApi = useDiagramStore.temporal.getState;
 
+  // Reactive State (for UI)
+  const currentFilePath = useDiagramStore((s) => s.currentFilePath);
+  const hasFilePath = !!currentFilePath;
+  const isDirty = useDiagramStore((s) => s.isDirty);
+
+  //  LIFECYCLE LISTENERS
+
+  // Listen for window close attempt (X button or Alt+F4)
   useEffect(() => {
     if (!window.electronAPI?.isElectron()) return;
 
     const unsubscribe = window.electronAPI.onAppRequestClose(() => {
       const { isDirty } = storeApi();
-      
       if (isDirty) {
         setPendingAction("exit");
         setShowUnsavedModal(true);
@@ -28,50 +38,91 @@ export const useDiagramActions = () => {
         window.electronAPI?.sendForceClose();
       }
     });
-
     return () => unsubscribe();
-  }, []);
+  }, [storeApi]);
 
-  // ---  ACTION: CLOSE FILE / NEW ---
-  const handleCloseFile = useCallback(() => {
-    const { isDirty, resetDiagram } = storeApi(); 
-    
+  //FILE OPERATIONS
+
+  // --- OPEN IN WEB ---
+  const handleWebImport = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      if (!file) return;
+
+      const reader = new FileReader();
+      reader.onload = (e) => {
+        try {
+          const content = e.target?.result as string;
+          const parsedData = JSON.parse(content);
+          const { loadDiagram } = storeApi();
+
+          loadDiagram(parsedData);
+
+          // Restaurar viewport si existe
+          if (parsedData.viewport) {
+            const { x, y, zoom } = parsedData.viewport;
+            setViewport({ x, y, zoom });
+          } else {
+            setTimeout(() => fitView({ duration: 800 }), 100);
+          }
+        } catch (error) {
+          console.error("Error loading file:", error);
+          alert("Error al leer el archivo. Asegúrate de que sea válido.");
+        }
+      };
+      reader.readAsText(file);
+      event.target.value = "";
+    },
+    [storeApi, fitView, setViewport],
+  );
+
+  // --- HANDLER OPEN  ---
+  const handleOpen = useCallback(async () => {
+    const { isDirty } = storeApi();
+
     if (isDirty) {
-      setPendingAction("closeFile");
+      setPendingAction("open");
       setShowUnsavedModal(true);
-    } else {
-      resetDiagram();
+      return;
     }
-  }, []);
 
-  // --- 2. ACTION: EXIT ---
-  const handleExit = useCallback(() => {
     if (window.electronAPI?.isElectron()) {
-       const { isDirty } = storeApi();
-       
-       if (isDirty) {
-         setPendingAction("exit");
-         setShowUnsavedModal(true);
-       } else {
-         window.electronAPI.close();
-       }
-    }
-  }, []);
+      const result = await StorageService.openDiagram();
+      if (result) {
+        const { loadDiagram, setFilePath, setDiagramName } = storeApi();
+        loadDiagram(result.data);
 
-  // --- ACTION: SAVE ---
+        if (result.filePath) {
+          setFilePath(result.filePath);
+          const fileName = result.filePath
+            .split(/[\\/]/)
+            .pop()
+            ?.replace(".luml", "");
+          if (fileName) setDiagramName(fileName);
+        }
+        setTimeout(() => fitView({ duration: 800 }), 100);
+      }
+    } else {
+      return "TRIGGER_WEB_INPUT";
+    }
+  }, [fitView, storeApi]);
+
+  // --- SAVE ---
   const handleSave = useCallback(async () => {
-    const { diagramId, diagramName, currentFilePath, setFilePath, setDirty } = storeApi();
+    const { diagramId, diagramName, currentFilePath, setFilePath, setDirty } =
+      storeApi();
     const flowObject = toObject();
-    
+
     document.body.style.cursor = "wait";
-    
+
+    // Save to current path
     const result = await StorageService.saveDiagram(
       flowObject,
       diagramId,
       diagramName,
-      currentFilePath
+      currentFilePath,
     );
-    
+
     document.body.style.cursor = "default";
 
     if (result.success && result.filePath) {
@@ -80,60 +131,176 @@ export const useDiagramActions = () => {
       return true;
     }
     return false;
-  }, [toObject]); 
+  }, [storeApi, toObject]);
 
-  // ---  MODAL'S HANDLER ---
+  // --- SAVE AS ---
+  const handleSaveAs = useCallback(async () => {
+    const { diagramId, diagramName } = storeApi();
+    const flowObject = toObject();
+
+    document.body.style.cursor = "wait";
+
+    const result = await StorageService.saveDiagram(
+      flowObject,
+      diagramId,
+      diagramName,
+      undefined,
+    );
+
+    document.body.style.cursor = "default";
+
+    if (result.success && result.filePath) {
+      const { setFilePath, setDirty, setDiagramName } = storeApi();
+      setFilePath(result.filePath);
+
+      const fileName = result.filePath
+        .split(/[\\/]/)
+        .pop()
+        ?.replace(".luml", "");
+      if (fileName) setDiagramName(fileName);
+
+      setDirty(false);
+      return true;
+    }
+    return false;
+  }, [storeApi, toObject]);
+
+  // --- CLOSE FILE / NEW ---
+  const handleCloseFile = useCallback(() => {
+    const { isDirty, resetDiagram } = storeApi();
+
+    if (isDirty) {
+      setPendingAction("closeFile");
+      setShowUnsavedModal(true);
+    } else {
+      resetDiagram();
+    }
+  }, [storeApi]);
+
+  // --- DISCARD CHANGES (REVERT) ---
+  const handleReloadLogic = useCallback(async () => {
+    const { currentFilePath, loadDiagram, setDirty } = storeApi();
+
+    if (currentFilePath && window.electronAPI?.isElectron()) {
+      const data = await StorageService.reloadDiagram(currentFilePath);
+      if (data) {
+        loadDiagram(data, true);
+
+        setDirty(false);
+        setTimeout(() => fitView({ duration: 800 }), 100);
+      }
+    }
+  }, [storeApi, fitView]);
+
+  const handleDiscardChangesTrigger = useCallback(() => {
+    const { isDirty: dirtyNow, currentFilePath: pathNow } = storeApi();
+
+    if (!pathNow) {
+      handleCloseFile();
+      return;
+    }
+
+    if (dirtyNow) {
+      setPendingAction("revert");
+      setShowUnsavedModal(true);
+    } else {
+      handleReloadLogic();
+    }
+  }, [storeApi, handleReloadLogic, handleCloseFile]);
+
   const handleDiscardChanges = useCallback(() => {
     setShowUnsavedModal(false);
-    localStorage.removeItem('libreuml-backup');
-    
+    localStorage.removeItem("libreuml-backup");
+
     const { resetDiagram } = storeApi();
 
     if (pendingAction === "closeFile") {
       resetDiagram();
     } else if (pendingAction === "exit") {
-       window.electronAPI?.sendForceClose();
+      window.electronAPI?.sendForceClose();
+    } else if (pendingAction === "open") {
+      resetDiagram();
+      handleOpen();
     }
+    // --- CASO REVERT ---
+    else if (pendingAction === "revert") {
+      handleReloadLogic();
+    }
+
     setPendingAction(null);
-  }, [pendingAction]);
+  }, [pendingAction, storeApi, handleOpen, handleReloadLogic]);
+
+  // --- EXIT APP ---
+  const handleExit = useCallback(() => {
+    if (window.electronAPI?.isElectron()) {
+      const { isDirty } = storeApi();
+
+      if (isDirty) {
+        setPendingAction("exit");
+        setShowUnsavedModal(true);
+      } else {
+        window.electronAPI.close();
+      }
+    }
+  }, [storeApi]);
+
+  //MODAL HANDLERS (CONFIRMATION)
 
   const handleSaveAndAction = useCallback(async () => {
     const saved = await handleSave();
+
     if (saved) {
-      localStorage.removeItem('libreuml-backup');
+      localStorage.removeItem("libreuml-backup");
       setShowUnsavedModal(false);
-      
+
       const { resetDiagram } = storeApi();
 
       if (pendingAction === "closeFile") {
         resetDiagram();
       } else if (pendingAction === "exit") {
         window.electronAPI?.sendForceClose();
+      } else if (pendingAction === "open") {
+        handleOpen();
       }
       setPendingAction(null);
     }
-  }, [handleSave, pendingAction]);
+  }, [handleSave, pendingAction, storeApi, handleOpen]);
 
-  // ---  VIEW ---
+  //  VIEW & UTILS
+
   const handleFitView = useCallback(() => {
     fitView({ duration: 800 });
   }, [fitView]);
 
+  //  PUBLIC API
+
   return {
+    // Actions
+    handleWebImport,
+    handleOpen,
+    handleSave,
+    handleSaveAs,
     handleNew: handleCloseFile,
     handleCloseFile,
-    handleSave,
     handleExit,
     handleFitView,
+    handleDiscardChangesAction: handleDiscardChangesTrigger,
+
+    // Edit Actions
     undo: () => temporalApi().undo(),
     redo: () => temporalApi().redo(),
-    
+
+    // State Flags
+    hasFilePath,
+    isDirty,
+
+    // Modal State Control
     modalState: {
       isOpen: showUnsavedModal,
       close: () => setShowUnsavedModal(false),
       onDiscard: handleDiscardChanges,
       onSave: handleSaveAndAction,
-      fileName: storeApi().diagramName 
-    }
+      fileName: storeApi().diagramName,
+    },
   };
 };

--- a/frontend/src/hooks/useAutosave.ts
+++ b/frontend/src/hooks/useAutosave.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { useDiagramStore } from '../store/diagramStore';
-import {  useReactFlow } from 'reactflow';
+import { useReactFlow } from 'reactflow';
 import type { DiagramState, UmlClassNode, UmlEdge } from '../features/diagram/types/diagram.types';
 
 const AUTOSAVE_INTERVAL = 30 * 1000; 
@@ -8,35 +8,40 @@ const STORAGE_KEY = 'libreuml-backup';
 
 export const useAutosave = () => {
   const { toObject } = useReactFlow();
-  const isDirty = useDiagramStore((state) => state.isDirty);
-  const diagramId = useDiagramStore((state) => state.diagramId);
-  const diagramName = useDiagramStore((state) => state.diagramName);
+  
+  // Use getState to read without re-rendering (optimization)
+  const storeApi = useDiagramStore.getState;
 
   useEffect(() => {
     const timer = setInterval(() => {
-      if (isDirty) {
-        console.log('🔄 Ejecutando Autosave de Emergencia...');
-        
-        const flowObject = toObject();
-        
-        const cleanEdges = flowObject.edges.map((edge) => {
-            const { ...semanticEdge } = edge;
-            return semanticEdge;
-        });
+      const { isDirty, diagramId, diagramName, currentFilePath } = storeApi();
 
-        const backupData: DiagramState = {
-            id: diagramId,
-            name: diagramName,
-            nodes: flowObject.nodes as unknown as UmlClassNode[],
-            edges: cleanEdges as unknown as UmlEdge[],
-            viewport: flowObject.viewport
-        };
-
-        localStorage.setItem(STORAGE_KEY, JSON.stringify(backupData));
-        localStorage.setItem(STORAGE_KEY + '-timestamp', new Date().toISOString());
+      // LOGIC: If not dirty OR no real file assigned, skip autosave.
+      if (!isDirty || !currentFilePath) {
+        return;
       }
+
+      console.log('🔄 Executing Autosave (Only for existing file)...');
+      
+      const flowObject = toObject();
+      
+      const cleanEdges = flowObject.edges.map((edge) => {
+          const { ...semanticEdge } = edge;
+          return semanticEdge;
+      });
+
+      const backupData: DiagramState = {
+          id: diagramId,
+          name: diagramName,
+          nodes: flowObject.nodes as unknown as UmlClassNode[],
+          edges: cleanEdges as unknown as UmlEdge[],
+          viewport: flowObject.viewport
+      };
+
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(backupData));
+      localStorage.setItem(STORAGE_KEY + '-timestamp', new Date().toISOString());
     }, AUTOSAVE_INTERVAL);
 
     return () => clearInterval(timer);
-  }, [isDirty, diagramId, diagramName, toObject]);
+  }, [storeApi, toObject]); 
 };

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1,14 +1,14 @@
 {
   "header": {
     "diagramNamePlaceholder": "Diagram Name",
-    "search": "Search",
+    "search": "Search (Ctrl+K)",
     "switchLanguage": "Switch Language",
     "import": "Import",
     "export": "Export",
     "save": "Save",
     "tooltips": {
-      "undo": "Undo (Ctrl+Z)",
-      "redo": "Redo (Ctrl+Y)",
+      "undo": "Undo",
+      "redo": "Redo",
       "showMiniMap": "Show MiniMap",
       "hideMiniMap": "Hide MiniMap",
       "zoomIn": "Zoom In",
@@ -20,6 +20,27 @@
       "png": "Export to PNG",
       "cloud": "Save to Cloud",
       "soon": "Soon"
+    }
+  },
+  "menubar": {
+    "file": {
+      "title": "File",
+      "new": "New Diagram",
+      "open": "Open...",
+      "save": "Save",
+      "saveAs": "Save As...",
+      "discard": "Discard Changes",
+      "close": "Close Editor",
+      "exit": "Exit"
+    },
+    "settings": {
+      "title": "Settings",
+      "general": "General",
+      "autoSave": "Auto Save",
+      "fileAssoc": "Associate .luml Files",
+      "startup": "Startup: Restore Session",
+      "language": "Language",
+      "theme": "Theme"
     }
   },
   "sidebar": {
@@ -102,6 +123,7 @@
   },
   "alerts": {
     "exportError": "Could not generate the image. Please try again.",
+    "savedSuccess": "Diagram saved successfully",
     "importError": "Error loading file. Make sure it is a valid .json or .luml."
   }
 }

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -1,14 +1,14 @@
 {
   "header": {
     "diagramNamePlaceholder": "Nombre del Diagrama",
-    "search": "Buscar",
+    "search": "Buscar (Ctrl+K)",
     "switchLanguage": "Cambiar Idioma",
     "import": "Importar",
     "export": "Exportar",
     "save": "Guardar",
     "tooltips": {
-      "undo": "Deshacer (Ctrl+Z)",
-      "redo": "Rehacer (Ctrl+Y)",
+      "undo": "Deshacer",
+      "redo": "Rehacer",
       "showMiniMap": "Mostrar Minimapa",
       "hideMiniMap": "Ocultar Minimapa",
       "zoomIn": "Acercar",
@@ -22,7 +22,27 @@
       "soon": "Pronto"
     }
   },
-
+  "menubar": {
+    "file": {
+      "title": "Archivo",
+      "new": "Nuevo Diagrama",
+      "open": "Abrir...",
+      "save": "Guardar",
+      "saveAs": "Guardar Como...",
+      "discard": "Descartar Cambios", 
+      "close": "Cerrar Editor",
+      "exit": "Salir"
+    },
+    "settings": {
+      "title": "Ajustes",
+      "general": "General",
+      "autoSave": "Autoguardado",
+      "fileAssoc": "Asociar Archivos .luml",
+      "startup": "Inicio: Restaurar Sesión",
+      "language": "Idioma",
+      "theme": "Tema"
+    }
+  },
   "sidebar": {
     "toolbox": "Caja de Herramientas",
     "nodes": {
@@ -103,6 +123,7 @@
   },
   "alerts": {
     "exportError": "No se pudo generar la imagen. Intenta de nuevo.",
+    "savedSuccess": "Diagrama guardado correctamente",
     "importError": "Error al leer el archivo. Asegúrate de que sea un .json o .luml válido."
   }
 }

--- a/frontend/src/services/storage.service.ts
+++ b/frontend/src/services/storage.service.ts
@@ -3,6 +3,7 @@ import { ExportService } from "./export.service";
 import type { DiagramState, UmlClassNode, UmlEdge } from "../features/diagram/types/diagram.types";
 
 export const StorageService = {
+  // --- SAVE DIAGRAM ---
   saveDiagram: async (
     flowObject: ReactFlowJsonObject,
     id: string,
@@ -41,7 +42,8 @@ export const StorageService = {
     }
   },
 
- openDiagram: async (): Promise<{ data: DiagramState; filePath: string } | null> => {
+  // --- OPEN WITH DIALOG ---
+  openDiagram: async (): Promise<{ data: DiagramState; filePath: string } | null> => {
     if (window.electronAPI?.isElectron()) {
       try {
         const result = await window.electronAPI.openFile();
@@ -55,11 +57,26 @@ export const StorageService = {
         };
       } catch (error) {
         console.error("Error opening via Electron:", error);
-        alert("El archivo está corrupto o no es válido.");
+        alert("File is corrupt or invalid.");
         return null;
       }
     } else {
       return null; 
     }
-  }
+  },
+
+  // RELOAD FROM DISK (SILENT) ---
+  reloadDiagram: async (filePath: string): Promise<DiagramState | null> => {
+    if (window.electronAPI?.isElectron()) {
+      try {
+        const result = await window.electronAPI.readFile(filePath);
+        if (result.success && result.content) {
+           return JSON.parse(result.content) as DiagramState;
+        }
+      } catch (error) {
+        console.error("Error reloading file:", error);
+      }
+    }
+    return null;
+  },
 };

--- a/frontend/src/types/electron.d.ts
+++ b/frontend/src/types/electron.d.ts
@@ -6,7 +6,8 @@ interface ElectronAPI {
   openFile: () => Promise<{ canceled: boolean; filePath?: string; content?: string }>;
   onAppRequestClose: (callback: () => void) => () => void;
   sendForceClose: () => void;
-
+  readFile: (filePath: string) => Promise<{ success: boolean; content?: string }>;
+  
   minimize: () => void;
   toggleMaximize: () => void;
   close: () => void;


### PR DESCRIPTION
- refactor(ui): replace monolithic Header with modular AppMenubar and generic Menubar components.
- feat(electron): enable frameless window and add 'file:read' IPC for silent reload.
- feat(logic): implement robust FileMenu actions (New, Open, Save, Save As, Discard).
- fix(store): update 'loadDiagram' to preserve file path on reload/revert operations.
- feat(hooks): add reactive 'isDirty' state and web import support to useDiagramActions.
- chore: add i18n keys for menubar and settings.