### PR TITLE
fix(lifecycle): resolve app exit loop and handle os window close events

### DIFF
--- a/frontend/src/features/diagram/hooks/actions/useAppLifecycle.ts
+++ b/frontend/src/features/diagram/hooks/actions/useAppLifecycle.ts
@@ -1,21 +1,17 @@
-import { useEffect, useCallback } from "react";
+import { useCallback } from "react";
 
 export const useAppLifecycle = () => {
-  // --- LISTENERS ---
-  useEffect(() => {
-    if (!window.electronAPI?.isElectron()) return;
-  }, []);
-
   // --- ACTIONS ---
-  const handleExit = useCallback(() => {
+  const quitApplication = useCallback(() => {
     if (window.electronAPI?.isElectron()) {
-      window.electronAPI?.close();
+      window.electronAPI?.sendForceClose(); 
     } else {
       console.warn("Exit requested (Web Mode)");
+      window.close(); 
     }
   }, []);
 
   return {
-    handleExit,
+    quitApplication, 
   };
 };


### PR DESCRIPTION
- Implement 'quitApplication' in useAppLifecycle to trigger force-close via IPC.
- Add 'onAppRequestClose' listener in useDiagramActions to intercept OS window close (X button).
- Connect OS close event to 'executeSafeAction' to ensure unsaved changes guard is respected.
- Fix zombie process issue on Linux/Windows/macOS when closing the main window.