### PR TITLE
feat(diagram): implement semantic validation and toast feedback

### DIFF
--- a/src/features/diagram/components/layout/DiagramEditor.tsx
+++ b/src/features/diagram/components/layout/DiagramEditor.tsx
@@ -2,6 +2,8 @@ import { ReactFlowProvider } from "reactflow";
 import DiagramCanvas from "./DiagramCanvas";
 import Sidebar from "./Sidebar";
 import AppMenubar from "../menubar/AppMenubar";
+import Toast from "../../../../components/shared/Toast";
+import { useDiagramStore } from "../../../../store/diagramStore";
 
 import { useAutoSave } from "../../../../hooks/useAutosave";
 import { useAutoRestore } from "../../../../hooks/useAutoRestore";
@@ -13,6 +15,9 @@ function DiagramManager() {
 }
 
 function EditorLogic() {
+  const activeToast = useDiagramStore((s) => s.activeToast);
+  const dismissToast = useDiagramStore((s) => s.dismissToast);
+
   return (
     <div className="flex flex-col w-screen h-screen overflow-hidden bg-gray-50">
       <DiagramManager />
@@ -26,6 +31,15 @@ function EditorLogic() {
           <DiagramCanvas />
         </div>
       </div>
+
+      {activeToast && (
+        <Toast 
+          message={activeToast.message}
+          type={activeToast.type}
+          onClose={dismissToast} 
+          duration={3000}
+        />
+      )}
     </div>
   );
 }

--- a/src/util/connectionValidator.ts
+++ b/src/util/connectionValidator.ts
@@ -1,0 +1,75 @@
+import type { stereotype, UmlRelationType } from "../features/diagram/types/diagram.types";
+
+/**
+ * Definition of allowed relationships based on UML 2.5 standards and Java semantics.
+ * Key: The relationship type.
+ * Value: A set of rules defining valid source and target stereotypes.
+ */
+const RELATIONSHIP_RULES: Record<
+  UmlRelationType,
+  {
+    sources: stereotype[];
+    targets: stereotype[];
+    validator?: (source: stereotype, target: stereotype) => boolean;
+  }
+> = {
+  inheritance: {
+    // Class extends Class, Interface extends Interface
+    sources: ["class", "abstract", "interface"],
+    targets: ["class", "abstract", "interface"],
+    validator: (source, target) => {
+      const isSourceInterface = source === "interface";
+      const isTargetInterface = target === "interface";
+      return isSourceInterface === isTargetInterface;
+    },
+  },
+  implementation: {
+    sources: ["class", "abstract", "enum"],
+    targets: ["interface"],
+  },
+  association: {
+    sources: ["class", "abstract", "interface", "enum"],
+    targets: ["class", "abstract", "interface", "enum"],
+  },
+  dependency: {
+    sources: ["class", "abstract", "interface", "enum"],
+    targets: ["class", "abstract", "interface", "enum"],
+  },
+  aggregation: {
+    sources: ["class", "abstract", "interface", "enum"],
+    targets: ["class", "abstract", "interface", "enum"],
+  },
+  composition: {
+    sources: ["class", "abstract", "interface", "enum"],
+    targets: ["class", "abstract", "interface", "enum"],
+  },
+};
+
+/**
+ * Validates if a connection is semantically correct according to UML rules.
+ * @param sourceStereotype The stereotype of the source node.
+ * @param targetStereotype The stereotype of the target node.
+ * @param relationType The type of relationship being attempted.
+ * @returns {boolean} True if the connection is valid, false otherwise.
+ */
+export const validateConnection = (
+  sourceStereotype: stereotype,
+  targetStereotype: stereotype,
+  relationType: UmlRelationType
+): boolean => {
+  if (sourceStereotype === "note" || targetStereotype === "note") return true;
+
+  const rule = RELATIONSHIP_RULES[relationType];
+  if (!rule) return false;
+
+  const validSource = rule.sources.includes(sourceStereotype);
+  const validTarget = rule.targets.includes(targetStereotype);
+
+  if (!validSource || !validTarget) return false;
+
+  if (rule.validator) {
+    return rule.validator(sourceStereotype, targetStereotype);
+  }
+
+  return true;
+};


### PR DESCRIPTION
- Add 'connectionValidator.ts' to enforce UML 2.5 relationship rules (e.g., prevent Interface extending Class).
- Integrate validation logic into 'diagramStore.onConnect'.
- Implement Toast notification system to alert users of invalid connections.
- Refactor 'UmlMarkers.tsx' to use MutationObserver for better theme synchronization.
- BLOCKER: Invalid semantic connections are now rejected by the engine.