### PR TITLE
feat(reverse-engineering): complete java import system with main detection

### DIFF
--- a/frontend/src/features/diagram/components/layout/DiagramCanvas.tsx
+++ b/frontend/src/features/diagram/components/layout/DiagramCanvas.tsx
@@ -33,6 +33,7 @@ import { useTranslation } from "react-i18next";
 import ExportModal from "../modals/ExportModal";
 import SingleClassGeneratorModal from "../modals/SingleClassGeneratorModal";
 import ProjectGeneratorModal from "../modals/ProjectGeneratorModal";
+import ImportCodeModal from "../modals/ImportCodeModal";
 
 const nodeTypes = {
   umlClass: UmlClassNode,
@@ -225,6 +226,11 @@ export default function DiagramCanvas() {
           closeModals();
         }}
         onCancel={closeModals}
+      />
+
+      <ImportCodeModal 
+        isOpen={activeModal === 'import-code'}
+        onClose={closeModals}
       />
 
       <SpotlightModal />

--- a/frontend/src/features/diagram/components/menubar/modules/CodeMenu.tsx
+++ b/frontend/src/features/diagram/components/menubar/modules/CodeMenu.tsx
@@ -15,7 +15,7 @@ export function CodeMenu() {
   // Store actions
   const openSingleGenerator = useUiStore((s) => s.openSingleGenerator); 
   const openProjectGenerator = useUiStore((s) => s.openProjectGenerator); 
-  const openReverseEngineering = useUiStore((s) => s.openReverseEngineering);
+  const openImportModal = useUiStore((s) => s.openImportCode);
 
   return (
     <MenubarTrigger label="Code">
@@ -41,7 +41,7 @@ export function CodeMenu() {
       <MenubarItem
         label="Import Java Code..."
         icon={<Upload className="w-4 h-4" />}
-        onClick={openReverseEngineering}
+        onClick={openImportModal}
       />
 
       <div className="h-px bg-surface-border my-1" />

--- a/frontend/src/features/diagram/components/modals/ImportCodeModal.tsx
+++ b/frontend/src/features/diagram/components/modals/ImportCodeModal.tsx
@@ -1,0 +1,222 @@
+import { useState, useRef } from "react";
+import type { ChangeEvent } from "react"; 
+import { Upload, FileText, Code, AlertCircle, X } from "lucide-react";
+import { useDiagramStore } from "../../../../store/diagramStore";
+import { ReverseEngineeringService } from "../../../../services/reverseEngineering.service";
+// Import types for casting
+import type {
+  UmlClassNode,
+  UmlEdge,
+  UmlClassData,
+} from "../../types/diagram.types";
+import type { Node, Edge } from "reactflow";
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+type Tab = "upload" | "paste";
+
+export default function ImportCodeModal({ isOpen, onClose }: Props) {
+  const [activeTab, setActiveTab] = useState<Tab>("upload");
+  const [code, setCode] = useState("");
+  const [fileName, setFileName] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isProcessing, setIsProcessing] = useState(false);
+
+  // Stores
+  const { nodes, edges, setNodes, setEdges } = useDiagramStore();
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  if (!isOpen) return null;
+
+  // --- Handlers ---
+
+  const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    readFile(file);
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    const file = e.dataTransfer.files?.[0];
+    if (file) readFile(file);
+  };
+
+  const readFile = (file: File) => {
+    if (!file.name.endsWith(".java")) {
+      setError("Please upload a valid .java file");
+      return;
+    }
+    setError(null);
+    setFileName(file.name);
+
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      const content = e.target?.result as string;
+      setCode(content);
+    };
+    reader.readAsText(file);
+  };
+
+  const handleImport = () => {
+    if (!code.trim()) {
+      setError("No code to import");
+      return;
+    }
+
+    setIsProcessing(true);
+    try {
+      const result = ReverseEngineeringService.process(
+        code,
+        nodes as unknown as UmlClassNode[],
+        edges as unknown as UmlEdge[],
+      );
+
+      setNodes(result.nodes as unknown as Node<UmlClassData>[]);
+      setEdges(result.edges as unknown as Edge[]);
+
+      onClose();
+      // Reset state
+      setCode("");
+      setFileName(null);
+    } catch (err) {
+      console.error(err);
+      setError("Failed to parse Java code. Check syntax.");
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm animate-in fade-in">
+      <div className="bg-surface-primary border border-surface-border rounded-xl shadow-2xl w-150 overflow-hidden flex flex-col max-h-[85vh]">
+        {/* Header */}
+        <div className="px-6 py-4 border-b border-surface-border bg-surface-secondary/50 flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <div className="p-2 bg-green-500/20 rounded-lg text-green-400">
+              <Upload className="w-5 h-5" />
+            </div>
+            <div>
+              <h3 className="font-bold text-text-primary">Import Java Code</h3>
+              <p className="text-xs text-text-muted">
+                Reverse engineering: Java to UML
+              </p>
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-text-muted hover:text-text-primary"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        {/* Tabs */}
+        <div className="flex border-b border-surface-border">
+          <button
+            onClick={() => setActiveTab("upload")}
+            className={`flex-1 py-3 text-sm font-medium flex items-center justify-center gap-2 transition-colors ${activeTab === "upload" ? "bg-surface-primary text-green-400 border-b-2 border-green-400" : "bg-surface-secondary/30 text-text-secondary hover:text-text-primary"}`}
+          >
+            <FileText className="w-4 h-4" /> Upload File
+          </button>
+          <button
+            onClick={() => setActiveTab("paste")}
+            className={`flex-1 py-3 text-sm font-medium flex items-center justify-center gap-2 transition-colors ${activeTab === "paste" ? "bg-surface-primary text-green-400 border-b-2 border-green-400" : "bg-surface-secondary/30 text-text-secondary hover:text-text-primary"}`}
+          >
+            <Code className="w-4 h-4" /> Paste Code
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="p-6 flex-1 overflow-y-auto">
+          {activeTab === "upload" ? (
+            <div
+              onDragOver={(e) => e.preventDefault()}
+              onDrop={handleDrop}
+              className="border-2 border-dashed border-surface-border hover:border-green-500/50 rounded-xl p-10 flex flex-col items-center justify-center gap-4 transition-colors cursor-pointer bg-surface-secondary/10 group"
+              onClick={() => fileInputRef.current?.click()}
+            >
+              <input
+                type="file"
+                ref={fileInputRef}
+                className="hidden"
+                accept=".java"
+                onChange={handleFileChange}
+              />
+
+              {fileName ? (
+                <>
+                  <div className="w-16 h-16 bg-green-500/20 rounded-full flex items-center justify-center text-green-400">
+                    <FileText className="w-8 h-8" />
+                  </div>
+                  <div className="text-center">
+                    <p className="text-text-primary font-medium">{fileName}</p>
+                    <p className="text-sm text-green-400">Ready to import</p>
+                  </div>
+                </>
+              ) : (
+                <>
+                  <div className="w-16 h-16 bg-surface-secondary rounded-full flex items-center justify-center text-text-muted group-hover:text-text-primary transition-colors">
+                    <Upload className="w-8 h-8" />
+                  </div>
+                  <div className="text-center space-y-1">
+                    <p className="text-text-primary font-medium">
+                      Click to upload or drag & drop
+                    </p>
+                    <p className="text-xs text-text-muted">
+                      Supports .java files
+                    </p>
+                  </div>
+                </>
+              )}
+            </div>
+          ) : (
+            <div className="h-full flex flex-col gap-2">
+              <textarea
+                className="w-full h-75 bg-surface-secondary border border-surface-border rounded-lg p-4 font-mono text-xs text-text-primary outline-none focus:border-green-500/50 resize-none"
+                placeholder="Paste your Java class code here..."
+                value={code}
+                onChange={(e) => setCode(e.target.value)}
+                spellCheck={false}
+              />
+            </div>
+          )}
+
+          {/* Error Message */}
+          {error && (
+            <div className="mt-4 p-3 bg-red-500/10 border border-red-500/20 rounded text-red-400 text-sm flex items-center gap-2">
+              <AlertCircle className="w-4 h-4" /> {error}
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="px-6 py-4 border-t border-surface-border bg-surface-secondary/50 flex justify-end gap-3">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 text-sm text-text-secondary hover:text-text-primary"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleImport}
+            disabled={!code || isProcessing}
+            className="flex items-center gap-2 px-6 py-2 bg-green-600 text-white rounded hover:bg-green-500 font-medium shadow-md active:scale-95 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {isProcessing ? (
+              "Analyzing..."
+            ) : (
+              <>
+                <Upload className="w-4 h-4" /> Import Class
+              </>
+            )}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/diagram/components/nodes/uml/UmlClassNode.tsx
+++ b/frontend/src/features/diagram/components/nodes/uml/UmlClassNode.tsx
@@ -1,5 +1,6 @@
 import { memo, useState } from "react";
 import { Handle, Position, type NodeProps } from "reactflow";
+import { Play } from "lucide-react";
 import type { UmlClassData } from "../../../types/diagram.types";
 import { useDiagramStore } from "../../../../../store/diagramStore";
 import { handleConfig } from "../../../../../config/theme.config";
@@ -14,6 +15,7 @@ const UmlClassNode = ({ id, data, selected }: NodeProps<UmlClassData>) => {
 
   const isInterface = data.stereotype === "interface";
   const isAbstract = data.stereotype === "abstract";
+  const isMain = data.isMain;
 
   let containerClass = "bg-uml-class-bg border-uml-class-border";
   let headerClass = "bg-surface-hover border-uml-class-border";
@@ -70,6 +72,15 @@ const UmlClassNode = ({ id, data, selected }: NodeProps<UmlClassData>) => {
         className={`p-2 border-b-2 text-center cursor-pointer hover:brightness-110 transition-all ${headerClass} ${selected ? "border-cyan-500/30!" : ""}`}
         onDoubleClick={() => setIsEditing(true)}
       >
+
+        {isMain && (
+          <div className="absolute top-1 right-1" title="Entry Point (Main)">
+            <div className="bg-green-500 text-white rounded-full p-0.5 shadow-sm animate-in zoom-in duration-300">
+               <Play className="w-3 h-3 fill-current" />
+            </div>
+          </div>
+        )}
+
         {isInterface && (
           <small
             className={`block text-[10px] leading-tight mb-0.5 font-mono ${badgeColor}`}

--- a/frontend/src/features/diagram/types/diagram.types.ts
+++ b/frontend/src/features/diagram/types/diagram.types.ts
@@ -1,6 +1,6 @@
 import type { CSSProperties } from 'react';
 
-export type stereotype = 'class' | 'interface' | 'abstract' | 'note';
+export type stereotype = 'class' | 'interface' | 'abstract' | 'note' | 'enum';
 export type UmlRelationType = 'association' | 'inheritance' | 'implementation' | 'dependency' | 'aggregation' | 'composition';
 export type visibility = '+' | '-' | '#' | '~';
 
@@ -17,6 +17,7 @@ export interface UmlMethod {
   name: string;
   returnType: string;
   visibility: visibility;
+  isStatic?: boolean;
   parameters: {name: string, type: string}[];
 }
 
@@ -26,6 +27,7 @@ export interface UmlClassData {
   attributes: UmlAttribute[];
   methods: UmlMethod[];
   stereotype: stereotype; 
+  isMain?: boolean;
 }
 
 export interface UmlClassNode {

--- a/frontend/src/services/javaParser.service.ts
+++ b/frontend/src/services/javaParser.service.ts
@@ -1,0 +1,137 @@
+import type { UmlAttribute, UmlMethod, visibility } from "../features/diagram/types/diagram.types";
+
+export interface ParsedClass {
+  name: string;
+  stereotype: 'class' | 'abstract' | 'interface' | 'enum';
+  parentClass: string | null;      
+  interfaces: string[];            
+  attributes: UmlAttribute[];      
+  methods: UmlMethod[];
+  isMain?: boolean; 
+}
+
+export class JavaParserService {
+
+  /**
+   * Main entry point: Parses a Java file content string into a structured object.
+   */
+  static parse(code: string): ParsedClass | null {
+    //  Clean comments
+    const cleanCode = JavaParserService.removeComments(code);
+    
+    //  Parse Class Declaration
+    const classInfo = JavaParserService.parseClassDeclaration(cleanCode);
+    if (!classInfo) return null;
+
+    //  Extract Class Body
+    const body = JavaParserService.extractClassBody(cleanCode);
+    
+    // Parse Members
+    const attributes = JavaParserService.parseAttributes(body);
+    const methods = JavaParserService.parseMethods(body);
+
+    //  Detect Main Method (Entry Point)
+    const isMain = methods.some(m => 
+      m.name === 'main' && 
+      m.isStatic && 
+      m.returnType === 'void' && 
+      m.parameters.length > 0 && 
+      (m.parameters[0].type === 'String[]' || m.parameters[0].type === 'String') 
+    );
+
+    return {
+      ...classInfo,
+      attributes,
+      methods,
+      isMain 
+    };
+  }
+
+  private static removeComments(code: string): string {
+    return code.replace(/\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
+  }
+
+  private static parseClassDeclaration(code: string): Omit<ParsedClass, 'attributes' | 'methods'> | null {
+    const classRegex = /(?:public\s+)?(?:abstract\s+)?(?:final\s+)?(class|interface|enum)\s+(\w+)(?:\s+extends\s+(\w+))?(?:\s+implements\s+([\w\s,]+))?/;
+    const match = code.match(classRegex);
+    if (!match) return null;
+
+    const [, typeStr, name, parentStr, interfacesStr] = match;
+
+    let stereotype: ParsedClass['stereotype'] = 'class';
+    if (code.includes('abstract class')) stereotype = 'abstract';
+    else if (typeStr === 'interface') stereotype = 'interface';
+    else if (typeStr === 'enum') stereotype = 'enum';
+
+    const interfaces = interfacesStr ? interfacesStr.split(',').map(i => i.trim()) : [];
+
+    return { name, stereotype, parentClass: parentStr || null, interfaces };
+  }
+
+  private static extractClassBody(code: string): string {
+    const firstBrace = code.indexOf('{');
+    const lastBrace = code.lastIndexOf('}');
+    if (firstBrace === -1 || lastBrace === -1) return "";
+    return code.substring(firstBrace + 1, lastBrace);
+  }
+
+  private static parseAttributes(body: string): UmlAttribute[] {
+    const attributes: UmlAttribute[] = [];
+    const attrRegex = /(private|protected|public)\s+(\w+(?:<.+>)?(?:\[\])?)\s+(\w+)\s*;/g;
+    
+    let match;
+    while ((match = attrRegex.exec(body)) !== null) {
+      const [, visibilityStr, type, name] = match;
+      attributes.push({
+        id: `attr-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
+        name,
+        type: type.replace('[]', ''),
+        visibility: JavaParserService.mapVisibility(visibilityStr),
+        isArray: type.includes('[]')
+      });
+    }
+    return attributes;
+  }
+
+  /**
+   * Parses methods updated to handle 'static' modifier
+   */
+  private static parseMethods(body: string): UmlMethod[] {
+    const methods: UmlMethod[] = [];
+    const methodRegex = /(private|protected|public)\s+(?:static\s+)?(?:final\s+)?(\w+(?:<.+>)?(?:\[\])?)\s+(\w+)\s*\(([^)]*)\)(?:\s*\{|;)/g;
+
+    let match;
+    while ((match = methodRegex.exec(body)) !== null) {
+      const fullMatch = match[0];
+      const [, visibilityStr, returnType, name, paramsStr] = match;
+
+      const isStatic = fullMatch.includes('static');
+
+      const parameters = paramsStr.trim() ? paramsStr.split(',').map(p => {
+        const parts = p.trim().split(/\s+/);
+        const paramName = parts[parts.length - 1];
+        const paramType = parts.slice(0, -1).join(' ');
+        return { name: paramName, type: paramType };
+      }) : [];
+
+      methods.push({
+        id: `meth-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
+        name,
+        returnType,
+        visibility: JavaParserService.mapVisibility(visibilityStr),
+        isStatic, 
+        parameters
+      });
+    }
+    return methods;
+  }
+
+  private static mapVisibility(javaVis: string): visibility {
+    switch (javaVis) {
+      case 'public': return '+';
+      case 'private': return '-';
+      case 'protected': return '#';
+      default: return '+'; 
+    }
+  }
+}

--- a/frontend/src/services/reverseEngineering.service.ts
+++ b/frontend/src/services/reverseEngineering.service.ts
@@ -1,0 +1,175 @@
+import type { 
+  UmlClassNode, 
+  UmlEdge, 
+  UmlRelationType
+} from "../features/diagram/types/diagram.types";
+import { JavaParserService } from "./javaParser.service";
+import { edgeConfig } from "../config/theme.config"; // <--- 1. IMPORTAR CONFIGURACIÓN DE TEMA
+import { MarkerType } from "reactflow";
+
+interface ReverseEngineeringResult {
+  nodes: UmlClassNode[];
+  edges: UmlEdge[];
+}
+
+export class ReverseEngineeringService {
+
+  static process(
+    code: string, 
+    existingNodes: UmlClassNode[], 
+    existingEdges: UmlEdge[]
+  ): ReverseEngineeringResult {
+    
+    // 1. Parsear
+    const parsed = JavaParserService.parse(code);
+    if (!parsed) {
+      console.warn("No se pudo parsear el código Java.");
+      return { nodes: existingNodes, edges: existingEdges };
+    }
+
+    const nodesMap = new Map<string, UmlClassNode>();
+    existingNodes.forEach(n => nodesMap.set(n.id, n));
+    
+    const edgesMap = new Map<string, UmlEdge>();
+    existingEdges.forEach(e => edgesMap.set(e.id, e));
+
+    // 2. Nodo Principal
+    const mainNodeId = this.generateNodeId(parsed.name);
+    const existingNode = nodesMap.get(mainNodeId);
+
+    const position = existingNode ? existingNode.position : { 
+      x: 100 + Math.random() * 50, 
+      y: 100 + Math.random() * 50 
+    };
+
+    const mainNode: UmlClassNode = {
+      id: mainNodeId,
+      type: 'umlClass',
+      position,
+      width: existingNode?.width,
+      height: existingNode?.height,
+      data: {
+        label: parsed.name,
+        stereotype: parsed.stereotype,
+        attributes: parsed.attributes,
+        methods: parsed.methods,
+        isMain: parsed.isMain
+      }
+    };
+    nodesMap.set(mainNodeId, mainNode);
+
+    
+    // inheritance
+    if (parsed.parentClass) {
+      this.handleRelation(parsed.name, parsed.parentClass, 'inheritance', nodesMap, edgesMap);
+    }
+
+    //  Implementation
+    if (parsed.interfaces.length > 0) {
+      parsed.interfaces.forEach(interfaceName => {
+        this.handleRelation(parsed.name, interfaceName, 'implementation', nodesMap, edgesMap, true);
+      });
+    }
+
+    //  association
+    parsed.attributes.forEach(attr => {
+      if (!this.isPrimitive(attr.type)) {
+        const targetName = this.extractBaseType(attr.type);
+        if (targetName !== parsed.name && targetName !== 'void') {
+            this.handleRelation(parsed.name, targetName, 'association', nodesMap, edgesMap);
+        }
+      }
+    });
+
+    return {
+      nodes: Array.from(nodesMap.values()),
+      edges: Array.from(edgesMap.values())
+    };
+  }
+
+  // --- Helpers ---
+
+  private static handleRelation(
+    sourceName: string,
+    targetName: string,
+    relationType: UmlRelationType,
+    nodesMap: Map<string, UmlClassNode>,
+    edgesMap: Map<string, UmlEdge>,
+    isTargetInterface: boolean = false
+  ) {
+    const sourceId = this.generateNodeId(sourceName);
+    const targetId = this.generateNodeId(targetName);
+
+    //  Ghost Node
+    if (!nodesMap.has(targetId)) {
+      nodesMap.set(targetId, {
+        id: targetId,
+        type: 'umlClass',
+        position: { x: 400 + Math.random() * 50, y: 100 + Math.random() * 50 },
+        data: {
+          label: targetName,
+          stereotype: isTargetInterface ? 'interface' : 'class',
+          attributes: [],
+          methods: []
+        }
+      });
+    }
+
+    const edgeId = `edge-${sourceName}-${targetName}-${relationType}`.toLowerCase();
+    
+    if (!edgesMap.has(edgeId)) {
+      const visualConfig = edgeConfig.types[relationType] || edgeConfig.types.association;
+      
+      let markerEnd = undefined;
+      
+      if (relationType === 'association' || relationType === 'dependency') {
+         markerEnd = {
+            type: MarkerType.Arrow,
+            width: visualConfig.marker?.width || 20,
+            height: visualConfig.marker?.height || 20,
+            color: visualConfig.style.stroke,
+         };
+      }
+
+      edgesMap.set(edgeId, {
+        id: edgeId,
+        source: sourceId,
+        target: targetId,
+        type: 'umlEdge', 
+        data: {
+          type: relationType,
+        },
+        style: {
+            ...edgeConfig.base.style,
+            ...visualConfig.style
+        },
+        markerEnd: markerEnd
+      });
+    }
+  }
+
+  private static generateNodeId(name: string): string {
+    return `node-${name.toLowerCase()}`;
+  }
+
+  private static isPrimitive(type: string): boolean {
+    const primitives = new Set([
+      'String', 'int', 'Integer', 'boolean', 'Boolean', 
+      'double', 'Double', 'float', 'Float', 'long', 'Long',
+      'char', 'Character', 'byte', 'Byte', 'short', 'Short',
+      'void', 'Object', 'Date', 'LocalDate', 'LocalDateTime', 'List', 'ArrayList'
+    ]);
+    const base = this.extractBaseType(type);
+    return primitives.has(base);
+  }
+
+  private static extractBaseType(type: string): string {
+    let clean = type.trim();
+    clean = clean.replace(/\[\]/g, '');
+    const genericMatch = clean.match(/<(.+)>/);
+    if (genericMatch) {
+      return genericMatch[1]; 
+    }
+    return clean;
+  }
+}

--- a/frontend/src/store/diagramStore.ts
+++ b/frontend/src/store/diagramStore.ts
@@ -59,6 +59,10 @@ interface DiagramStoreState {
   toggleSnapToGrid: () => void;
   toggleShowAllEdges: () => void;
 
+  // --- Import Actions ---
+  setNodes: (nodes: Node<UmlClassData>[]) => void; 
+  setEdges: (edges: Edge[]) => void;               
+
   // --- Node Actions ---
   addNode: (
     position: { x: number; y: number },
@@ -99,6 +103,9 @@ export const useDiagramStore = create<DiagramStoreState>()(
       toggleGrid: () => set((s) => ({ showGrid: !s.showGrid })),
       toggleSnapToGrid: () => set((s) => ({ snapToGrid: !s.snapToGrid })),
       toggleShowAllEdges: () => set((s) => ({ showAllEdges: !s.showAllEdges })),
+
+      setNodes: (nodes) => set({ nodes, isDirty: true }), 
+      setEdges: (edges) => set({ edges, isDirty: true }), 
 
       // --- React Flow Callbacks ---
       onNodesChange: (changes) =>

--- a/frontend/src/store/uiStore.ts
+++ b/frontend/src/store/uiStore.ts
@@ -9,7 +9,9 @@ export type ActiveModal =
   | "export-modal"
   | "engineering-single"
   | "engineering-project"
-  | "engineering-reverse";
+  | "engineering-reverse"
+  | "import-code"
+  | null;
 
 interface UiStoreState {
   // state
@@ -24,11 +26,12 @@ interface UiStoreState {
   openSingleGenerator: () => void;
   openProjectGenerator: () => void;
   openReverseEngineering: () => void;
+  openImportCode: () => void;
   closeModals: () => void;
 }
 
 export const useUiStore = create<UiStoreState>((set) => ({
-  activeModal: "none",
+  activeModal:null,
   editingId: null,
 
   openClassEditor: (nodeId) =>
@@ -44,10 +47,15 @@ export const useUiStore = create<UiStoreState>((set) => ({
 
   openSingleGenerator: () =>
     set({ activeModal: "engineering-single", editingId: null }),
+
   openProjectGenerator: () =>
     set({ activeModal: "engineering-project", editingId: null }),
+
   openReverseEngineering: () =>
     set({ activeModal: "engineering-reverse", editingId: null }),
+
+  openImportCode: () =>
+    set({ activeModal: "import-code", editingId: null }),
 
   closeModals: () => set({ activeModal: "none", editingId: null }),
 }));


### PR DESCRIPTION
- Add 'isMain' detection in JavaParserService to identify entry points.
- Update 'UmlClassNode' to render a 'Play' icon 🟢 on Main classes.
- Inject theme styles (edgeConfig) into imported relationships in ReverseEngineeringService.
- Add 'setNodes' and 'setEdges' to diagramStore for bulk updates.
- Fix TypeScript types and casting in ImportCodeModal.
- Finalize 'Ghost Node' strategy for non-blocking imports.