### PR TITLE
feat(ui): implement Help and Edu menus based on architecture doc

### DIFF
--- a/frontend/src/features/diagram/components/menubar/AppMenubar.tsx
+++ b/frontend/src/features/diagram/components/menubar/AppMenubar.tsx
@@ -14,6 +14,8 @@ import { SettingsMenu } from "./modules/SettingsMenu";
 import { EditMenu } from "./modules/EditMenu";
 import { ExportMenu } from "./modules/ExportMenu";
 import { CodeMenu } from "./modules/CodeMenu";
+import { EduMenu } from "./modules/EduMenu";
+import { HelpMenu } from "./modules/HelpMenu";
 
 export default function AppMenubar() {
   const diagramName = useDiagramStore((s) => s.diagramName);
@@ -42,6 +44,8 @@ export default function AppMenubar() {
               <ViewMenu />  
               <ExportMenu />
               <SettingsMenu />
+              <EduMenu />
+              <HelpMenu />
           </div>
         </div>
 

--- a/frontend/src/features/diagram/components/menubar/modules/EduMenu.tsx
+++ b/frontend/src/features/diagram/components/menubar/modules/EduMenu.tsx
@@ -1,0 +1,53 @@
+import { 
+  GraduationCap, 
+  Award, 
+  CheckCircle2, 
+  Gamepad2, 
+  ScrollText 
+} from "lucide-react";
+import { MenubarTrigger } from "../../../../../components/ui/menubar/MenubarTrigger";
+import { MenubarItem } from "../../../../../components/ui/menubar/MenubarItem";
+
+export function EduMenu() {
+  return (
+    <MenubarTrigger label="Edu">
+      
+      <div className="px-2 py-1.5 text-xs font-semibold text-text-muted select-none">
+        Learning Tools (Coming Soon)
+      </div>
+
+      <MenubarItem
+        label="UML Linter (Auto-grade)"
+        icon={<CheckCircle2 className="w-4 h-4" />}
+        disabled={true} // 🔒 Incoming
+      />
+
+      <MenubarItem
+        label="Exam Mode"
+        icon={<GraduationCap className="w-4 h-4" />}
+        disabled={true} // 🔒 Incoming
+      />
+
+      <div className="h-px bg-surface-border my-1" />
+
+      <MenubarItem
+        label="Achievements"
+        icon={<Award className="w-4 h-4" />}
+        disabled={true} // 🔒 Incoming
+      />
+
+      <MenubarItem
+        label="Keyboard Gamification"
+        icon={<Gamepad2 className="w-4 h-4" />}
+        disabled={true} // 🔒 Incoming
+      />
+
+      <MenubarItem
+        label="Certificates"
+        icon={<ScrollText className="w-4 h-4" />}
+        disabled={true} // 🔒 Incoming
+      />
+
+    </MenubarTrigger>
+  );
+}

--- a/frontend/src/features/diagram/components/menubar/modules/HelpMenu.tsx
+++ b/frontend/src/features/diagram/components/menubar/modules/HelpMenu.tsx
@@ -1,0 +1,58 @@
+import { 
+  BookOpen, 
+  Bug, 
+  Map, 
+  Info, 
+  Rocket 
+} from "lucide-react";
+import { MenubarTrigger } from "../../../../../components/ui/menubar/MenubarTrigger";
+import { MenubarItem } from "../../../../../components/ui/menubar/MenubarItem";
+
+export function HelpMenu() {
+  
+  const openDocs = () => window.open("https://github.com/tu-usuario/LibreUML#readme", "_blank");
+  const reportIssue = () => window.open("https://github.com/tu-usuario/LibreUML/issues", "_blank");
+  const openRoadmap = () => window.open("https://github.com/users/tu-usuario/projects/1", "_blank"); 
+  
+  const showAbout = () => {
+    alert("LibreUML v1.0.0\n\nThe Open Source UML Editor for Students.\nDeveloped with ❤️ in React + Electron.");
+  };
+
+  return (
+    <MenubarTrigger label="Help">
+      
+      <MenubarItem
+        label="Getting Started"
+        icon={<Rocket className="w-4 h-4" />}
+        disabled={true} // 🔒 Incoming
+      />
+
+      <MenubarItem
+        label="Documentation"
+        icon={<BookOpen className="w-4 h-4" />}
+        onClick={openDocs}
+      />
+
+      <MenubarItem
+        label="Report Issue"
+        icon={<Bug className="w-4 h-4" />}
+        onClick={reportIssue}
+      />
+
+      <div className="h-px bg-surface-border my-1" />
+
+      <MenubarItem
+        label="Roadmap"
+        icon={<Map className="w-4 h-4" />}
+        onClick={openRoadmap}
+      />
+
+      <MenubarItem
+        label="About LibreUML"
+        icon={<Info className="w-4 h-4" />}
+        onClick={showAbout}
+      />
+
+    </MenubarTrigger>
+  );
+}


### PR DESCRIPTION
- Add 'EduMenu' module with placeholder features (Linter, Exam Mode) for future release.
- Add 'HelpMenu' with active links to Documentation, Issues, and Roadmap.
- Update 'AppMenubar' to include new modules, completing the VS Code-like layout.
- Finalize top-level UI structure according to UI_ARCHITECTURE.md.