### PR TITLE
feat(export): implement comprehensive diagram export system (PNG/SVG)

### DIFF
--- a/frontend/electron/preload.ts
+++ b/frontend/electron/preload.ts
@@ -26,6 +26,9 @@ contextBridge.exposeInMainWorld("electronAPI", {
 
   associateFiles: () => ipcRenderer.invoke("app:associate-files"),
 
+  saveImage: (dataUrl: string, fileName: string, format: string) => 
+    ipcRenderer.invoke("dialog:saveImage", { dataUrl, fileName, format }),
+
   onOpenFileFromOS: (callback: (filePath: string) => void) => {
     const subscription = (_: IpcRendererEvent, filePath: string) => callback(filePath);
     ipcRenderer.on('app:open-file-from-os', subscription);

--- a/frontend/src/features/diagram/components/layout/DiagramCanvas.tsx
+++ b/frontend/src/features/diagram/components/layout/DiagramCanvas.tsx
@@ -30,6 +30,7 @@ import { useEdgeStyling } from "../../hooks/useEdgeStyling";
 import { useThemeSystem } from "../../../../hooks/useThemeSystem";
 import { useNodeDragging } from "../../hooks/useNodeDragging";
 import { useTranslation } from "react-i18next";
+import ExportModal from "../modals/ExportModal";
 
 const nodeTypes = {
   umlClass: UmlClassNode,
@@ -197,6 +198,11 @@ export default function DiagramCanvas() {
           }}
         />
       )}
+
+      <ExportModal 
+        isOpen={activeModal === 'export-modal'}
+        onClose={closeModals}
+      />
 
       <ConfirmationModal
         isOpen={activeModal === 'clear-confirmation'}

--- a/frontend/src/features/diagram/components/menubar/AppMenubar.tsx
+++ b/frontend/src/features/diagram/components/menubar/AppMenubar.tsx
@@ -12,6 +12,7 @@ import { FileMenu } from "./modules/FileMenu";
 import { ViewMenu } from "./modules/ViewMenu"; 
 import { SettingsMenu } from "./modules/SettingsMenu"; 
 import { EditMenu } from "./modules/EditMenu";
+import { ExportMenu } from "./modules/ExportMenu";
 
 export default function AppMenubar() {
   const diagramName = useDiagramStore((s) => s.diagramName);
@@ -35,9 +36,10 @@ export default function AppMenubar() {
 
           <div className="flex items-center h-full no-drag">
               <FileMenu actions={actions} />
-              <ViewMenu />  
-              <SettingsMenu />
               <EditMenu />
+              <ViewMenu />  
+              <ExportMenu />
+              <SettingsMenu />
           </div>
         </div>
 

--- a/frontend/src/features/diagram/components/menubar/modules/ExportMenu.tsx
+++ b/frontend/src/features/diagram/components/menubar/modules/ExportMenu.tsx
@@ -1,0 +1,42 @@
+import { 
+  Download, 
+  Image as ImageIcon,
+  Share2
+} from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { MenubarTrigger } from "../../../../../components/ui/menubar/MenubarTrigger";
+import { MenubarItem } from "../../../../../components/ui/menubar/MenubarItem";
+import { useUiStore } from "../../../../../store/uiStore";
+
+export function ExportMenu() {
+  const { t } = useTranslation();
+  const openExportModal = useUiStore((s) => s.openExportModal);
+
+  return (
+    <MenubarTrigger label={t("menubar.export.title") || "Export"}>
+      
+      {/* Primary Action */}
+      <MenubarItem
+        label={t("menubar.export.image") || "Export Image..."}
+        icon={<ImageIcon className="w-4 h-4" />}
+        shortcut="Ctrl+E"
+        onClick={openExportModal}
+      />
+
+      {/* Future Features (Placeholder) */}
+      <div className="h-px bg-surface-border my-1" />
+      
+      <MenubarItem
+        label={t("menubar.export.pdf") || "Export PDF"}
+        icon={<Download className="w-4 h-4" />}
+        disabled={true} // Coming soon
+      />
+       <MenubarItem
+        label={t("menubar.export.github") || "Export to GitHub"}
+        icon={<Share2 className="w-4 h-4" />}
+        disabled={true} // Coming soon
+      />
+
+    </MenubarTrigger>
+  );
+}

--- a/frontend/src/features/diagram/components/modals/ExportModal.tsx
+++ b/frontend/src/features/diagram/components/modals/ExportModal.tsx
@@ -1,0 +1,354 @@
+import { useState, useEffect, useCallback } from "react";
+import {
+  Download,
+  Image as ImageIcon,
+  FileCode,
+  Network,
+  AlertTriangle,
+  Timer,
+  ArrowRight,
+} from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { useReactFlow } from "reactflow";
+import { useDiagramStore } from "../../../../store/diagramStore";
+import { useSettingsStore } from "../../../../store/settingsStore";
+import { ExportService } from "../../../../services/export.service";
+
+interface ExportModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export default function ExportModal({ isOpen, onClose }: ExportModalProps) {
+  const { t } = useTranslation();
+  const { getNodes } = useReactFlow();
+
+  // Stores
+  const diagramName = useDiagramStore((s) => s.diagramName);
+  const showAllEdges = useDiagramStore((s) => s.showAllEdges);
+  const toggleShowAllEdges = useDiagramStore((s) => s.toggleShowAllEdges);
+
+  const suppressSvgWarning = useSettingsStore((s) => s.suppressSvgWarning);
+  const setSuppressSvgWarning = useSettingsStore(
+    (s) => s.setSuppressSvgWarning,
+  );
+
+  // Local State
+  const [format, setFormat] = useState<"png" | "svg">("png");
+  const [scale, setScale] = useState<number>(2);
+  const [transparent, setTransparent] = useState(false);
+  const [includeConnections, setIncludeConnections] = useState(false);
+
+  const [isExporting, setIsExporting] = useState(false);
+
+  // Warning Flow State
+  const [view, setView] = useState<"config" | "warning">("config");
+  const [countdown, setCountdown] = useState(3);
+  const [dontShowAgain, setDontShowAgain] = useState(false);
+
+  useEffect(() => {
+    if (isOpen) {
+      setView("config");
+      setCountdown(3);
+      setDontShowAgain(false);
+      setIncludeConnections(showAllEdges ?? false);
+    }
+  }, [isOpen, showAllEdges]);
+
+  // Countdown (3 segundos)
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout>;
+
+    if (view === "warning" && countdown > 0) {
+      timer = setTimeout(() => setCountdown((prev) => prev - 1), 1000);
+    }
+    return () => clearTimeout(timer);
+  }, [view, countdown]);
+
+  // --- CORE EXPORT LOGIC ---
+  const executeExport = useCallback(async () => {
+    setIsExporting(true);
+    const viewportEl = document.querySelector(
+      ".react-flow__viewport",
+    ) as HTMLElement;
+
+    if (!viewportEl) {
+      setIsExporting(false);
+      return;
+    }
+
+    const computedStyle = getComputedStyle(document.documentElement);
+    const bgColor = computedStyle.getPropertyValue("--canvas-base").trim();
+
+    //  VISUAL STATE FUNCTION (SNAPSHOT)
+    const originalShowEdgesState = useDiagramStore.getState().showAllEdges;
+    let stateChanged = false;
+
+    if (includeConnections && !originalShowEdgesState) {
+      toggleShowAllEdges();
+      stateChanged = true;
+      await new Promise((resolve) => setTimeout(resolve, 400));
+    }
+
+    try {
+      await ExportService.downloadImage(viewportEl, getNodes(), {
+        fileName: diagramName || "diagram",
+        format,
+        scale,
+        transparent,
+        backgroundColor: bgColor,
+      });
+
+      if (format === "svg" && dontShowAgain) {
+        setSuppressSvgWarning(true);
+      }
+
+      onClose();
+    } catch (error) {
+      alert(
+        t("alerts.exportError") ||
+          "Error exporting image" +
+            (error instanceof Error ? `: ${error.message}` : ""),
+      );
+    } finally {
+      if (stateChanged) {
+        toggleShowAllEdges();
+      }
+      setIsExporting(false);
+    }
+  }, [
+    diagramName,
+    format,
+    scale,
+    transparent,
+    includeConnections,
+    toggleShowAllEdges,
+    getNodes,
+    onClose,
+    t,
+    dontShowAgain,
+    setSuppressSvgWarning,
+  ]);
+
+  // --- HANDLERS ---
+  const handleExportClick = () => {
+    if (format === "svg" && !suppressSvgWarning) {
+      setView("warning");
+      setCountdown(3);
+    } else {
+      executeExport();
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm animate-in fade-in duration-200">
+      <div className="bg-surface-primary border border-surface-border rounded-xl shadow-2xl w-96 overflow-hidden animate-in zoom-in-95 duration-200">
+        {/* === VIEW 1: CONFIGURATION === */}
+        {view === "config" && (
+          <>
+            <div className="px-6 py-4 border-b border-surface-border bg-surface-secondary/50 flex items-center gap-3">
+              <div className="p-2 bg-uml-class-bg rounded-lg text-uml-class-border">
+                <Download className="w-5 h-5" />
+              </div>
+              <h3 className="font-bold text-text-primary">
+                {t("modals.export.title") || "Export Image"}
+              </h3>
+            </div>
+
+            <div className="p-6 space-y-6">
+              {/* Format */}
+              <div className="space-y-3">
+                <label className="text-xs font-bold text-text-secondary uppercase tracking-wider">
+                  {t("modals.export.format") || "Format"}
+                </label>
+                <div className="grid grid-cols-2 gap-3">
+                  <button
+                    onClick={() => setFormat("png")}
+                    className={`flex flex-col items-center gap-2 p-3 rounded-lg border transition-all ${
+                      format === "png"
+                        ? "bg-uml-class-bg border-uml-class-border text-uml-class-border ring-1 ring-uml-class-border"
+                        : "bg-surface-secondary border-surface-border text-text-secondary hover:bg-surface-hover"
+                    }`}
+                  >
+                    <ImageIcon className="w-6 h-6" />
+                    <span className="text-xs font-bold">PNG</span>
+                  </button>
+
+                  <button
+                    onClick={() => setFormat("svg")}
+                    className={`flex flex-col items-center gap-2 p-3 rounded-lg border transition-all ${
+                      format === "svg"
+                        ? "bg-uml-class-bg border-uml-class-border text-uml-class-border ring-1 ring-uml-class-border"
+                        : "bg-surface-secondary border-surface-border text-text-secondary hover:bg-surface-hover"
+                    }`}
+                  >
+                    <FileCode className="w-6 h-6" />
+                    <span className="text-xs font-bold">SVG</span>
+                  </button>
+                </div>
+              </div>
+
+              {/* Settings (PNG Only) */}
+              {format === "png" && (
+                <div className="space-y-3 animate-in fade-in slide-in-from-top-2">
+                  <label className="text-xs font-bold text-text-secondary uppercase tracking-wider">
+                    {t("modals.export.quality") || "Quality"}
+                  </label>
+                  <div className="flex gap-2">
+                    {[1, 2, 4].map((s) => (
+                      <button
+                        key={s}
+                        onClick={() => setScale(s)}
+                        className={`flex-1 py-1.5 text-xs font-mono rounded border transition-all ${
+                          scale === s
+                            ? "bg-uml-class-border text-white border-uml-class-border"
+                            : "bg-transparent border-surface-border text-text-secondary hover:border-text-secondary"
+                        }`}
+                      >
+                        {s}x
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              <div className="h-px bg-surface-border my-2" />
+
+              {/* Toggles */}
+              <div className="space-y-3">
+                {/* 1. Transparent */}
+                <div className="flex items-center justify-between">
+                  <span className="text-sm text-text-primary">
+                    {t("modals.export.transparent") || "Transparent Background"}
+                  </span>
+                  <button
+                    onClick={() => setTransparent(!transparent)}
+                    className={`w-10 h-5 rounded-full transition-colors relative ${
+                      transparent ? "bg-uml-class-border" : "bg-text-muted/30"
+                    }`}
+                  >
+                    <div
+                      className={`absolute top-1 left-1 w-3 h-3 bg-white rounded-full transition-transform ${transparent ? "translate-x-5" : "translate-x-0"}`}
+                    />
+                  </button>
+                </div>
+
+                {/* 2. Highlight Connections (NEW) */}
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <Network className="w-4 h-4 text-text-secondary" />
+                    <span className="text-sm text-text-primary">
+                      {t("modals.export.highlight") || "Highlight Connections"}
+                    </span>
+                  </div>
+                  <button
+                    onClick={() => setIncludeConnections(!includeConnections)}
+                    className={`w-10 h-5 rounded-full transition-colors relative ${
+                      includeConnections
+                        ? "bg-uml-class-border"
+                        : "bg-text-muted/30"
+                    }`}
+                  >
+                    <div
+                      className={`absolute top-1 left-1 w-3 h-3 bg-white rounded-full transition-transform ${includeConnections ? "translate-x-5" : "translate-x-0"}`}
+                    />
+                  </button>
+                </div>
+              </div>
+            </div>
+
+            {/* Footer */}
+            <div className="px-6 py-4 bg-surface-secondary/30 border-t border-surface-border flex justify-end gap-3">
+              <button
+                onClick={onClose}
+                className="px-4 py-2 text-sm text-text-secondary hover:text-text-primary transition-colors"
+              >
+                {t("modals.common.cancel")}
+              </button>
+              <button
+                onClick={handleExportClick}
+                disabled={isExporting}
+                className="flex items-center gap-2 px-6 py-2 bg-uml-class-border text-white rounded font-medium shadow-md hover:brightness-110 active:scale-95 transition-all disabled:opacity-50"
+              >
+                {isExporting ? t("header.exportMenu.soon") : t("header.export")}
+              </button>
+            </div>
+          </>
+        )}
+
+        {/* === VIEW 2: SVG WARNING === */}
+        {view === "warning" && (
+          <div className="animate-in fade-in slide-in-from-right-4 duration-300">
+            <div className="px-6 py-4 border-b border-surface-border bg-amber-500/10 flex items-center gap-3">
+              <div className="p-2 bg-amber-500/20 rounded-lg text-amber-500">
+                <AlertTriangle className="w-5 h-5" />
+              </div>
+              <h3 className="font-bold text-text-primary">
+                {t("modals.export.svgWarningTitle") || "SVG Compatibility"}
+              </h3>
+            </div>
+
+            <div className="p-6">
+              <p className="text-sm text-text-secondary leading-relaxed mb-4">
+                {t("modals.export.svgWarningMessage") ||
+                  "Some image viewers on Windows, Mac, or Linux might not display the exported SVG correctly because it contains embedded HTML styles."}
+              </p>
+
+              <div className="p-3 bg-surface-secondary border border-surface-border rounded-lg text-xs text-text-muted mb-6">
+                <strong>💡 Tip:</strong>{" "}
+                {t("modals.export.svgTip") ||
+                  "If it looks broken, try opening the .svg file in your web browser (Chrome, Edge, etc)."}
+              </div>
+
+              <label className="flex items-center gap-2 cursor-pointer select-none">
+                <input
+                  type="checkbox"
+                  checked={dontShowAgain}
+                  onChange={(e) => setDontShowAgain(e.target.checked)}
+                  className="rounded border-surface-border bg-surface-secondary text-uml-class-border focus:ring-uml-class-border"
+                />
+                <span className="text-sm text-text-secondary">
+                  {t("modals.export.dontShowAgain") || "Don't show this again"}
+                </span>
+              </label>
+            </div>
+
+            <div className="px-6 py-4 bg-surface-secondary/30 border-t border-surface-border flex justify-between items-center">
+              <button
+                onClick={() => setView("config")}
+                className="text-sm text-text-secondary hover:text-text-primary underline"
+              >
+                {t("modals.common.back")}
+              </button>
+
+              <button
+                onClick={executeExport}
+                disabled={countdown > 0}
+                className={`flex items-center gap-2 px-6 py-2 rounded font-medium shadow-md transition-all 
+                  ${
+                    countdown > 0
+                      ? "bg-surface-border text-text-muted cursor-not-allowed"
+                      : "bg-amber-600 hover:bg-amber-500 text-white active:scale-95"
+                  }`}
+              >
+                {countdown > 0 ? (
+                  <>
+                    <Timer className="w-4 h-4 animate-pulse" />
+                    {t("modals.export.wait")} ({countdown}s)
+                  </>
+                ) : (
+                  <>
+                    {t("modals.common.continue")}
+                    <ArrowRight className="w-4 h-4" />
+                  </>
+                )}
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -61,6 +61,12 @@
       "delete": "Delete",
       "selectAll": "Select All",
       "edit": "Edit Properties"
+    },
+    "export": {
+      "title": "Export",
+      "image": "Image (PNG/SVG)...",
+      "pdf": "Export PDF (Soon)",
+      "github": "Publish to GitHub"
     }
   },
   "sidebar": {
@@ -119,7 +125,9 @@
       "save": "Save",
       "cancel": "Cancel",
       "clear": "Clear",
-      "discard": "Discard"
+      "discard": "Discard",
+      "back": "Back",
+      "continue": "Continue"
     },
     "classEditor": {
       "title": "Edit Class:",
@@ -168,6 +176,18 @@
       "elementsFound": "elements found",
       "navigate": "Navigate",
       "select": "Select"
+    },
+    "export": {
+      "title": "Export Diagram",
+      "format": "Format",
+      "quality": "Quality (Scale)",
+      "transparent": "Transparent Background",
+      "highlight": "Highlight Connections (High Contrast)",
+      "svgWarningTitle": "SVG Compatibility Warning",
+      "svgWarningMessage": "Some image viewers on Windows, Mac, or Linux might not display the exported SVG correctly because it uses embedded HTML/CSS for styling.",
+      "svgTip": "If the file looks empty or broken, try opening the .svg file in a web browser (Chrome, Edge, Firefox).",
+      "dontShowAgain": "Don't show this warning again",
+      "wait": "Read this"
     }
   },
   "alerts": {

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -61,6 +61,12 @@
       "delete": "Eliminar",
       "selectAll": "Seleccionar Todo",
       "edit": "Editar Propiedades"
+    },
+    "export": {
+      "title": "Exportar",
+      "image": "Imagen (PNG/SVG)...",
+      "pdf": "Exportar PDF (Pronto)",
+      "github": "Publicar en GitHub"
     }
   },
   "sidebar": {
@@ -119,7 +125,9 @@
       "save": "Guardar",
       "cancel": "Cancelar",
       "clear": "Limpiar",
-      "discard": "Descartar"
+      "discard": "Descartar",
+      "back": "Atrás",
+      "continue": "Continuar"
     },
     "classEditor": {
       "title": "Editar Clase:",
@@ -168,6 +176,18 @@
       "elementsFound": "elementos encontrados",
       "navigate": "Navegar",
       "select": "Seleccionar"
+    },
+    "export": {
+      "title": "Exportar Diagrama",
+      "format": "Formato",
+      "quality": "Calidad (Escala)",
+      "transparent": "Fondo Transparente",
+      "highlight": "Resaltar Conexiones (Alto Contraste)",
+      "svgWarningTitle": "Aviso de Compatibilidad SVG",
+      "svgWarningMessage": "Algunos visores de imágenes en Windows, Mac o Linux podrían no mostrar el SVG correctamente porque utiliza estilos HTML/CSS incrustados.",
+      "svgTip": "Si el archivo se ve vacío o roto, intenta abrir el .svg en tu navegador web (Chrome, Edge, Firefox).",
+      "dontShowAgain": "No mostrar este aviso de nuevo",
+      "wait": "Lee esto"
     }
   },
   "alerts": {

--- a/frontend/src/services/export.service.ts
+++ b/frontend/src/services/export.service.ts
@@ -1,5 +1,4 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-import { toPng } from "html-to-image";
+import { toPng, toSvg } from "html-to-image";
 import {
   getRectOfNodes,
   getTransformForBounds,
@@ -12,29 +11,38 @@ import type {
   UmlEdge,
 } from "../features/diagram/types/diagram.types";
 
+export interface ExportImageOptions {
+  fileName: string;
+  format: "png" | "svg";
+  scale: number;
+  transparent: boolean;
+  backgroundColor: string;
+}
+
 export const ExportService = {
+  // --- JSON (NATIVO) ---
   downloadJson: (
     flowObject: ReactFlowJsonObject,
     id: string,
-    name: string
+    name: string,
   ): void => {
     const cleanEdges = flowObject.edges.map((edge) => {
-      const {
-        style,
-        markerEnd,
-        animated,
-        zIndex,
-        selected,
-        ...semanticEdge
-      } = edge;
-
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { style, markerEnd, animated, zIndex, selected, ...semanticEdge } =
+        edge;
       return semanticEdge;
+    });
+
+    const cleanNodes = flowObject.nodes.map((node) => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { selected, dragging, ...semanticNode } = node;
+      return semanticNode;
     });
 
     const exportData: DiagramState = {
       id,
       name,
-      nodes: flowObject.nodes as unknown as UmlClassNode[],
+      nodes: cleanNodes as unknown as UmlClassNode[],
       edges: cleanEdges as unknown as UmlEdge[],
       viewport: flowObject.viewport,
     };
@@ -49,34 +57,84 @@ export const ExportService = {
     URL.revokeObjectURL(url);
   },
 
-  downloadPng: async (
+  // --- IMAGEN (PNG/SVG) ---
+  downloadImage: async (
     viewportEl: HTMLElement,
     nodes: Node[],
-    fileName: string
+    options: ExportImageOptions,
   ): Promise<void> => {
     const nodesBounds = getRectOfNodes(nodes);
+
+    if (nodesBounds.width === 0 || nodesBounds.height === 0) return;
+
     const transform = getTransformForBounds(
       nodesBounds,
       nodesBounds.width,
       nodesBounds.height,
       0.5,
-      2
+      2,
     );
 
-    const dataUrl = await toPng(viewportEl, {
-      backgroundColor: "#0B0F1A",
+    const backgroundStyle =
+      !options.transparent && options.format === "svg"
+        ? { backgroundColor: options.backgroundColor }
+        : {};
+
+    const config = {
       width: nodesBounds.width,
       height: nodesBounds.height,
       style: {
         width: `${nodesBounds.width}px`,
         height: `${nodesBounds.height}px`,
         transform: `translate(${transform[0]}px, ${transform[1]}px) scale(${transform[2]})`,
+        ...backgroundStyle,
       },
-    });
+      backgroundColor:
+        options.format === "png" && !options.transparent
+          ? options.backgroundColor
+          : undefined,
+      filter: (node: HTMLElement) => {
+        const classList = node.classList;
+        if (!classList) return true;
+        return (
+          !classList.contains("react-flow__minimap") &&
+          !classList.contains("react-flow__controls") &&
+          !classList.contains("react-flow__panel")
+        );
+      },
+    };
 
-    const link = document.createElement("a");
-    link.download = `${fileName}.png`;
-    link.href = dataUrl;
-    link.click();
+    let dataUrl = "";
+
+    try {
+      if (options.format === "svg") {
+        dataUrl = await toSvg(viewportEl, config);
+      } else {
+        dataUrl = await toPng(viewportEl, {
+          ...config,
+          pixelRatio: options.scale,
+        });
+      }
+
+      if (window.electronAPI?.isElectron()) {
+        const result = await window.electronAPI.saveImage(
+          dataUrl,
+          options.fileName,
+          options.format,
+        );
+
+        if (result.canceled) {
+          console.log("Exportación cancelada por el usuario");
+        }
+      } else {
+        const link = document.createElement("a");
+        link.download = `${options.fileName}.${options.format}`;
+        link.href = dataUrl;
+        link.click();
+      }
+    } catch (error) {
+      console.error("Error exporting image:", error);
+      throw error;
+    }
   },
 };

--- a/frontend/src/store/settingsStore.ts
+++ b/frontend/src/store/settingsStore.ts
@@ -8,6 +8,7 @@ interface SettingsState {
   restoreSession: boolean;
   theme: "light" | "dark" | "system"; 
   language: string;
+  suppressSvgWarning: boolean;
   
   // --- inside state  ---
   lastFilePath?: string; 
@@ -18,6 +19,7 @@ interface SettingsState {
   setTheme: (theme: "light" | "dark") => void;
   setLanguage: (lang: string) => void;
   setLastFilePath: (path: string | undefined) => void;
+  setSuppressSvgWarning: (suppress: boolean) => void;
 }
 
 export const useSettingsStore = create<SettingsState>()(
@@ -27,6 +29,7 @@ export const useSettingsStore = create<SettingsState>()(
       restoreSession: false,
       theme: "dark", 
       language: "en",
+      suppressSvgWarning: false,
       lastFilePath: undefined,
 
       toggleAutoSave: () => set((s) => ({ autoSave: !s.autoSave })),
@@ -40,6 +43,8 @@ export const useSettingsStore = create<SettingsState>()(
         set({ language: lang });
       },
 
+      setSuppressSvgWarning: (suppress) => set({ suppressSvgWarning: suppress }),
+
       setLastFilePath: (path) => set({ lastFilePath: path }),
     }),
     {
@@ -49,7 +54,8 @@ export const useSettingsStore = create<SettingsState>()(
         restoreSession: state.restoreSession,
         theme: state.theme,
         language: state.language,
-        lastFilePath: state.lastFilePath
+        lastFilePath: state.lastFilePath,
+        suppressSvgWarning: state.suppressSvgWarning,
       }),
     }
   )

--- a/frontend/src/store/uiStore.ts
+++ b/frontend/src/store/uiStore.ts
@@ -1,21 +1,23 @@
 import { create } from "zustand";
 
 // Define the types for active modals in the UI
-export type ActiveModal = 
-  | "none" 
-  | "class-editor" 
-  | "multiplicity-editor" 
-  | "clear-confirmation"; 
+export type ActiveModal =
+  | "none"
+  | "class-editor"
+  | "multiplicity-editor"
+  | "clear-confirmation"
+  | "export-modal";
 
 interface UiStoreState {
   // state
   activeModal: ActiveModal;
-  editingId: string | null; 
+  editingId: string | null;
 
   // actions
   openClassEditor: (nodeId: string) => void;
   openMultiplicityEditor: (edgeId: string) => void;
   openClearConfirmation: () => void;
+  openExportModal: () => void;
   closeModals: () => void;
 }
 
@@ -32,6 +34,7 @@ export const useUiStore = create<UiStoreState>((set) => ({
   openClearConfirmation: () =>
     set({ activeModal: "clear-confirmation", editingId: null }),
 
-  closeModals: () =>
-    set({ activeModal: "none", editingId: null }),
+  openExportModal: () => set({ activeModal: "export-modal", editingId: null }),
+
+  closeModals: () => set({ activeModal: "none", editingId: null }),
 }));

--- a/frontend/src/types/electron.d.ts
+++ b/frontend/src/types/electron.d.ts
@@ -21,18 +21,28 @@ declare global {
   interface Window {
     electronAPI?: {
       isElectron: () => boolean;
-      
-      // Archivos
-      saveFile: (content: string, filePath?: string, defaultName?: string) => Promise<FileOperationResult>;
+
+      // File operations
+      saveFile: (
+        content: string,
+        filePath?: string,
+        defaultName?: string,
+      ) => Promise<FileOperationResult>;
       openFile: () => Promise<FileOperationResult>;
       readFile: (filePath: string) => Promise<ReadFileResult>;
+      saveImage: (
+        dataUrl: string,
+        fileName: string,
+        format: string,
+      ) => Promise<FileOperationResult>;
 
+      // Window controls
       minimize: () => void;
       toggleMaximize: () => void;
       close: () => void;
       onAppRequestClose: (callback: () => void) => () => void;
       sendForceClose: () => void;
-
+      // OS integrations
       associateFiles: () => Promise<AssociationResult>;
       onOpenFileFromOS: (callback: (filePath: string) => void) => () => void;
     };


### PR DESCRIPTION
- Promote export functionality to a dedicated top-level 'ExportMenu' in AppMenubar.
- Implement 'ExportModal' allowing configuration of:
  - Format: PNG (Raster) vs SVG (Vector).
  - Quality: Scale factors (1x, 2x, 4x) for HD PNGs.
  - Background: Toggle transparency or theme color.
  - Visuals: "Highlight Connections" mode (Neon effect) for export snapshots.
- Update 'ExportService' to handle SVG background injection and styling isolation.
- Add persistent user warning for SVG compatibility with desktop viewers (stored in settings).
- Implement native OS file dialogs via Electron IPC ('dialog:saveImage') to resolve filename issues on Linux/Windows.
- Integrate 'uiStore' to manage export modal state.