### PR TITLE
refactor(hooks): architecture decoupling using SRP and Action Guard pattern

### DIFF
--- a/frontend/src/features/diagram/hooks/actions/useAppLifecycle.ts
+++ b/frontend/src/features/diagram/hooks/actions/useAppLifecycle.ts
@@ -1,0 +1,37 @@
+import { useEffect, useCallback } from "react";
+
+interface UseAppLifecycleProps {
+  executeSafeAction: (action: () => void | Promise<void>) => void;
+}
+
+export const useAppLifecycle = ({
+  executeSafeAction,
+}: UseAppLifecycleProps) => {
+  // --- LISTENERS ---
+
+  useEffect(() => {
+    if (!window.electronAPI?.isElectron()) return;
+
+    const unsubscribe = window.electronAPI.onAppRequestClose(() => {
+      executeSafeAction(() => {
+        window.electronAPI?.sendForceClose();
+      });
+    });
+
+    return () => unsubscribe();
+  }, [executeSafeAction]);
+
+  // --- ACTIONS ---
+
+  const handleExit = useCallback(() => {
+    if (window.electronAPI?.isElectron()) {
+      executeSafeAction(() => {
+        window.electronAPI?.close();
+      });
+    }
+  }, [executeSafeAction]);
+
+  return {
+    handleExit,
+  };
+};

--- a/frontend/src/features/diagram/hooks/actions/useEditorControls.ts
+++ b/frontend/src/features/diagram/hooks/actions/useEditorControls.ts
@@ -1,0 +1,30 @@
+import { useCallback } from "react";
+import { useReactFlow } from "reactflow";
+import { useDiagramStore } from "../../../../store/diagramStore";
+
+export const useEditorControls = () => {
+  const { fitView } = useReactFlow();
+  const temporalApi = useDiagramStore.temporal.getState;
+
+  // --- VIEW ACTIONS ---
+  
+  const handleFitView = useCallback(() => {
+    fitView({ duration: 800 });
+  }, [fitView]);
+
+  // --- HISTORY ACTIONS ---
+
+  const undo = useCallback(() => {
+    temporalApi().undo();
+  }, [temporalApi]);
+
+  const redo = useCallback(() => {
+    temporalApi().redo();
+  }, [temporalApi]);
+
+  return {
+    handleFitView,
+    undo,
+    redo,
+  };
+};

--- a/frontend/src/features/diagram/hooks/actions/useFileLifecycle.ts
+++ b/frontend/src/features/diagram/hooks/actions/useFileLifecycle.ts
@@ -1,0 +1,148 @@
+import { useCallback } from "react";
+import { useReactFlow } from "reactflow";
+import { useDiagramStore } from "../../../../store/diagramStore";
+import { StorageService } from "../../../../services/storage.service";
+
+export const useFileLifecycle = () => {
+  const { toObject, fitView, setViewport } = useReactFlow();
+  const storeApi = useDiagramStore.getState;
+
+  // --- HELPERS ---
+  
+  const fitViewAfterLoad = useCallback(() => {
+    setTimeout(() => fitView({ duration: 800 }), 100);
+  }, [fitView]);
+
+  // --- ACTIONS ---
+
+  // CREATE NEW / RESET
+  const createNewDiagram = useCallback(() => {
+    const { resetDiagram } = storeApi();
+    resetDiagram();
+  }, [storeApi]);
+
+  // OPEN FROM DISK
+  const openDiagramFromDisk = useCallback(async () => {
+    if (!window.electronAPI?.isElectron()) return;
+
+    const result = await StorageService.openDiagram();
+    if (result) {
+      const { loadDiagram, setFilePath, setDiagramName } = storeApi();
+      loadDiagram(result.data);
+      
+      if (result.filePath) {
+        setFilePath(result.filePath);
+        const fileName = result.filePath.split(/[\\/]/).pop()?.replace(".luml", "");
+        if (fileName) setDiagramName(fileName);
+      }
+      fitViewAfterLoad();
+    }
+  }, [storeApi, fitViewAfterLoad]);
+
+  // IMPORT FROM WEB (JSON)
+  const importFromWeb = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      try {
+        const content = e.target?.result as string;
+        const parsedData = JSON.parse(content);
+        const { loadDiagram } = storeApi();
+
+        loadDiagram(parsedData);
+
+        if (parsedData.viewport) {
+          const { x, y, zoom } = parsedData.viewport;
+          setViewport({ x, y, zoom });
+        } else {
+          fitViewAfterLoad();
+        }
+      } catch (error) {
+        console.error("Error loading file:", error);
+        alert("Error loading file. Please ensure it is a valid .json or .luml.");
+      }
+    };
+    reader.readAsText(file);
+    event.target.value = ""; 
+  }, [storeApi, setViewport, fitViewAfterLoad]);
+
+  // SAVE (Current Path)
+  const saveDiagram = useCallback(async () => {
+    const { diagramId, diagramName, currentFilePath, setFilePath, setDirty } = storeApi();
+    
+    if (!currentFilePath) return false;
+
+    const flowObject = toObject();
+    document.body.style.cursor = "wait";
+
+    const result = await StorageService.saveDiagram(
+      flowObject,
+      diagramId,
+      diagramName,
+      currentFilePath
+    );
+
+    document.body.style.cursor = "default";
+
+    if (result.success && result.filePath) {
+      setFilePath(result.filePath);
+      setDirty(false);
+      return true;
+    }
+    return false;
+  }, [storeApi, toObject]);
+
+  // SAVE AS (New Path)
+  const saveDiagramAs = useCallback(async () => {
+    const { diagramId, diagramName } = storeApi();
+    const flowObject = toObject();
+
+    document.body.style.cursor = "wait";
+
+    const result = await StorageService.saveDiagram(
+      flowObject,
+      diagramId,
+      diagramName,
+      undefined 
+    );
+
+    document.body.style.cursor = "default";
+
+    if (result.success && result.filePath) {
+      const { setFilePath, setDirty, setDiagramName } = storeApi();
+      setFilePath(result.filePath);
+
+      const fileName = result.filePath.split(/[\\/]/).pop()?.replace(".luml", "");
+      if (fileName) setDiagramName(fileName);
+
+      setDirty(false);
+      return true;
+    }
+    return false;
+  }, [storeApi, toObject]);
+
+  // REVERT (Reload from Disk)
+  const revertDiagram = useCallback(async () => {
+    const { currentFilePath, loadDiagram, setDirty } = storeApi();
+
+    if (currentFilePath && window.electronAPI?.isElectron()) {
+      const data = await StorageService.reloadDiagram(currentFilePath);
+      if (data) {
+        loadDiagram(data, true);
+        setDirty(false);
+        fitViewAfterLoad();
+      }
+    }
+  }, [storeApi, fitViewAfterLoad]);
+
+  return {
+    createNewDiagram,
+    openDiagramFromDisk,
+    importFromWeb,
+    saveDiagram,
+    saveDiagramAs,
+    revertDiagram,
+  };
+};

--- a/frontend/src/features/diagram/hooks/useActionGuard.ts
+++ b/frontend/src/features/diagram/hooks/useActionGuard.ts
@@ -1,0 +1,62 @@
+import { useState, useCallback } from "react";
+import { useDiagramStore } from "../../../store/diagramStore";
+
+type PendingAction = () => void | Promise<void>;
+
+export const useActionGuard = () => {
+  const [showModal, setShowModal] = useState(false);
+  const [pendingAction, setPendingAction] = useState<PendingAction | null>(null);
+
+  /**
+   * Executes an action safely.
+   * Checks current dirty state directly from store.
+   */
+  const executeSafeAction = useCallback((action: PendingAction) => {
+    const currentIsDirty = useDiagramStore.getState().isDirty;
+
+    if (!currentIsDirty) {
+      action();
+    } else {
+      setPendingAction(() => action);
+      setShowModal(true);
+    }
+  }, []);
+
+  const confirmDiscard = useCallback(() => {
+    setShowModal(false);
+    localStorage.removeItem("libreuml-backup");
+    
+    if (pendingAction) {
+      pendingAction();
+    }
+    setPendingAction(null);
+  }, [pendingAction]);
+
+  const confirmSave = useCallback(async (saveFn: () => Promise<boolean>) => {
+    const success = await saveFn();
+    if (success) {
+      setShowModal(false);
+      localStorage.removeItem("libreuml-backup");
+      
+      if (pendingAction) {
+        pendingAction();
+      }
+      setPendingAction(null);
+    }
+  }, [pendingAction]);
+
+  const cancelAction = useCallback(() => {
+    setShowModal(false);
+    setPendingAction(null);
+  }, []);
+
+  return {
+    executeSafeAction,
+    modalState: {
+      isOpen: showModal,
+      close: cancelAction,
+      onDiscard: confirmDiscard,
+      onSave: confirmSave,
+    }
+  };
+};

--- a/frontend/src/features/diagram/hooks/useDiagramActions.ts
+++ b/frontend/src/features/diagram/hooks/useDiagramActions.ts
@@ -1,306 +1,92 @@
-import { useCallback, useEffect, useState } from "react";
-import { useReactFlow } from "reactflow";
+import { useCallback } from "react";
 import { useDiagramStore } from "../../../store/diagramStore";
-import { StorageService } from "../../../services/storage.service";
+
+// Import Specialists
+import { useActionGuard } from "./useActionGuard";
+import { useFileLifecycle } from "./actions/useFileLifecycle";
+import { useEditorControls } from "./actions/useEditorControls";
+import { useAppLifecycle } from "./actions/useAppLifecycle";
 
 export const useDiagramActions = () => {
-  // HOOKS & LOCAL STATE
-
-  const { toObject, fitView, setViewport } = useReactFlow();
-
-  // State to control modals and pending actions
-  const [showUnsavedModal, setShowUnsavedModal] = useState(false);
-  const [pendingAction, setPendingAction] = useState<
-    "closeFile" | "exit" | "open" | "revert" | null
-  >(null);
-
-  // Store Access (Lazy)
-  const storeApi = useDiagramStore.getState;
-  const temporalApi = useDiagramStore.temporal.getState;
-
-  // Reactive State (for UI)
+  // REACTIVE STATE (For UI)
+  const isDirty = useDiagramStore((s) => s.isDirty);
   const currentFilePath = useDiagramStore((s) => s.currentFilePath);
   const hasFilePath = !!currentFilePath;
-  const isDirty = useDiagramStore((s) => s.isDirty);
 
-  //  LIFECYCLE LISTENERS
+  // INITIALIZE SPECIALISTS
+  const { executeSafeAction, modalState } = useActionGuard();
+  
+  // Specialists
+  const fileLifecycle = useFileLifecycle();
+  const editorControls = useEditorControls();
+  
+  // App Lifecycle needs the guard to handle safe exit
+  const appLifecycle = useAppLifecycle({ executeSafeAction });
 
-  // Listen for window close attempt (X button or Alt+F4)
-  useEffect(() => {
-    if (!window.electronAPI?.isElectron()) return;
-
-    const unsubscribe = window.electronAPI.onAppRequestClose(() => {
-      const { isDirty } = storeApi();
-      if (isDirty) {
-        setPendingAction("exit");
-        setShowUnsavedModal(true);
-      } else {
-        window.electronAPI?.sendForceClose();
-      }
-    });
-    return () => unsubscribe();
-  }, [storeApi]);
-
-  //FILE OPERATIONS
-
-  // --- OPEN IN WEB ---
-  const handleWebImport = useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>) => {
-      const file = event.target.files?.[0];
-      if (!file) return;
-
-      const reader = new FileReader();
-      reader.onload = (e) => {
-        try {
-          const content = e.target?.result as string;
-          const parsedData = JSON.parse(content);
-          const { loadDiagram } = storeApi();
-
-          loadDiagram(parsedData);
-
-          // Restaurar viewport si existe
-          if (parsedData.viewport) {
-            const { x, y, zoom } = parsedData.viewport;
-            setViewport({ x, y, zoom });
-          } else {
-            setTimeout(() => fitView({ duration: 800 }), 100);
-          }
-        } catch (error) {
-          console.error("Error loading file:", error);
-          alert("Error al leer el archivo. Asegúrate de que sea válido.");
-        }
-      };
-      reader.readAsText(file);
-      event.target.value = "";
-    },
-    [storeApi, fitView, setViewport],
-  );
-
-  // --- HANDLER OPEN  ---
+  //  ORCHESTRATED ACTIONS
   const handleOpen = useCallback(async () => {
-    const { isDirty } = storeApi();
-
-    if (isDirty) {
-      setPendingAction("open");
-      setShowUnsavedModal(true);
-      return;
-    }
-
     if (window.electronAPI?.isElectron()) {
-      const result = await StorageService.openDiagram();
-      if (result) {
-        const { loadDiagram, setFilePath, setDiagramName } = storeApi();
-        loadDiagram(result.data);
-
-        if (result.filePath) {
-          setFilePath(result.filePath);
-          const fileName = result.filePath
-            .split(/[\\/]/)
-            .pop()
-            ?.replace(".luml", "");
-          if (fileName) setDiagramName(fileName);
-        }
-        setTimeout(() => fitView({ duration: 800 }), 100);
-      }
+      executeSafeAction(fileLifecycle.openDiagramFromDisk);
+      return null;
     } else {
-      return "TRIGGER_WEB_INPUT";
-    }
-  }, [fitView, storeApi]);
-
-  // --- SAVE ---
-  const handleSave = useCallback(async () => {
-    const { diagramId, diagramName, currentFilePath, setFilePath, setDirty } =
-      storeApi();
-    const flowObject = toObject();
-
-    document.body.style.cursor = "wait";
-
-    // Save to current path
-    const result = await StorageService.saveDiagram(
-      flowObject,
-      diagramId,
-      diagramName,
-      currentFilePath,
-    );
-
-    document.body.style.cursor = "default";
-
-    if (result.success && result.filePath) {
-      setFilePath(result.filePath);
-      setDirty(false);
-      return true;
-    }
-    return false;
-  }, [storeApi, toObject]);
-
-  // --- SAVE AS ---
-  const handleSaveAs = useCallback(async () => {
-    const { diagramId, diagramName } = storeApi();
-    const flowObject = toObject();
-
-    document.body.style.cursor = "wait";
-
-    const result = await StorageService.saveDiagram(
-      flowObject,
-      diagramId,
-      diagramName,
-      undefined,
-    );
-
-    document.body.style.cursor = "default";
-
-    if (result.success && result.filePath) {
-      const { setFilePath, setDirty, setDiagramName } = storeApi();
-      setFilePath(result.filePath);
-
-      const fileName = result.filePath
-        .split(/[\\/]/)
-        .pop()
-        ?.replace(".luml", "");
-      if (fileName) setDiagramName(fileName);
-
-      setDirty(false);
-      return true;
-    }
-    return false;
-  }, [storeApi, toObject]);
-
-  // --- CLOSE FILE / NEW ---
-  const handleCloseFile = useCallback(() => {
-    const { isDirty, resetDiagram } = storeApi();
-
-    if (isDirty) {
-      setPendingAction("closeFile");
-      setShowUnsavedModal(true);
-    } else {
-      resetDiagram();
-    }
-  }, [storeApi]);
-
-  // --- DISCARD CHANGES (REVERT) ---
-  const handleReloadLogic = useCallback(async () => {
-    const { currentFilePath, loadDiagram, setDirty } = storeApi();
-
-    if (currentFilePath && window.electronAPI?.isElectron()) {
-      const data = await StorageService.reloadDiagram(currentFilePath);
-      if (data) {
-        loadDiagram(data, true);
-
-        setDirty(false);
-        setTimeout(() => fitView({ duration: 800 }), 100);
-      }
-    }
-  }, [storeApi, fitView]);
-
-  const handleDiscardChangesTrigger = useCallback(() => {
-    const { isDirty: dirtyNow, currentFilePath: pathNow } = storeApi();
-
-    if (!pathNow) {
-      handleCloseFile();
-      return;
-    }
-
-    if (dirtyNow) {
-      setPendingAction("revert");
-      setShowUnsavedModal(true);
-    } else {
-      handleReloadLogic();
-    }
-  }, [storeApi, handleReloadLogic, handleCloseFile]);
-
-  const handleDiscardChanges = useCallback(() => {
-    setShowUnsavedModal(false);
-    localStorage.removeItem("libreuml-backup");
-
-    const { resetDiagram } = storeApi();
-
-    if (pendingAction === "closeFile") {
-      resetDiagram();
-    } else if (pendingAction === "exit") {
-      window.electronAPI?.sendForceClose();
-    } else if (pendingAction === "open") {
-      resetDiagram();
-      handleOpen();
-    }
-    // --- CASO REVERT ---
-    else if (pendingAction === "revert") {
-      handleReloadLogic();
-    }
-
-    setPendingAction(null);
-  }, [pendingAction, storeApi, handleOpen, handleReloadLogic]);
-
-  // --- EXIT APP ---
-  const handleExit = useCallback(() => {
-    if (window.electronAPI?.isElectron()) {
-      const { isDirty } = storeApi();
-
-      if (isDirty) {
-        setPendingAction("exit");
-        setShowUnsavedModal(true);
+      const isClean = !useDiagramStore.getState().isDirty;
+      if (isClean) {
+        return "TRIGGER_WEB_INPUT";
       } else {
-        window.electronAPI.close();
+
+        executeSafeAction(fileLifecycle.createNewDiagram); 
+        return null;
       }
     }
-  }, [storeApi]);
+  }, [executeSafeAction, fileLifecycle]);
 
-  //MODAL HANDLERS (CONFIRMATION)
 
-  const handleSaveAndAction = useCallback(async () => {
-    const saved = await handleSave();
+  const handleNew = useCallback(() => {
+    executeSafeAction(fileLifecycle.createNewDiagram);
+  }, [executeSafeAction, fileLifecycle]);
 
-    if (saved) {
-      localStorage.removeItem("libreuml-backup");
-      setShowUnsavedModal(false);
+  const handleDiscardChangesAction = useCallback(() => {
+    const hasPath = !!useDiagramStore.getState().currentFilePath;
+    
+    const discardStrategy = hasPath 
+      ? fileLifecycle.revertDiagram 
+      : fileLifecycle.createNewDiagram;
 
-      const { resetDiagram } = storeApi();
+    executeSafeAction(discardStrategy);
+  }, [executeSafeAction, fileLifecycle]);
 
-      if (pendingAction === "closeFile") {
-        resetDiagram();
-      } else if (pendingAction === "exit") {
-        window.electronAPI?.sendForceClose();
-      } else if (pendingAction === "open") {
-        handleOpen();
-      }
-      setPendingAction(null);
-    }
-  }, [handleSave, pendingAction, storeApi, handleOpen]);
-
-  //  VIEW & UTILS
-
-  const handleFitView = useCallback(() => {
-    fitView({ duration: 800 });
-  }, [fitView]);
+  /**
+   * SAVE FLOW:
+   * Direct execution (no guard needed to save)
+   */
+  const handleSave = useCallback(async () => {
+    return await fileLifecycle.saveDiagram();
+  }, [fileLifecycle]);
 
   //  PUBLIC API
-
   return {
-    // Actions
-    handleWebImport,
+    // File Actions
+    handleNew,
     handleOpen,
+    handleWebImport: fileLifecycle.importFromWeb,
     handleSave,
-    handleSaveAs,
-    handleNew: handleCloseFile,
-    handleCloseFile,
-    handleExit,
-    handleFitView,
-    handleDiscardChangesAction: handleDiscardChangesTrigger,
-
-    // Edit Actions
-    undo: () => temporalApi().undo(),
-    redo: () => temporalApi().redo(),
-
-    // State Flags
+    handleSaveAs: fileLifecycle.saveDiagramAs,
+    handleCloseFile: handleNew, // Alias
+    handleDiscardChangesAction,
+    
+    // App Actions
+    handleExit: appLifecycle.handleExit,
+    
+    // Editor Actions
+    handleFitView: editorControls.handleFitView,
+    undo: editorControls.undo,
+    redo: editorControls.redo,
+    
+    // State
     hasFilePath,
     isDirty,
 
-    // Modal State Control
-    modalState: {
-      isOpen: showUnsavedModal,
-      close: () => setShowUnsavedModal(false),
-      onDiscard: handleDiscardChanges,
-      onSave: handleSaveAndAction,
-      fileName: storeApi().diagramName,
-    },
+    // Modal (Managed by the Guard)
+    modalState
   };
 };


### PR DESCRIPTION
- refactor: split monolithic useDiagramActions into specialized hooks (useFileLifecycle, useEditorControls, useAppLifecycle).
- feat(hooks): implement 'useActionGuard' for centralized dirty-state checks and modal handling.
- refactor(actions): replace switch-case logic with polymorphic executeSafeAction pattern.
- fix: ensure web import logic is encapsulated in file lifecycle.
- chore: cleanup unused dependencies in diagram hooks.