### PR TITLE
feat(ui): implement View menu with grid controls and connection highlighting

### DIFF
--- a/frontend/src/features/diagram/components/layout/DiagramCanvas.tsx
+++ b/frontend/src/features/diagram/components/layout/DiagramCanvas.tsx
@@ -52,6 +52,8 @@ export default function DiagramCanvas() {
     updateNodeData,
     updateEdgeData, 
     showMiniMap,
+    showGrid,
+    snapToGrid,
   } = useDiagramStore();
 
   // Local State (Modals)
@@ -110,6 +112,8 @@ export default function DiagramCanvas() {
         onConnect={onConnect}
         nodeTypes={nodeTypes}
         edgeTypes={edgeTypes}
+        snapToGrid={snapToGrid}
+        snapGrid={[20, 20]}
         // Hover Interaction
         onNodeMouseEnter={(_, node) => setHoveredNodeId(node.id)}
         onNodeMouseLeave={() => setHoveredNodeId(null)}
@@ -128,6 +132,17 @@ export default function DiagramCanvas() {
         connectionMode={ConnectionMode.Loose}
         fitView
       >
+
+        {showGrid && (         
+          <Background
+            variant={BackgroundVariant.Dots}
+            gap={24}
+            size={1.5}
+            color={canvasConfig.gridColor}
+            style={{ opacity: canvasConfig.gridOpacity }}
+          />
+        )}
+
         <Background
           variant={BackgroundVariant.Dots}
           gap={24}

--- a/frontend/src/features/diagram/components/menubar/AppMenubar.tsx
+++ b/frontend/src/features/diagram/components/menubar/AppMenubar.tsx
@@ -9,6 +9,7 @@ import ConfirmationModal from "../../../../components/shared/ConfirmationModal";
 
 // Modules
 import { FileMenu } from "./modules/FileMenu";
+import { ViewMenu } from "./modules/ViewMenu"; 
 import { SettingsMenu } from "./modules/SettingsMenu"; 
 
 export default function AppMenubar() {
@@ -17,7 +18,6 @@ export default function AppMenubar() {
   
   const actions = useDiagramActions(); 
   
-
   const { modalState } = actions; 
 
   if (!modalState) return null;
@@ -26,7 +26,6 @@ export default function AppMenubar() {
     <>
       <header className="h-10 w-full bg-surface-primary border-b border-surface-border flex items-center justify-between select-none drag-region pl-3 pr-0 z-50 shrink-0">
         
-        {/* IZQUIERDA: Logo + Menus */}
         <div className="flex items-center gap-1 h-full">
           <div className="flex items-center gap-2 font-bold text-sm no-drag mr-4">
              <Box className="w-4 h-4 text-uml-class-border fill-uml-class-bg/20" />
@@ -35,6 +34,7 @@ export default function AppMenubar() {
 
           <div className="flex items-center h-full no-drag">
               <FileMenu actions={actions} />
+              <ViewMenu />  {/* <--- NUEVO ITEM */}
               <SettingsMenu />
           </div>
         </div>

--- a/frontend/src/features/diagram/components/menubar/modules/ViewMenu.tsx
+++ b/frontend/src/features/diagram/components/menubar/modules/ViewMenu.tsx
@@ -1,0 +1,120 @@
+import { 
+  ZoomIn, 
+  ZoomOut, 
+  Maximize, 
+  Map, 
+  Search,
+  Check,
+  Grid3X3,
+  Magnet,
+  Network
+} from "lucide-react";
+import { useReactFlow } from "reactflow";
+import { useTranslation } from "react-i18next";
+import { MenubarTrigger } from "../../../../../components/ui/menubar/MenubarTrigger";
+import { MenubarItem } from "../../../../../components/ui/menubar/MenubarItem";
+import { useDiagramStore } from "../../../../../store/diagramStore";
+import { useSpotlightStore } from "../../../hooks/useSpotlight";
+
+export function ViewMenu() {
+  const { t } = useTranslation();
+  
+  // React Flow Controls
+  const { zoomIn, zoomOut, fitView } = useReactFlow();
+
+  // Custom Stores
+  const showMiniMap = useDiagramStore((s) => s.showMiniMap);
+  const toggleMiniMap = useDiagramStore((s) => s.toggleMiniMap);
+  const showAllEdges = useDiagramStore((s) => s.showAllEdges);
+  const toggleShowAllEdges = useDiagramStore((s) => s.toggleShowAllEdges);
+  
+  // Grid & Snap 
+  const showGrid = useDiagramStore((s) => s.showGrid);
+  const toggleGrid = useDiagramStore((s) => s.toggleGrid);
+  const snapToGrid = useDiagramStore((s) => s.snapToGrid);
+  const toggleSnapToGrid = useDiagramStore((s) => s.toggleSnapToGrid);
+
+  const toggleSpotlight = useSpotlightStore((s) => s.toggle);
+
+  return (
+    <MenubarTrigger label={t("menubar.view.title") || "View"}>
+      
+      {/* --- ZOOM CONTROLS --- */}
+      <MenubarItem
+        label={t("menubar.view.zoomIn") || "Zoom In"}
+        icon={<ZoomIn className="w-4 h-4" />}
+        shortcut="Ctrl + +"
+        onClick={() => zoomIn({ duration: 300 })}
+      />
+      <MenubarItem
+        label={t("menubar.view.zoomOut") || "Zoom Out"}
+        icon={<ZoomOut className="w-4 h-4" />}
+        shortcut="Ctrl + -"
+        onClick={() => zoomOut({ duration: 300 })}
+      />
+      <MenubarItem
+        label={t("menubar.view.fitView") || "Fit View"}
+        icon={<Maximize className="w-4 h-4" />}
+        shortcut="Space"
+        onClick={() => fitView({ duration: 800 })}
+      />
+
+      <div className="h-px bg-surface-border my-1" />
+
+      {/* --- VISUAL AIDS --- */}
+      <MenubarItem
+        label={t("menubar.view.minimap") || "Show Minimap"}
+        icon={
+          <div className="relative">
+            <Map className="w-4 h-4" />
+            {showMiniMap && <Check className="w-3 h-3 absolute -bottom-1 -right-1 text-green-500 font-bold" />}
+          </div>
+        }
+        onClick={toggleMiniMap}
+      />
+
+      <MenubarItem
+        label={t("menubar.view.grid") || "Show Grid"}
+        icon={
+          <div className="relative">
+            <Grid3X3 className="w-4 h-4" />
+            {showGrid && <Check className="w-3 h-3 absolute -bottom-1 -right-1 text-green-500 font-bold" />}
+          </div>
+        }
+        onClick={toggleGrid}
+      />
+
+       <MenubarItem
+        label={t("menubar.view.snap") || "Snap to Grid"}
+        icon={
+          <div className="relative">
+            <Magnet className="w-4 h-4" />
+            {snapToGrid && <Check className="w-3 h-3 absolute -bottom-1 -right-1 text-green-500 font-bold" />}
+          </div>
+        }
+        onClick={toggleSnapToGrid}
+      />
+      <MenubarItem
+        label={t("menubar.view.connections") || "Highlight Connections"}
+        icon={
+          <div className="relative">
+            <Network className="w-4 h-4" />
+            {showAllEdges && <Check className="w-3 h-3 absolute -bottom-1 -right-1 text-green-500 font-bold" />}
+          </div>
+        }
+        onClick={toggleShowAllEdges}
+      />
+
+      <div className="h-px bg-surface-border my-1" />
+
+      {/* --- TOOLS --- */}
+      <MenubarItem
+        label={t("menubar.view.spotlight") || "Spotlight Search"}
+        icon={<Search className="w-4 h-4" />}
+        shortcut="Ctrl + K"
+        onClick={toggleSpotlight}
+      />
+
+    </MenubarTrigger>
+  );
+}

--- a/frontend/src/features/diagram/hooks/useEdgeStyling.ts
+++ b/frontend/src/features/diagram/hooks/useEdgeStyling.ts
@@ -4,19 +4,24 @@ import { useDiagramStore } from "../../../store/diagramStore";
 
 export const useEdgeStyling = () => {
   const edges = useDiagramStore((s) => s.edges);
+  const showAllEdges = useDiagramStore((s) => s.showAllEdges); 
+  
   const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null);
   const [hoveredEdgeId, setHoveredEdgeId] = useState<string | null>(null);
 
   const displayEdges = useMemo(() => {
-    if (!hoveredNodeId && !hoveredEdgeId) return edges;
+    if (!hoveredNodeId && !hoveredEdgeId && !showAllEdges) return edges;
 
     return edges.map((edge) => {
       const isConnectedToNode =
         hoveredNodeId &&
         (edge.source === hoveredNodeId || edge.target === hoveredNodeId);
+      
       const isHoveredEdge = hoveredEdgeId && edge.id === hoveredEdgeId;
 
-      if (isConnectedToNode || isHoveredEdge) {
+      const shouldHighlight = showAllEdges || isConnectedToNode || isHoveredEdge;
+
+      if (shouldHighlight) {
         const type = edge.data?.type || "default";
         const configTypes = edgeConfig.types as Record<string, { highlight?: string }>;
         
@@ -28,7 +33,7 @@ export const useEdgeStyling = () => {
           
           data: {
             ...edge.data,
-            isHovered: isHoveredEdge, 
+            isHovered: true, 
           },
 
           style: {
@@ -36,6 +41,7 @@ export const useEdgeStyling = () => {
             stroke: highlightColor,
             strokeWidth: 3, 
             zIndex: 999,    
+            opacity: 1, 
           },
         };
       }
@@ -45,7 +51,7 @@ export const useEdgeStyling = () => {
         style: { ...edge.style, opacity: 0.2 },
       };
     });
-  }, [edges, hoveredNodeId, hoveredEdgeId]);
+  }, [edges, hoveredNodeId, hoveredEdgeId, showAllEdges]); 
 
   return {
     displayEdges,

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -41,6 +41,17 @@
       "startup": "Startup: Restore Session",
       "language": "Language",
       "theme": "Theme"
+    },
+    "view": {
+      "title": "View",
+      "zoomIn": "Zoom In",
+      "zoomOut": "Zoom Out",
+      "fitView": "Fit View",
+      "minimap": "Show Minimap",
+      "grid": "Show Grid",
+      "snap": "Snap to Grid",
+      "spotlight": "Spotlight Search",
+      "connections": "Highlight Connections"
     }
   },
   "sidebar": {

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -41,6 +41,17 @@
       "startup": "Inicio: Restaurar Sesión",
       "language": "Idioma",
       "theme": "Tema"
+    },
+    "view": {
+      "title": "Ver",
+      "zoomIn": "Acercar",
+      "zoomOut": "Alejar",
+      "fitView": "Ajustar Vista",
+      "minimap": "Mostrar Minimapa",
+      "grid": "Mostrar Rejilla",
+      "snap": "Ajustar a la Rejilla",
+      "spotlight": "Búsqueda Rápida",
+      "connections": "Resaltar Conexiones"
     }
   },
   "sidebar": {


### PR DESCRIPTION
- Create 'ViewMenu' module to centralize visual toggle actions (Zoom, Minimap, Grid, Snap, Spotlight).
- Update 'diagramStore' to persist visual states: 'showGrid', 'snapToGrid', and 'showAllEdges'.
- Integrate grid rendering and snapping logic into 'DiagramCanvas' via React Flow props.
- Implement "Highlight Connections" mode in 'useEdgeStyling' to visualize all relationships simultaneously without hovering.
- Add i18n translations for new View menu items in English and Spanish.
- Integrate 'ViewMenu' into 'AppMenubar' layout between File and Settings.