### PR TITLE
feat(ui): implement neon selection effects and optimize node editing state

### DIFF
--- a/frontend/src/features/diagram/components/menubar/AppMenubar.tsx
+++ b/frontend/src/features/diagram/components/menubar/AppMenubar.tsx
@@ -11,6 +11,7 @@ import ConfirmationModal from "../../../../components/shared/ConfirmationModal";
 import { FileMenu } from "./modules/FileMenu";
 import { ViewMenu } from "./modules/ViewMenu"; 
 import { SettingsMenu } from "./modules/SettingsMenu"; 
+import { EditMenu } from "./modules/EditMenu";
 
 export default function AppMenubar() {
   const diagramName = useDiagramStore((s) => s.diagramName);
@@ -34,8 +35,9 @@ export default function AppMenubar() {
 
           <div className="flex items-center h-full no-drag">
               <FileMenu actions={actions} />
-              <ViewMenu />  {/* <--- NUEVO ITEM */}
+              <ViewMenu />  
               <SettingsMenu />
+              <EditMenu />
           </div>
         </div>
 

--- a/frontend/src/features/diagram/components/menubar/modules/EditMenu.tsx
+++ b/frontend/src/features/diagram/components/menubar/modules/EditMenu.tsx
@@ -1,0 +1,81 @@
+import { 
+  Undo2, 
+  Redo2, 
+  Copy, 
+  Trash2, 
+  CheckSquare, 
+  Pencil
+} from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { MenubarTrigger } from "../../../../../components/ui/menubar/MenubarTrigger";
+import { MenubarItem } from "../../../../../components/ui/menubar/MenubarItem";
+import { useEditActions } from "../../../hooks/actions/seEditActions";
+
+export function EditMenu() {
+  const { t } = useTranslation();
+  
+  // Connect to the Logic Hook
+  const { 
+    handleUndo, 
+    handleRedo, 
+    handleDuplicate, 
+    handleDelete, 
+    handleSelectAll,
+    handleEditSelected
+  } = useEditActions();
+
+  return (
+    <MenubarTrigger label={t("menubar.edit.title") || "Edit"}>
+      
+      {/* --- HISTORY --- */}
+      <MenubarItem
+        label={t("menubar.edit.undo") || "Undo"}
+        icon={<Undo2 className="w-4 h-4" />}
+        shortcut="Ctrl+Z"
+        onClick={handleUndo}
+      />
+      <MenubarItem
+        label={t("menubar.edit.redo") || "Redo"}
+        icon={<Redo2 className="w-4 h-4" />}
+        shortcut="Ctrl+Y"
+        onClick={handleRedo}
+      />
+
+      <div className="h-px bg-surface-border my-1" />
+
+      {/* --- MANIPULATION --- */}
+      <MenubarItem
+        label={t("menubar.edit.duplicate") || "Duplicate"}
+        icon={<Copy className="w-4 h-4" />}
+        shortcut="Ctrl+D"
+        onClick={handleDuplicate}
+      />
+
+      <MenubarItem
+        label={t("menubar.edit.edit") || "Edit Properties"}
+        icon={<Pencil className="w-4 h-4" />}
+        shortcut="Enter"
+        onClick={handleEditSelected}
+      />
+
+      <MenubarItem
+        label={t("menubar.edit.delete") || "Delete"}
+        icon={<Trash2 className="w-4 h-4" />}
+        shortcut="Supr"
+        danger
+        onClick={handleDelete}
+      />
+
+      <div className="h-px bg-surface-border my-1" />
+
+      {/* --- SELECTION --- */}
+      <MenubarItem
+        label={t("menubar.edit.selectAll") || "Select All"}
+        icon={<CheckSquare className="w-4 h-4" />}
+        shortcut="Ctrl+A"
+        onClick={handleSelectAll}
+      />
+
+    </MenubarTrigger>
+  );
+}

--- a/frontend/src/features/diagram/components/nodes/uml/UmlClassNode.tsx
+++ b/frontend/src/features/diagram/components/nodes/uml/UmlClassNode.tsx
@@ -1,19 +1,12 @@
-import { memo, useState, useEffect } from "react";
+import { memo, useState } from "react";
 import { Handle, Position, type NodeProps } from "reactflow";
 import type { UmlClassData } from "../../../types/diagram.types";
 import { useDiagramStore } from "../../../../../store/diagramStore";
 import { handleConfig } from "../../../../../config/theme.config";
 
-const UmlClassNode = ({ id, data }: NodeProps<UmlClassData>) => {
+const UmlClassNode = ({ id, data, selected }: NodeProps<UmlClassData>) => {
   const updateNodeData = useDiagramStore((s) => s.updateNodeData);
-  const [isEditing, setIsEditing] = useState(false);
-
-  useEffect(() => {
-    if (data.label === "NewClass") {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setIsEditing(true);
-    }
-  }, [data.label]);
+  const [isEditing, setIsEditing] = useState(() => data.label === "NewClass");
 
   const handleLabelChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     updateNodeData(id, { label: e.target.value });
@@ -36,11 +29,13 @@ const UmlClassNode = ({ id, data }: NodeProps<UmlClassData>) => {
     badgeColor = "text-uml-abstract-border";
   }
 
-
+  const selectionClasses = selected
+    ? "ring-2 ring-cyan-400 shadow-[0_0_15px_rgba(34,211,238,0.4)] !border-cyan-500 z-10"
+    : "hover:shadow-md";
 
   return (
     <div
-      className={`border-2 rounded-sm w-64 shadow-lg overflow-visible group transition-colors duration-200 ${containerClass}`}
+      className={`border-2 rounded-sm w-64 overflow-visible group transition-all duration-200 ${containerClass} ${selectionClasses}`}
     >
       {/* Target Handles Green */}
       <Handle
@@ -72,7 +67,7 @@ const UmlClassNode = ({ id, data }: NodeProps<UmlClassData>) => {
 
       {/* HEADER */}
       <div
-        className={`p-2 border-b-2 text-center cursor-pointer hover:brightness-110 transition-all ${headerClass}`}
+        className={`p-2 border-b-2 text-center cursor-pointer hover:brightness-110 transition-all ${headerClass} ${selected ? "border-cyan-500/30!" : ""}`}
         onDoubleClick={() => setIsEditing(true)}
       >
         {isInterface && (
@@ -111,7 +106,11 @@ const UmlClassNode = ({ id, data }: NodeProps<UmlClassData>) => {
 
       {/* BODY: Attributes */}
       <div
-        className={`p-2 border-b-2 min-h-6 text-xs text-left font-mono text-text-secondary ${isInterface ? "border-uml-interface-border" : isAbstract ? "border-uml-abstract-border" : "border-uml-class-border"}`}
+        className={`p-2 border-b-2 min-h-6 text-xs text-left font-mono text-text-secondary ${
+            selected 
+              ? "border-cyan-500/30!" 
+              : isInterface ? "border-uml-interface-border" : isAbstract ? "border-uml-abstract-border" : "border-uml-class-border"
+        }`}
       >
         {data.attributes && data.attributes.length > 0 ? (
           data.attributes.map((attr) => (

--- a/frontend/src/features/diagram/components/nodes/uml/UmlNoteNode.tsx
+++ b/frontend/src/features/diagram/components/nodes/uml/UmlNoteNode.tsx
@@ -5,15 +5,20 @@ import type { UmlClassData } from "../../../types/diagram.types";
 import { useDiagramStore } from "../../../../../store/diagramStore";
 import { handleConfig } from "../../../../../config/theme.config";
 
-const UmlNoteNode = ({ id, data }: NodeProps<UmlClassData>) => {
+const UmlNoteNode = ({ id, data, selected }: NodeProps<UmlClassData>) => {
   const updateNodeData = useDiagramStore((s) => s.updateNodeData);
 
   const [editingTitle, setEditingTitle] = useState(false);
   const [editingContent, setEditingContent] = useState(false);
 
   const handleStyle = `${handleConfig.size} ${handleConfig.base} ${handleConfig.colors.note} opacity-0 group-hover:opacity-100`;
+
+  const selectionClasses = selected
+    ? "ring-2 ring-cyan-400 shadow-[0_0_15px_rgba(34,211,238,0.4)] !border-cyan-500 z-10"
+    : "border-uml-note-border hover:shadow-md";
+
   return (
-    <div className="bg-uml-note-bg border border-uml-note-border rounded-sm w-56 shadow-md overflow-visible relative group flex flex-col font-sans transition-colors">
+    <div className={`bg-uml-note-bg border rounded-sm w-56 overflow-visible relative group flex flex-col font-sans transition-all duration-200 ${selectionClasses}`}>
       {/* Top */}
       <Handle
         type="source"

--- a/frontend/src/features/diagram/hooks/actions/seEditActions.ts
+++ b/frontend/src/features/diagram/hooks/actions/seEditActions.ts
@@ -1,0 +1,67 @@
+import { useCallback } from "react";
+import { useDiagramStore } from "../../../../store/diagramStore";
+import { useUiStore } from "../../../../store/uiStore";
+
+export const useEditActions = () => {
+  // --- STORES ---
+  const storeApi = useDiagramStore.getState;
+  const temporalApi = useDiagramStore.temporal.getState;
+  const { openClassEditor } = useUiStore();
+
+  // --- ACTIONS ---
+  const handleUndo = useCallback(() => {
+    temporalApi().undo();
+  }, [temporalApi]);
+
+
+  const handleRedo = useCallback(() => {
+    temporalApi().redo();
+  }, [temporalApi]);
+
+  const handleDuplicate = useCallback(() => {
+    const { nodes, duplicateNode } = storeApi();
+    const selectedNodes = nodes.filter((n) => n.selected);
+    
+    selectedNodes.forEach((node) => {
+      duplicateNode(node.id);
+    });
+  }, [storeApi]);
+
+  const handleDelete = useCallback(() => {
+    const { nodes, edges, deleteNode, deleteEdge } = storeApi();
+    
+    nodes.filter((n) => n.selected).forEach((n) => deleteNode(n.id));
+
+    edges.filter((e) => e.selected).forEach((e) => deleteEdge(e.id));
+  }, [storeApi]);
+
+  const handleSelectAll = useCallback(() => {
+    const { nodes, onNodesChange } = storeApi();
+    
+    const changes = nodes.map((node) => ({
+      id: node.id,
+      type: "select" as const,
+      selected: true,
+    }));
+
+    onNodesChange(changes);
+  }, [storeApi]);
+
+  const handleEditSelected = useCallback(() => {
+    const { nodes } = storeApi();
+    const selectedNodes = nodes.filter((n) => n.selected);
+
+    if (selectedNodes.length === 1) {
+      openClassEditor(selectedNodes[0].id);
+    }
+  }, [storeApi, openClassEditor]);
+
+  return {
+    handleUndo,
+    handleRedo,
+    handleDuplicate,
+    handleDelete,
+    handleSelectAll,
+    handleEditSelected
+  };
+};

--- a/frontend/src/features/diagram/hooks/useEdgeStyling.ts
+++ b/frontend/src/features/diagram/hooks/useEdgeStyling.ts
@@ -4,54 +4,63 @@ import { useDiagramStore } from "../../../store/diagramStore";
 
 export const useEdgeStyling = () => {
   const edges = useDiagramStore((s) => s.edges);
-  const showAllEdges = useDiagramStore((s) => s.showAllEdges); 
+  const nodes = useDiagramStore((s) => s.nodes); 
+  const showAllEdges = useDiagramStore((s) => s.showAllEdges);
   
   const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null);
   const [hoveredEdgeId, setHoveredEdgeId] = useState<string | null>(null);
 
   const displayEdges = useMemo(() => {
-    if (!hoveredNodeId && !hoveredEdgeId && !showAllEdges) return edges;
+    const selectedNodeIds = nodes
+      .filter(n => n.selected)
+      .map(n => n.id);
+    
+    const hasSelection = selectedNodeIds.length > 0;
+
+    if (!hoveredNodeId && !hoveredEdgeId && !showAllEdges && !hasSelection) return edges;
 
     return edges.map((edge) => {
-      const isConnectedToNode =
+      const isConnectedToHoveredNode =
         hoveredNodeId &&
         (edge.source === hoveredNodeId || edge.target === hoveredNodeId);
       
       const isHoveredEdge = hoveredEdgeId && edge.id === hoveredEdgeId;
 
-      const shouldHighlight = showAllEdges || isConnectedToNode || isHoveredEdge;
+      const isConnectedToSelectedNode = hasSelection && 
+        (selectedNodeIds.includes(edge.source) || selectedNodeIds.includes(edge.target));
+
+      const shouldHighlight = showAllEdges || isConnectedToHoveredNode || isHoveredEdge || isConnectedToSelectedNode;
 
       if (shouldHighlight) {
         const type = edge.data?.type || "default";
         const configTypes = edgeConfig.types as Record<string, { highlight?: string }>;
         
-        const highlightColor = configTypes[type]?.highlight || "var(--edge-base)";
+        let highlightColor = configTypes[type]?.highlight || "var(--edge-base)";
+        if (isConnectedToSelectedNode && !showAllEdges) {
+            highlightColor = "#06b6d4"; 
+        }
 
         return {
           ...edge,
           animated: false,
-          
-          data: {
-            ...edge.data,
-            isHovered: true, 
-          },
-
+          data: { ...edge.data, isHovered: true },
           style: {
             ...edge.style,
             stroke: highlightColor,
             strokeWidth: 3, 
             zIndex: 999,    
-            opacity: 1, 
+            opacity: 1,
+            transition: 'all 0.3s ease' ,
           },
         };
       }
 
       return {
         ...edge,
-        style: { ...edge.style, opacity: 0.2 },
+        style: { ...edge.style, opacity: 0.2, transition: 'all 0.3s ease' },
       };
     });
-  }, [edges, hoveredNodeId, hoveredEdgeId, showAllEdges]); 
+  }, [edges, nodes, hoveredNodeId, hoveredEdgeId, showAllEdges]); 
 
   return {
     displayEdges,

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -52,6 +52,15 @@
       "snap": "Snap to Grid",
       "spotlight": "Spotlight Search",
       "connections": "Highlight Connections"
+    },
+    "edit": {
+      "title": "Edit",
+      "undo": "Undo",
+      "redo": "Redo",
+      "duplicate": "Duplicate",
+      "delete": "Delete",
+      "selectAll": "Select All",
+      "edit": "Edit Properties"
     }
   },
   "sidebar": {
@@ -120,6 +129,8 @@
       "add": "Add",
       "noAttributes": "No attributes defined.",
       "noMethods": "No methods defined.",
+      "cancel": "Cancel",
+      "save": "Save",
       "placeholders": {
         "name": "name",
         "methodName": "methodName"

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -52,6 +52,15 @@
       "snap": "Ajustar a la Rejilla",
       "spotlight": "Búsqueda Rápida",
       "connections": "Resaltar Conexiones"
+    },
+    "edit": {
+      "title": "Editar",
+      "undo": "Deshacer",
+      "redo": "Rehacer",
+      "duplicate": "Duplicar",
+      "delete": "Eliminar",
+      "selectAll": "Seleccionar Todo",
+      "edit": "Editar Propiedades"
     }
   },
   "sidebar": {
@@ -120,6 +129,8 @@
       "add": "Agregar",
       "noAttributes": "No hay atributos definidos.",
       "noMethods": "No hay métodos definidos.",
+      "cancel": "Cancelar",
+      "save": "Guardar",
       "placeholders": {
         "name": "nombre",
         "methodName": "nombreMetodo"

--- a/frontend/src/store/uiStore.ts
+++ b/frontend/src/store/uiStore.ts
@@ -1,0 +1,37 @@
+import { create } from "zustand";
+
+// Define the types for active modals in the UI
+export type ActiveModal = 
+  | "none" 
+  | "class-editor" 
+  | "multiplicity-editor" 
+  | "clear-confirmation"; 
+
+interface UiStoreState {
+  // state
+  activeModal: ActiveModal;
+  editingId: string | null; 
+
+  // actions
+  openClassEditor: (nodeId: string) => void;
+  openMultiplicityEditor: (edgeId: string) => void;
+  openClearConfirmation: () => void;
+  closeModals: () => void;
+}
+
+export const useUiStore = create<UiStoreState>((set) => ({
+  activeModal: "none",
+  editingId: null,
+
+  openClassEditor: (nodeId) =>
+    set({ activeModal: "class-editor", editingId: nodeId }),
+
+  openMultiplicityEditor: (edgeId) =>
+    set({ activeModal: "multiplicity-editor", editingId: edgeId }),
+
+  openClearConfirmation: () =>
+    set({ activeModal: "clear-confirmation", editingId: null }),
+
+  closeModals: () =>
+    set({ activeModal: "none", editingId: null }),
+}));


### PR DESCRIPTION
- Add 'selected' prop handling in UmlClassNode and UmlNoteNode to render Cyan/Neon visual feedback.
- Update 'useEdgeStyling' to automatically highlight connections attached to selected nodes.
- Refactor UmlClassNode to use lazy state initialization, removing unstable useEffect for 'NewClass' auto-edit.
- Enhance visual hierarchy by adding distinct ring and shadow effects for active selection states.