### PR TITLE
feat(i18n): localize engineering, edu and help modules

### DIFF
--- a/frontend/src/features/diagram/components/menubar/modules/CodeMenu.tsx
+++ b/frontend/src/features/diagram/components/menubar/modules/CodeMenu.tsx
@@ -4,13 +4,13 @@ import {
   Upload, 
   Play 
 } from "lucide-react";
-//import { useTranslation } from "react-i18next";
+import { useTranslation } from "react-i18next";
 import { MenubarTrigger } from "../../../../../components/ui/menubar/MenubarTrigger";
 import { MenubarItem } from "../../../../../components/ui/menubar/MenubarItem";
 import { useUiStore } from "../../../../../store/uiStore";
 
 export function CodeMenu() {
-  //const { t } = useTranslation();
+  const { t } = useTranslation();
   
   // Store actions
   const openSingleGenerator = useUiStore((s) => s.openSingleGenerator); 
@@ -18,41 +18,36 @@ export function CodeMenu() {
   const openImportModal = useUiStore((s) => s.openImportCode);
 
   return (
-    <MenubarTrigger label="Code">
-      
-      {/* UML -> Code (Single Class) */}
+   <MenubarTrigger label={t("menubar.code.title")}>
       <MenubarItem
-        label="Generate Class Code..."
+        label={t("menubar.code.generateClass")} 
         icon={<FileCode className="w-4 h-4" />}
         shortcut="Ctrl+G"
-        onClick={openSingleGenerator}
+        onClick={openSingleGenerator} 
       />
 
       {/*  Generate Project (Bulk) */}
       <MenubarItem
-        label="Generate Project (.zip)..."
+        label={t("menubar.code.generateProject")} 
         icon={<Package className="w-4 h-4" />}
         onClick={openProjectGenerator}
       />
-
       <div className="h-px bg-surface-border my-1" />
 
       {/*  Code -> UML (Reverse) */}
       <MenubarItem
-        label="Import Java Code..."
+        label={t("menubar.code.importJava")} 
         icon={<Upload className="w-4 h-4" />}
         onClick={openImportModal}
       />
-
       <div className="h-px bg-surface-border my-1" />
 
       {/* Future Stuff */}
       <MenubarItem
-        label="Live Code Preview"
+        label={t("menubar.code.livePreview")} 
         icon={<Play className="w-4 h-4" />}
         disabled={true} 
       />
-
     </MenubarTrigger>
   );
 }

--- a/frontend/src/features/diagram/components/menubar/modules/EduMenu.tsx
+++ b/frontend/src/features/diagram/components/menubar/modules/EduMenu.tsx
@@ -7,23 +7,25 @@ import {
 } from "lucide-react";
 import { MenubarTrigger } from "../../../../../components/ui/menubar/MenubarTrigger";
 import { MenubarItem } from "../../../../../components/ui/menubar/MenubarItem";
+import { useTranslation } from "react-i18next";
 
 export function EduMenu() {
+  const { t } = useTranslation();
   return (
-    <MenubarTrigger label="Edu">
+    <MenubarTrigger label={t("menubar.edu.title")}>
       
       <div className="px-2 py-1.5 text-xs font-semibold text-text-muted select-none">
         Learning Tools (Coming Soon)
       </div>
 
       <MenubarItem
-        label="UML Linter (Auto-grade)"
+        label={t("menubar.edu.linter")}
         icon={<CheckCircle2 className="w-4 h-4" />}
         disabled={true} // 🔒 Incoming
       />
 
       <MenubarItem
-        label="Exam Mode"
+        label={t("menubar.edu.exam")}
         icon={<GraduationCap className="w-4 h-4" />}
         disabled={true} // 🔒 Incoming
       />
@@ -31,19 +33,19 @@ export function EduMenu() {
       <div className="h-px bg-surface-border my-1" />
 
       <MenubarItem
-        label="Achievements"
+        label={t("menubar.edu.achievements")}
         icon={<Award className="w-4 h-4" />}
         disabled={true} // 🔒 Incoming
       />
 
       <MenubarItem
-        label="Keyboard Gamification"
+        label={t("menubar.edu.gamification")}
         icon={<Gamepad2 className="w-4 h-4" />}
         disabled={true} // 🔒 Incoming
       />
 
       <MenubarItem
-        label="Certificates"
+        label={t("menubar.edu.certificates")}
         icon={<ScrollText className="w-4 h-4" />}
         disabled={true} // 🔒 Incoming
       />

--- a/frontend/src/features/diagram/components/menubar/modules/HelpMenu.tsx
+++ b/frontend/src/features/diagram/components/menubar/modules/HelpMenu.tsx
@@ -7,8 +7,10 @@ import {
 } from "lucide-react";
 import { MenubarTrigger } from "../../../../../components/ui/menubar/MenubarTrigger";
 import { MenubarItem } from "../../../../../components/ui/menubar/MenubarItem";
+import { useTranslation } from "react-i18next";
 
 export function HelpMenu() {
+  const { t } = useTranslation();
   
   const openDocs = () => window.open("https://github.com/tu-usuario/LibreUML#readme", "_blank");
   const reportIssue = () => window.open("https://github.com/tu-usuario/LibreUML/issues", "_blank");
@@ -19,22 +21,22 @@ export function HelpMenu() {
   };
 
   return (
-    <MenubarTrigger label="Help">
+    <MenubarTrigger label={t("menubar.help.title")}>
       
       <MenubarItem
-        label="Getting Started"
+        label={t("menubar.help.gettingStarted")}
         icon={<Rocket className="w-4 h-4" />}
         disabled={true} // 🔒 Incoming
       />
 
       <MenubarItem
-        label="Documentation"
+        label={t("menubar.help.documentation")}
         icon={<BookOpen className="w-4 h-4" />}
         onClick={openDocs}
       />
 
       <MenubarItem
-        label="Report Issue"
+        label={t("menubar.help.reportIssue")}
         icon={<Bug className="w-4 h-4" />}
         onClick={reportIssue}
       />
@@ -42,13 +44,13 @@ export function HelpMenu() {
       <div className="h-px bg-surface-border my-1" />
 
       <MenubarItem
-        label="Roadmap"
+        label={t("menubar.help.roadmap")}
         icon={<Map className="w-4 h-4" />}
         onClick={openRoadmap}
       />
 
       <MenubarItem
-        label="About LibreUML"
+        label={t("menubar.help.about")}
         icon={<Info className="w-4 h-4" />}
         onClick={showAbout}
       />

--- a/frontend/src/features/diagram/components/modals/ImportCodeModal.tsx
+++ b/frontend/src/features/diagram/components/modals/ImportCodeModal.tsx
@@ -3,6 +3,7 @@ import type { ChangeEvent } from "react";
 import { Upload, FileText, Code, AlertCircle, X } from "lucide-react";
 import { useDiagramStore } from "../../../../store/diagramStore";
 import { ReverseEngineeringService } from "../../../../services/reverseEngineering.service";
+import { useTranslation } from "react-i18next";
 // Import types for casting
 import type {
   UmlClassNode,
@@ -19,6 +20,9 @@ interface Props {
 type Tab = "upload" | "paste";
 
 export default function ImportCodeModal({ isOpen, onClose }: Props) {
+
+  const {t} = useTranslation();
+
   const [activeTab, setActiveTab] = useState<Tab>("upload");
   const [code, setCode] = useState("");
   const [fileName, setFileName] = useState<string | null>(null);
@@ -101,9 +105,9 @@ export default function ImportCodeModal({ isOpen, onClose }: Props) {
               <Upload className="w-5 h-5" />
             </div>
             <div>
-              <h3 className="font-bold text-text-primary">Import Java Code</h3>
+              <h3 className="font-bold text-text-primary">{t("modals.importCode.title")}</h3>
               <p className="text-xs text-text-muted">
-                Reverse engineering: Java to UML
+                {t("modals.importCode.subtitle")}
               </p>
             </div>
           </div>
@@ -121,13 +125,13 @@ export default function ImportCodeModal({ isOpen, onClose }: Props) {
             onClick={() => setActiveTab("upload")}
             className={`flex-1 py-3 text-sm font-medium flex items-center justify-center gap-2 transition-colors ${activeTab === "upload" ? "bg-surface-primary text-green-400 border-b-2 border-green-400" : "bg-surface-secondary/30 text-text-secondary hover:text-text-primary"}`}
           >
-            <FileText className="w-4 h-4" /> Upload File
+            <FileText className="w-4 h-4" /> {t("modals.importCode.tabUpload")}
           </button>
           <button
             onClick={() => setActiveTab("paste")}
             className={`flex-1 py-3 text-sm font-medium flex items-center justify-center gap-2 transition-colors ${activeTab === "paste" ? "bg-surface-primary text-green-400 border-b-2 border-green-400" : "bg-surface-secondary/30 text-text-secondary hover:text-text-primary"}`}
           >
-            <Code className="w-4 h-4" /> Paste Code
+            <Code className="w-4 h-4" /> {t("modals.importCode.tabPaste")}
           </button>
         </div>
 
@@ -155,7 +159,7 @@ export default function ImportCodeModal({ isOpen, onClose }: Props) {
                   </div>
                   <div className="text-center">
                     <p className="text-text-primary font-medium">{fileName}</p>
-                    <p className="text-sm text-green-400">Ready to import</p>
+                    <p className="text-sm text-green-400">{t("modals.importCode.ready")}</p>
                   </div>
                 </>
               ) : (
@@ -165,10 +169,10 @@ export default function ImportCodeModal({ isOpen, onClose }: Props) {
                   </div>
                   <div className="text-center space-y-1">
                     <p className="text-text-primary font-medium">
-                      Click to upload or drag & drop
+                      {t("modals.importCode.dragDropTitle")}
                     </p>
                     <p className="text-xs text-text-muted">
-                      Supports .java files
+                      {t("modals.importCode.dragDropSubtitle")}
                     </p>
                   </div>
                 </>
@@ -178,7 +182,7 @@ export default function ImportCodeModal({ isOpen, onClose }: Props) {
             <div className="h-full flex flex-col gap-2">
               <textarea
                 className="w-full h-75 bg-surface-secondary border border-surface-border rounded-lg p-4 font-mono text-xs text-text-primary outline-none focus:border-green-500/50 resize-none"
-                placeholder="Paste your Java class code here..."
+                placeholder={t("modals.importCode.placeholder") || "Paste your Java code here..."}
                 value={code}
                 onChange={(e) => setCode(e.target.value)}
                 spellCheck={false}
@@ -200,7 +204,7 @@ export default function ImportCodeModal({ isOpen, onClose }: Props) {
             onClick={onClose}
             className="px-4 py-2 text-sm text-text-secondary hover:text-text-primary"
           >
-            Cancel
+            {t("modals.common.cancel")}
           </button>
           <button
             onClick={handleImport}
@@ -208,10 +212,10 @@ export default function ImportCodeModal({ isOpen, onClose }: Props) {
             className="flex items-center gap-2 px-6 py-2 bg-green-600 text-white rounded hover:bg-green-500 font-medium shadow-md active:scale-95 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {isProcessing ? (
-              "Analyzing..."
+              t("modals.importCode.analyzing")
             ) : (
               <>
-                <Upload className="w-4 h-4" /> Import Class
+                <Upload className="w-4 h-4" /> {t("modals.importCode.importBtn")}
               </>
             )}
           </button>

--- a/frontend/src/features/diagram/components/modals/ProjectGeneratorModal.tsx
+++ b/frontend/src/features/diagram/components/modals/ProjectGeneratorModal.tsx
@@ -3,6 +3,7 @@ import { Package, Download, Box, Hammer, Coffee } from "lucide-react";
 import { useDiagramStore } from "../../../../store/diagramStore";
 import { ProjectZipperService } from "../../../../services/project-zipper.service";
 import type { UmlClassNode } from "../../types/diagram.types";
+import { useTranslation } from "react-i18next";
 
 interface Props {
   isOpen: boolean;
@@ -12,6 +13,7 @@ interface Props {
 export default function ProjectGeneratorModal({ isOpen, onClose }: Props) {
   const nodes = useDiagramStore((s) => s.nodes);
   const diagramName = useDiagramStore((s) => s.diagramName);
+  const { t } = useTranslation();
   
   // --- State  ---
   const [groupId, setGroupId] = useState("com.example");
@@ -30,7 +32,6 @@ export default function ProjectGeneratorModal({ isOpen, onClose }: Props) {
 
   const classNodes = nodes.filter(n => n.type === 'umlClass') as UmlClassNode[];
 
-  // Calculamos el paquete en tiempo real
   const packageName = `${groupId}.${artifactId}`.replace(/\.\./g, ".").toLowerCase();
 
   if (!isOpen) return null;
@@ -66,8 +67,8 @@ export default function ProjectGeneratorModal({ isOpen, onClose }: Props) {
             <Package className="w-5 h-5" />
           </div>
           <div>
-            <h3 className="font-bold text-text-primary">Generate Project</h3>
-            <p className="text-xs text-text-muted">Export structure ready for IDEs</p>
+            <h3 className="font-bold text-text-primary">{t("modals.projectGenerator.title")}</h3>
+            <p className="text-xs text-text-muted">{t("modals.projectGenerator.subtitle")}</p>
           </div>
         </div>
 
@@ -78,11 +79,11 @@ export default function ProjectGeneratorModal({ isOpen, onClose }: Props) {
           <div className="flex items-center justify-between p-3 bg-surface-secondary/30 rounded-lg border border-surface-border">
              <div className="flex items-center gap-2 text-sm text-text-secondary">
                 <Box className="w-4 h-4 text-purple-400" />
-                <span className="font-mono">{classNodes.length} Classes</span>
+                <span className="font-mono">{classNodes.length} {t("modals.projectGenerator.statsClasses")}</span>
              </div>
              <div className="w-px h-4 bg-surface-border" />
              <div className="flex items-center gap-2 text-sm text-text-secondary">
-                 <span className="text-xs text-text-muted">Target Package:</span>
+                 <span className="text-xs text-text-muted">{t("modals.projectGenerator.statsPackage")}:</span>
                  <span className="font-mono text-purple-300">{packageName}</span>
              </div>
           </div>
@@ -91,7 +92,7 @@ export default function ProjectGeneratorModal({ isOpen, onClose }: Props) {
              {/* Left Col: Identifiers */}
              <div className="space-y-4">
                  <div className="space-y-1">
-                   <label className="text-xs font-bold text-text-secondary uppercase">Group ID</label>
+                   <label className="text-xs font-bold text-text-secondary uppercase">{t("modals.projectGenerator.groupId")}</label>
                    <input 
                      className="w-full bg-surface-secondary border border-surface-border rounded p-2 text-sm font-mono text-text-primary focus:border-purple-500 outline-none transition-colors"
                      value={groupId}
@@ -101,7 +102,7 @@ export default function ProjectGeneratorModal({ isOpen, onClose }: Props) {
                  </div>
                  
                  <div className="space-y-1">
-                   <label className="text-xs font-bold text-text-secondary uppercase">Artifact ID</label>
+                   <label className="text-xs font-bold text-text-secondary uppercase">{t("modals.projectGenerator.artifactId")}</label>
                    <input 
                      className="w-full bg-surface-secondary border border-surface-border rounded p-2 text-sm font-mono text-text-primary focus:border-purple-500 outline-none transition-colors"
                      value={artifactId}
@@ -116,7 +117,7 @@ export default function ProjectGeneratorModal({ isOpen, onClose }: Props) {
                 {/* Build Tool Selector */}
                 <div className="space-y-1">
                    <label className="text-xs font-bold text-text-secondary uppercase flex items-center gap-1">
-                      <Hammer className="w-3 h-3" /> Build System
+                      <Hammer className="w-3 h-3" /> {t("modals.projectGenerator.buildSystem")}
                    </label>
                    <div className="grid grid-cols-2 gap-2">
                       <button
@@ -137,7 +138,7 @@ export default function ProjectGeneratorModal({ isOpen, onClose }: Props) {
                 {/* Java Version Selector */}
                 <div className="space-y-1">
                    <label className="text-xs font-bold text-text-secondary uppercase flex items-center gap-1">
-                      <Coffee className="w-3 h-3" /> Java Version
+                      <Coffee className="w-3 h-3" /> {t("modals.projectGenerator.javaVersion")}
                    </label>
                    <select
                      value={javaVersion}
@@ -157,16 +158,16 @@ export default function ProjectGeneratorModal({ isOpen, onClose }: Props) {
         {/* Footer */}
         <div className="px-6 py-4 border-t border-surface-border bg-surface-secondary/50 flex justify-end gap-3">
           <button onClick={onClose} className="px-4 py-2 text-sm text-text-secondary hover:text-text-primary">
-             Cancel
+            {t("modals.common.cancel")}
           </button>
           <button 
             onClick={handleGenerate}
             disabled={isGenerating}
             className="flex items-center gap-2 px-6 py-2 bg-purple-600 text-white rounded hover:bg-purple-500 font-medium shadow-md active:scale-95 transition-all disabled:opacity-50"
           >
-            {isGenerating ? "Zipping..." : (
+            {isGenerating ? t("modals.projectGenerator.zipping") : (
                <>
-                 <Download className="w-4 h-4" /> Download .zip
+                 <Download className="w-4 h-4" /> {t("modals.projectGenerator.download")}
                </>
             )}
           </button>

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -67,6 +67,30 @@
       "image": "Image (PNG/SVG)...",
       "pdf": "Export PDF (Soon)",
       "github": "Publish to GitHub"
+    },
+    "code": {
+      "title": "Code",
+      "generateClass": "Generate Class Code...",
+      "generateProject": "Generate Project (.zip)...",
+      "importJava": "Import Java Code...",
+      "livePreview": "Live Code Preview"
+    },
+    "edu": {
+      "title": "Edu",
+      "placeholder": "Learning Tools (Soon)",
+      "linter": "UML Linter (Auto-grade)",
+      "exam": "Exam Mode",
+      "achievements": "Achievements",
+      "gamification": "Keyboard Gamification",
+      "certificates": "Certificates"
+    },
+    "help": {
+      "title": "Help",
+      "gettingStarted": "Getting Started",
+      "documentation": "Documentation",
+      "reportIssue": "Report Issue",
+      "roadmap": "Roadmap",
+      "about": "About LibreUML"
     }
   },
   "sidebar": {
@@ -188,6 +212,32 @@
       "svgTip": "If the file looks empty or broken, try opening the .svg file in a web browser (Chrome, Edge, Firefox).",
       "dontShowAgain": "Don't show this warning again",
       "wait": "Read this"
+    },
+    "importCode": {
+      "title": "Import Java Code",
+      "subtitle": "Reverse engineering: Java to UML",
+      "tabUpload": "Upload File",
+      "tabPaste": "Paste Code",
+      "dragDropTitle": "Click to upload or drag & drop",
+      "dragDropSubtitle": "Supports .java files",
+      "ready": "Ready to import",
+      "placeholder": "Paste your Java class code here...",
+      "analyzing": "Analyzing...",
+      "importBtn": "Import Class",
+      "errorExt": "Please upload a valid .java file",
+      "errorEmpty": "No code to import"
+    },
+    "projectGenerator": {
+      "title": "Generate Project",
+      "subtitle": "Export structure ready for IDEs",
+      "statsClasses": "Classes",
+      "statsPackage": "Target Package",
+      "groupId": "GROUP ID",
+      "artifactId": "ARTIFACT ID",
+      "buildSystem": "BUILD SYSTEM",
+      "javaVersion": "JAVA VERSION",
+      "zipping": "Zipping...",
+      "download": "Download .zip"
     }
   },
   "alerts": {

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -67,6 +67,30 @@
       "image": "Imagen (PNG/SVG)...",
       "pdf": "Exportar PDF (Pronto)",
       "github": "Publicar en GitHub"
+    },
+    "code": {
+      "title": "Código",
+      "generateClass": "Generar Código de Clase...",
+      "generateProject": "Generar Proyecto (.zip)...",
+      "importJava": "Importar Código Java...",
+      "livePreview": "Vista Previa en Vivo"
+    },
+    "edu": {
+      "title": "Edu",
+      "placeholder": "Herramientas (Pronto)",
+      "linter": "Linter UML (Auto-calificar)",
+      "exam": "Modo Examen",
+      "achievements": "Logros",
+      "gamification": "Gamificación Teclado",
+      "certificates": "Certificados"
+    },
+    "help": {
+      "title": "Ayuda",
+      "gettingStarted": "Primeros Pasos",
+      "documentation": "Documentación",
+      "reportIssue": "Reportar Error",
+      "roadmap": "Hoja de Ruta",
+      "about": "Acerca de LibreUML"
     }
   },
   "sidebar": {
@@ -188,6 +212,32 @@
       "svgTip": "Si el archivo se ve vacío o roto, intenta abrir el .svg en tu navegador web (Chrome, Edge, Firefox).",
       "dontShowAgain": "No mostrar este aviso de nuevo",
       "wait": "Lee esto"
+    },
+    "importCode": {
+      "title": "Importar Código Java",
+      "subtitle": "Ingeniería inversa: Java a UML",
+      "tabUpload": "Subir Archivo",
+      "tabPaste": "Pegar Código",
+      "dragDropTitle": "Clic para subir o arrastra y suelta",
+      "dragDropSubtitle": "Soporta archivos .java",
+      "ready": "Listo para importar",
+      "placeholder": "Pega tu código de clase Java aquí...",
+      "analyzing": "Analizando...",
+      "importBtn": "Importar Clase",
+      "errorExt": "Por favor sube un archivo .java válido",
+      "errorEmpty": "No hay código para importar"
+    },
+    "projectGenerator": {
+      "title": "Generar Proyecto",
+      "subtitle": "Exportar estructura lista para IDEs",
+      "statsClasses": "Clases",
+      "statsPackage": "Paquete Destino",
+      "groupId": "GROUP ID",
+      "artifactId": "ARTIFACT ID",
+      "buildSystem": "SISTEMA DE CONSTRUCCIÓN",
+      "javaVersion": "VERSIÓN JAVA",
+      "zipping": "Comprimiendo...",
+      "download": "Descargar .zip"
     }
   },
   "alerts": {


### PR DESCRIPTION
- Update 'en.json' and 'es.json' with full translation keys for Code, Edu, Help, and Modals.
- Refactor 'CodeMenu', 'EduMenu', and 'HelpMenu' to use 'useLanguage' hook.
- Implement dynamic translation in 'ImportCodeModal' and 'ProjectGeneratorModal'.
- Ensure UI consistency across languages (English/Spanish) for all new features.