### PR TITLE
feat(diagram): complete edge relationship system

### DIFF
--- a/frontend/src/config/theme.config.ts
+++ b/frontend/src/config/theme.config.ts
@@ -16,6 +16,8 @@ const PALETTE = {
   implementation: "var(--edge-implementation)",
   dependency: "var(--edge-dependency)",
   association: "var(--edge-association)",
+  aggregation: "var(--edge-aggregation)",
+  composition: "var(--edge-composition)",
   note: "var(--edge-note)",
   arrowHead: "var(--arrow-head)",
 };
@@ -52,20 +54,18 @@ export const edgeConfig = {
       zIndex: 5,
       highlight: PALETTE.association,
     },
-    // === NUEVAS: AGREGACIÓN Y COMPOSICIÓN ===
     aggregation: {
       style: { strokeWidth: 2, stroke: PALETTE.base },
-      marker: { color: PALETTE.association, width: 25, height: 25 },
+      marker: { color: PALETTE.aggregation, width: 25, height: 25 }, // Color propio
       zIndex: 8,
-      highlight: PALETTE.association,
+      highlight: PALETTE.aggregation, // Color al hacer hover
     },
     composition: {
       style: { strokeWidth: 2.5, stroke: PALETTE.base },
-      marker: { color: PALETTE.association, width: 25, height: 25 },
+      marker: { color: PALETTE.composition, width: 25, height: 25 }, // Color propio
       zIndex: 9,
-      highlight: PALETTE.association,
+      highlight: PALETTE.composition, // Color al hacer hover
     },
-    // === FIN NUEVAS ===
     note: {
       style: { strokeWidth: 1, strokeDasharray: "3,3", stroke: PALETTE.base },
       marker: { color: PALETTE.base, width: 15, height: 15 },

--- a/frontend/src/features/diagram/components/edges/CustomUmlEdge.tsx
+++ b/frontend/src/features/diagram/components/edges/CustomUmlEdge.tsx
@@ -28,48 +28,60 @@ export default function CustomUmlEdge({
     borderRadius: 20,
   });
 
+  // --- Data Extraction ---
   const edgeType = data?.type || 'association';
   const isHovered = data?.isHovered; 
+  
+  const sourceMultiplicity = data?.sourceMultiplicity || ""; 
+  const targetMultiplicity = data?.targetMultiplicity || "";
 
+  // --- Styling ---
   const strokeColor = style.stroke || 'var(--edge-base)';
   const canvasBase = 'var(--canvas-base)'; 
 
+  const textStyleClass = `
+    nodrag nopan 
+    text-[11px] font-mono font-medium 
+    text-slate-500 dark:text-slate-300 
+    bg-canvas-base 
+    px-1 rounded 
+    select-none 
+    transition-colors
+  `;
+
+  // --- Marker Rendering & Geometry ---
   const getMarkerRotation = () => {
     switch (targetPosition) {
       case Position.Top: return 90;
       case Position.Left: return 0;
-      case Position.Bottom: return -90;
+      case Position.Bottom: return   -90;
       case Position.Right: return 180;
       default: return 0;
     }
   };
   const rotation = getMarkerRotation();
 
-  // --- Marker Rendering ---
+  const hasBigMarker = ['inheritance', 'implementation', 'composition', 'aggregation'].includes(edgeType);
+
   const renderMarker = () => {
     switch (edgeType) {
       case 'inheritance':
-        return (
-          <g transform={`translate(${targetX}, ${targetY}) rotate(${rotation})`}>
-            <path 
-              d="M -16,-8 L -16,8 L 0,0 Z" 
-              fill={canvasBase} 
-              stroke={strokeColor} 
-              strokeWidth="2" 
-              strokeLinejoin="round" 
-            />
-          </g>
-        );
       case 'implementation':
         return (
           <g transform={`translate(${targetX}, ${targetY}) rotate(${rotation})`}>
-            <path 
-              d="M -16,-8 L -16,8 L 0,0 Z" 
-              fill={canvasBase} 
-              stroke={strokeColor} 
-              strokeWidth="2" 
-              strokeLinejoin="round" 
-            />
+            <path d="M -16,-8 L -16,8 L 0,0 Z" fill={canvasBase} stroke={strokeColor} strokeWidth="2" strokeLinejoin="round" />
+          </g>
+        );
+      case 'aggregation':
+        return (
+          <g transform={`translate(${targetX}, ${targetY}) rotate(${rotation})`}>
+            <path d="M 0,0 L -12,6 L -24,0 L -12,-6 Z" fill={canvasBase} stroke={strokeColor} strokeWidth="2" strokeLinejoin="round" />
+          </g>
+        );
+      case 'composition':
+        return (
+          <g transform={`translate(${targetX}, ${targetY}) rotate(${rotation})`}>
+            <path d="M 0,0 L -12,6 L -24,0 L -12,-6 Z" fill={strokeColor} stroke={strokeColor} strokeWidth="2" strokeLinejoin="round" />
           </g>
         );
       default: 
@@ -77,19 +89,31 @@ export default function CustomUmlEdge({
     }
   };
 
-  const hasCustomMarker = ['inheritance', 'implementation', 'composition', 'aggregation'].includes(edgeType);
-  const effectiveMarkerEnd = hasCustomMarker ? undefined : markerEnd;
+  const effectiveMarkerEnd = hasBigMarker ? undefined : markerEnd;
 
-  // --- Render ---
+  const getLabelStyle = (x: number, y: number, pos: Position, offset: number) => {
+    const style: React.CSSProperties = { position: 'absolute', pointerEvents: 'none' };
+    
+    switch (pos) {
+      case Position.Top: 
+        style.transform = `translate(5px, -100%) translate(${x}px, ${y - offset}px)`;
+        break;
+      case Position.Bottom: 
+        style.transform = `translate(5px, 0%) translate(${x}px, ${y + offset}px)`;
+        break;
+      case Position.Left: 
+        style.transform = `translate(-100%, -100%) translate(${x - offset}px, ${y - 3}px)`; 
+        break;
+      case Position.Right: 
+        style.transform = `translate(0%, -100%) translate(${x + offset}px, ${y - 3}px)`;
+        break;
+    }
+    return style;
+  };
+
   return (
     <>
-      <BaseEdge 
-        id={id} 
-        path={edgePath} 
-        style={style} 
-        markerEnd={effectiveMarkerEnd} 
-      />
-
+      <BaseEdge id={id} path={edgePath} style={style} markerEnd={effectiveMarkerEnd} />
       {renderMarker()}
 
       <EdgeLabelRenderer>
@@ -102,25 +126,36 @@ export default function CustomUmlEdge({
           className="nodrag nopan flex flex-col items-center gap-1"
         >
           {isHovered && (
-             <div className="
-                bg-surface-primary text-primary border border-primary/30 
-                text-[10px] font-bold px-2 py-0.5 rounded shadow-lg 
-                animate-in fade-in zoom-in duration-150 mb-1 select-none
-             ">
+             <div className="bg-surface-primary text-primary border border-primary/30 text-[10px] font-bold px-2 py-0.5 rounded shadow-lg animate-in fade-in zoom-in duration-150 mb-1 select-none">
                {t(`connections.${edgeType}`, { defaultValue: edgeType })}
              </div>
           )}
 
           {label && (
-            <div className={`
-              text-[11px] font-mono font-medium px-1.5 py-0.5 rounded transition-colors duration-200
-              ${isHovered ? 'text-primary font-bold' : 'text-text-secondary'}
-              bg-canvas-base/80 select-none
-            `}>
+            <div className={textStyleClass}>
               {t(String(label), { defaultValue: String(label) })}
             </div>
           )}
         </div>
+
+        {sourceMultiplicity && (
+          <div
+            style={getLabelStyle(sourceX, sourceY, sourcePosition, 10)}
+            className={`${textStyleClass} z-10`} 
+          >
+            {sourceMultiplicity}
+          </div>
+        )}
+
+        {targetMultiplicity && (
+          <div
+            style={getLabelStyle(targetX, targetY, targetPosition, hasBigMarker ? 28 : 12)} 
+            className={`${textStyleClass} z-10`} 
+          >
+            {targetMultiplicity}
+          </div>
+        )}
+
       </EdgeLabelRenderer>
     </>
   );

--- a/frontend/src/features/diagram/components/layout/Sidebar.tsx
+++ b/frontend/src/features/diagram/components/layout/Sidebar.tsx
@@ -13,6 +13,7 @@ import {
   PanelLeft,
   ChevronDown,
   ChevronRight,
+  Diamond,
 } from "lucide-react";
 import { useDiagramStore } from "../../../../store/diagramStore";
 import type { stereotype, UmlRelationType } from "../../types/diagram.types";
@@ -146,7 +147,7 @@ export default function Sidebar() {
               icon={
                 <MoveRight className={isExpanded ? "w-5 h-5" : "w-6 h-6"} />
               }
-              label={t('sidebar.connections.association')}
+              label={t("sidebar.connections.association")}
               color={edgeConfig.types.association.highlight}
               isExpanded={isExpanded}
             />
@@ -156,7 +157,7 @@ export default function Sidebar() {
               activeMode={activeConnectionMode}
               onClick={() => setConnectionMode("inheritance")}
               icon={<ArrowUp className={isExpanded ? "w-5 h-5" : "w-6 h-6"} />}
-              label={t('sidebar.connections.inheritance')}
+              label={t("sidebar.connections.inheritance")}
               color={edgeConfig.types.inheritance.highlight}
               isExpanded={isExpanded}
             />
@@ -168,7 +169,7 @@ export default function Sidebar() {
               icon={
                 <ArrowUpRight className={isExpanded ? "w-5 h-5" : "w-6 h-6"} />
               }
-              label={t('sidebar.connections.implementation')}
+              label={t("sidebar.connections.implementation")}
               color={edgeConfig.types.implementation.highlight}
               isExpanded={isExpanded}
             />
@@ -182,8 +183,32 @@ export default function Sidebar() {
                   className={isExpanded ? "w-5 h-5" : "w-6 h-6"}
                 />
               }
-              label={t('sidebar.connections.dependency')}
+              label={t("sidebar.connections.dependency")}
               color={edgeConfig.types.dependency.highlight}
+              isExpanded={isExpanded}
+            />
+
+            <ConnectionItem
+              mode="aggregation"
+              activeMode={activeConnectionMode}
+              onClick={() => setConnectionMode("aggregation")}
+              icon={<Diamond className={isExpanded ? "w-5 h-5" : "w-6 h-6"} />}
+              label={t("sidebar.connections.aggregation")}
+              color={edgeConfig.types.aggregation.highlight}
+              isExpanded={isExpanded}
+            />
+
+            <ConnectionItem
+              mode="composition"
+              activeMode={activeConnectionMode}
+              onClick={() => setConnectionMode("composition")}
+              icon={
+                <Diamond
+                  className={`${isExpanded ? "w-5 h-5" : "w-6 h-6"} fill-current`}
+                />
+              }
+              label={t("sidebar.connections.composition")}
+              color={edgeConfig.types.composition.highlight}
               isExpanded={isExpanded}
             />
           </div>

--- a/frontend/src/features/diagram/components/modals/MultiplicityModal.tsx
+++ b/frontend/src/features/diagram/components/modals/MultiplicityModal.tsx
@@ -1,0 +1,155 @@
+import { useState, useEffect } from "react";
+import { X, Check, ArrowRight, ArrowLeft } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+interface MultiplicityModalProps {
+  isOpen: boolean;
+  initialSource: string;
+  initialTarget: string;
+  onClose: () => void;
+  onSave: (source: string, target: string) => void;
+}
+
+const PREDEFINED_OPTIONS = ["0..1", "1", "0..*", "1..*", "*"];
+
+export default function MultiplicityModal({
+  isOpen,
+  initialSource,
+  initialTarget,
+  onClose,
+  onSave,
+}: MultiplicityModalProps) {
+  const { t } = useTranslation();
+  const [source, setSource] = useState(initialSource);
+  const [target, setTarget] = useState(initialTarget);
+
+  useEffect(() => {
+    if (isOpen) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setSource(initialSource);
+      setTarget(initialTarget);
+    }
+  }, [isOpen, initialSource, initialTarget]);
+
+  if (!isOpen) return null;
+
+  const handleSave = () => {
+    onSave(source, target);
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm animate-in fade-in duration-200">
+      <div className="bg-surface-primary border border-surface-border rounded-lg shadow-2xl w-full max-w-md overflow-hidden flex flex-col animate-in zoom-in-95 duration-200">
+        
+        {/* HEADER */}
+        <div className="px-4 py-3 border-b border-surface-border flex justify-between items-center bg-surface-secondary/50">
+          <h2 className="text-sm font-bold text-text-primary uppercase tracking-wide">
+            {t("modals.multiplicity.title")} 
+          </h2>
+          <button onClick={onClose} className="text-text-secondary hover:text-text-primary transition-colors">
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        {/* BODY */}
+        <div className="p-6 grid grid-cols-2 gap-6">
+          
+          {/* SOURCE COLUMN */}
+          <div className="flex flex-col gap-3">
+            <div className="flex items-center gap-2 text-xs font-bold text-indigo-500 mb-1">
+              <ArrowLeft className="w-3 h-3" />
+              {t("modals.multiplicity.source")}
+            </div>
+            
+            <input
+              type="text"
+              value={source}
+              readOnly
+              placeholder="Select..."
+              className="w-full bg-surface-secondary border border-surface-border rounded px-3 py-2 text-sm text-text-primary focus:outline-none cursor-default font-mono text-center"
+            />
+
+            <div className="flex flex-wrap gap-1.5 justify-center">
+              {PREDEFINED_OPTIONS.map((opt) => (
+                <button
+                  key={`src-${opt}`}
+                  onClick={() => setSource(opt)}
+                  className={`text-[10px] px-2 py-1 rounded border transition-all
+                    ${source === opt 
+                      ? "bg-indigo-100 dark:bg-indigo-900/30 border-indigo-500 text-indigo-600 dark:text-indigo-300 font-bold scale-105" 
+                      : "bg-surface-primary border-surface-border text-text-secondary hover:border-text-primary hover:bg-surface-hover"
+                    }`}
+                >
+                  {opt}
+                </button>
+              ))}
+               <button
+                 onClick={() => setSource("")}
+                 className="text-[10px] px-2 py-1 rounded border border-red-200 text-red-400 hover:bg-red-50 hover:text-red-500 transition-colors"
+              >
+                {t("modals.common.clear")}
+              </button>
+            </div>
+          </div>
+
+          {/* TARGET COLUMN */}
+          <div className="flex flex-col gap-3 border-l border-surface-border/50 pl-6">
+            <div className="flex items-center gap-2 text-xs font-bold text-indigo-500 mb-1">
+              {t("modals.multiplicity.target")}
+              <ArrowRight className="w-3 h-3" />
+            </div>
+
+            <input
+              type="text"
+              value={target}
+              readOnly
+              placeholder="Select..."
+              className="w-full bg-surface-secondary border border-surface-border rounded px-3 py-2 text-sm text-text-primary focus:outline-none cursor-default font-mono text-center"
+            />
+
+            <div className="flex flex-wrap gap-1.5 justify-center">
+              {PREDEFINED_OPTIONS.map((opt) => (
+                <button
+                  key={`tgt-${opt}`}
+                  onClick={() => setTarget(opt)}
+                  className={`text-[10px] px-2 py-1 rounded border transition-all
+                    ${target === opt 
+                      ? "bg-indigo-100 dark:bg-indigo-900/30 border-indigo-500 text-indigo-600 dark:text-indigo-300 font-bold scale-105" 
+                      : "bg-surface-primary border-surface-border text-text-secondary hover:border-text-primary hover:bg-surface-hover"
+                    }`}
+                >
+                  {opt}
+                </button>
+              ))}
+               <button
+                 onClick={() => setTarget("")}
+                 className="text-[10px] px-2 py-1 rounded border border-red-200 text-red-400 hover:bg-red-50 hover:text-red-500 transition-colors"
+              >
+                {t("modals.common.clear")}
+              </button>
+            </div>
+          </div>
+
+        </div>
+
+        {/* FOOTER */}
+        <div className="px-4 py-3 bg-surface-secondary/30 border-t border-surface-border flex justify-end gap-2">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 text-xs font-medium text-text-secondary hover:text-text-primary transition-colors"
+          >
+            {t("modals.common.cancel")}
+          </button>
+          <button
+            onClick={handleSave}
+            className="flex items-center gap-2 px-4 py-2 bg-uml-class-border text-white text-xs font-bold rounded shadow-sm hover:brightness-110 transition-all active:scale-95"
+          >
+            <Check className="w-3 h-3" />
+            {t("modals.common.save")}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -57,7 +57,9 @@
       "association": "Association",
       "inheritance": "Inheritance",
       "implementation": "Implementation",
-      "dependency": "Dependency"
+      "dependency": "Dependency",
+      "aggregation": "Aggregation",
+      "composition": "Composition"
     },
     "legend": {
       "title": "Connection Logic",
@@ -83,13 +85,21 @@
     "edge": {
       "reverse": "Reverse Direction ⇄",
       "toAssociation": "To: Association →",
+      "defineMultiplicity": "Define Multiplicity",
       "toInheritance": "To: Inheritance ▷",
       "toImplementation": "To: Implementation ⇢",
       "toDependency": "To: Dependency ⇢",
+      "toAggregation": "Convert to Aggregation",
+      "toComposition": "Convert to Composition",
       "delete": "Delete Connection"
     }
   },
   "modals": {
+    "common": {
+      "save": "Save",
+      "cancel": "Cancel",
+      "clear": "Clear"
+    },
     "classEditor": {
       "title": "Edit Class:",
       "className": "CLASS NAME",
@@ -98,12 +108,15 @@
       "add": "Add",
       "noAttributes": "No attributes defined.",
       "noMethods": "No methods defined.",
-      "cancel": "Cancel",
-      "save": "Save Changes",
       "placeholders": {
         "name": "name",
         "methodName": "methodName"
       }
+    },
+    "multiplicity": {
+      "title": "Configure Cardinality",
+      "source": "Start (Source)",
+      "target": "End (Target)"
     },
     "confirmation": {
       "clearTitle": "Clear Entire Canvas?",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -57,7 +57,9 @@
       "association": "Asociación",
       "inheritance": "Herencia",
       "implementation": "Implementación",
-      "dependency": "Dependencia"
+      "dependency": "Dependencia",
+      "aggregation": "Agregación",
+      "composition": "Composición"
     },
     "legend": {
       "title": "Lógica de Conexión",
@@ -84,12 +86,20 @@
       "reverse": "Invertir Dirección ⇄",
       "toAssociation": "A: Asociación →",
       "toInheritance": "A: Herencia ▷",
+      "defineMultiplicity": "Definir Multiplicidad",
       "toImplementation": "A: Implementación ⇢",
       "toDependency": "A: Dependencia ⇢",
+      "toAggregation": "Convertir a Agregación",
+      "toComposition": "Convertir a Composición",
       "delete": "Eliminar Conexión"
     }
   },
   "modals": {
+    "common": {
+      "save": "Guardar",
+      "cancel": "Cancelar",
+      "clear": "Limpiar"
+    },
     "classEditor": {
       "title": "Editar Clase:",
       "className": "NOMBRE DE CLASE",
@@ -98,12 +108,15 @@
       "add": "Agregar",
       "noAttributes": "No hay atributos definidos.",
       "noMethods": "No hay métodos definidos.",
-      "cancel": "Cancelar",
-      "save": "Guardar Cambios",
       "placeholders": {
         "name": "nombre",
         "methodName": "nombreMetodo"
       }
+    },
+    "multiplicity": {
+      "title": "Configurar Cardinalidad",
+      "source": "Inicio (Origen)",
+      "target": "Fin (Destino)"
     },
     "confirmation": {
       "clearTitle": "¿Limpiar todo el Lienzo?",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -39,6 +39,10 @@
   --edge-association: #8b5cf6;
   --edge-note: #eab308;
   --arrow-head: #0f172a;
+
+  --edge-aggregation: #059669; /* Emerald 600 */
+  --edge-composition: #d97706; /* Amber 600 */
+
 }
 
 .dark {
@@ -80,6 +84,10 @@
   --edge-association: #a78bfa;
   --edge-note: #fef08a;
   --arrow-head: #ffffff;
+
+  --edge-aggregation: #34d399; /* Emerald 400 */
+  --edge-composition: #fbbf24; /* Amber 400 */
+
 }
 
 @theme {


### PR DESCRIPTION
- Add MultiplicityModal for defining cardinality (0..1, 1, *, etc.)
- Update Context Menu to trigger multiplicity edition for compatible edges.
- Refactor CustomUmlEdge to render source/target labels visually.
- Fix i18n structure: organize modals and context menu keys.
- Update diagramStore with type-safe edge data updates.
- Final polish on edge factory and styling.