### PR TITLE
feat(persistence): implement strict schema validation and multiplicity persistence

### DIFF
--- a/frontend/src/features/diagram/types/diagram.types.ts
+++ b/frontend/src/features/diagram/types/diagram.types.ts
@@ -28,25 +28,31 @@ export interface UmlClassData {
   stereotype: stereotype; 
 }
 
-
-// UML Class Node Type for React Flow
 export interface UmlClassNode {
   id: string;
-  type: 'umlClass';
+  type: 'umlClass' | 'umlNote'; 
   position: { 
     x: number; 
     y: number; 
   };
   data: UmlClassData; 
   selected?: boolean;     
+  width?: number;   
+  height?: number; 
 }
-
 
 export interface UmlMarker {
   type: string;
   width?: number;
   height?: number;
   color?: string;
+}
+
+export interface UmlEdgeData {
+  type: UmlRelationType | 'note' | string;
+  sourceMultiplicity?: string; 
+  targetMultiplicity?: string; 
+  isHovered?: boolean;         
 }
 
 export interface UmlEdge {
@@ -58,11 +64,11 @@ export interface UmlEdge {
   animated?: boolean;
   
   style?: CSSProperties;       
-  markerEnd?: UmlMarker | string;   
+  markerEnd?: UmlMarker | string;
+  sourceHandle?: string | null; 
+  targetHandle?: string | null;
 
-  data?: {
-    type: UmlRelationType | 'note' | string;
-  };
+  data?: UmlEdgeData; 
 }
 
 export interface DiagramState {
@@ -70,6 +76,7 @@ export interface DiagramState {
   name: string;
   nodes: UmlClassNode[];
   edges: UmlEdge[]; 
+  activeConnectionMode?: UmlRelationType; 
   viewport: { 
     x: number; 
     y: number; 


### PR DESCRIPTION
- Update diagram.types.ts to strictly type UmlEdgeData and include activeConnectionMode in DiagramState.
- Refactor diagramStore.ts to correctly hydrate connection modes and preserve edge multiplicity during load/updates.
- Harden useFileLifecycle.ts with strict serialization logic, removing unsafe 'any' casts for edges.
- Fix node sanitization bug during save by handling null values for width and height properties.