### PR TITLE
feat(diagram): enable Web persistence, Enum support and Code Preview

### DIFF
--- a/src/features/diagram/components/layout/Sidebar.tsx
+++ b/src/features/diagram/components/layout/Sidebar.tsx
@@ -4,6 +4,7 @@ import {
   CircleDot,
   BoxSelect,
   StickyNote,
+  List,
   ArrowUpRight,
   GitCommitHorizontal,
   ArrowUp,
@@ -112,6 +113,16 @@ export default function Sidebar() {
               }
               label={t("sidebar.nodes.abstract")}
               color="var(--color-uml-abstract-border)"
+              isExpanded={isExpanded}
+              onDragStart={onDragStart}
+            />
+            <DraggableItem
+              type="enum" 
+              icon={
+                <List className={isExpanded ? "w-5 h-5" : "w-6 h-6"} />
+              }
+              label="Enum" 
+              color="#A855F7" 
               isExpanded={isExpanded}
               onDragStart={onDragStart}
             />

--- a/src/features/diagram/components/menubar/modules/FileMenu.tsx
+++ b/src/features/diagram/components/menubar/modules/FileMenu.tsx
@@ -40,6 +40,15 @@ export function FileMenu({ actions }: FileMenuProps) {
     });
   };
 
+  // --- LOGIC: SAVE BUTTONS STATE ---
+  const isElectron = !!window.electronAPI?.isElectron();
+
+  // Save: Disabled in Electron if no file path (forces Save As). Enabled in Web (Download).
+  const isSaveDisabled = isElectron ? !hasFilePath : false;
+
+  // Save As: Disabled in Web (Browser handles downloads via 'Save').
+  const isSaveAsDisabled = !isElectron;
+
   return (
     <>
       <input
@@ -72,13 +81,14 @@ export function FileMenu({ actions }: FileMenuProps) {
           icon={<Save className="w-4 h-4" />}
           shortcut="Ctrl+S"
           onClick={handleSave}
-          disabled={!hasFilePath} 
+          disabled={isSaveDisabled} 
         />
         <MenubarItem
           label={t("menubar.file.saveAs") || "Save As..."}
           icon={<FileOutput className="w-4 h-4" />}
           shortcut="Ctrl+Shift+S"
           onClick={handleSaveAs}
+          disabled={isSaveAsDisabled} 
         />
 
         <MenubarItem

--- a/src/features/diagram/components/modals/SingleClassGeneratorModal.tsx
+++ b/src/features/diagram/components/modals/SingleClassGeneratorModal.tsx
@@ -1,7 +1,9 @@
-import { useState, useEffect } from "react";
-import { Package, Download, Box, Hammer, Coffee } from "lucide-react";
+import { useState, useEffect, useMemo } from "react";
+import { Copy, Check, FileCode, X } from "lucide-react";
+import { useTranslation } from "react-i18next";
 import { useDiagramStore } from "../../../../store/diagramStore";
-import { ProjectZipperService } from "../../../../services/project-zipper.service";
+import { useUiStore } from "../../../../store/uiStore";
+import { JavaGeneratorService } from "../../../../services/javaGenerator.service";
 import type { UmlClassNode } from "../../types/diagram.types";
 
 interface Props {
@@ -9,169 +11,171 @@ interface Props {
   onClose: () => void;
 }
 
-export default function ProjectGeneratorModal({ isOpen, onClose }: Props) {
+export default function SingleClassGeneratorModal({ isOpen, onClose }: Props) {
+  const { t } = useTranslation();
   const nodes = useDiagramStore((s) => s.nodes);
-  const diagramName = useDiagramStore((s) => s.diagramName);
+  const editingId = useUiStore((s) => s.editingId); 
   
-  // --- ESTADOS ---
-  // 1. Configuración Básica
-  const [groupId, setGroupId] = useState("com.example");
-  const [artifactId, setArtifactId] = useState("");
-  
-  // 2. Configuración Avanzada (NUEVO)
-  const [javaVersion, setJavaVersion] = useState("17");
-  const [buildTool, setBuildTool] = useState<"maven" | "gradle">("maven");
-  
-  const [isGenerating, setIsGenerating] = useState(false);
+  const [selectedClassId, setSelectedClassId] = useState<string>("");
+  const [language, setLanguage] = useState("java"); // State for language
+  const [generatedCode, setGeneratedCode] = useState("");
+  const [copied, setCopied] = useState(false);
 
-  // Inicializar artifactId al abrir
+  //  Determine target class priority
   useEffect(() => {
-    if (isOpen) {
-      const cleanName = diagramName.toLowerCase().replace(/[^a-z0-9]/g, "");
-      setArtifactId(cleanName || "myproject");
+    if (!isOpen) {
+        // eslint-disable-next-line react-hooks/set-state-in-effect
+        setGeneratedCode("");
+        setCopied(false);
+        setLanguage("java"); 
+        return;
     }
-  }, [isOpen, diagramName]);
 
-  // Filtrar nodos válidos
-  const classNodes = nodes.filter(n => n.type === 'umlClass') as UmlClassNode[];
+    let targetId = "";
 
-  // Cálculo dinámico del paquete (GroupId + ArtifactId)
-  const packageName = `${groupId}.${artifactId}`.replace(/\.\./g, ".").toLowerCase();
+    if (editingId) {
+        targetId = editingId;
+    } else {
+        const selectedNodes = nodes.filter(n => n.selected && n.type === 'umlClass');
+        if (selectedNodes.length === 1) {
+            targetId = selectedNodes[0].id;
+        } else if (nodes.length > 0) {
+            const firstClass = nodes.find(n => n.type === 'umlClass');
+            if (firstClass) targetId = firstClass.id;
+        }
+    }
+    
+    setSelectedClassId(targetId);
+  }, [isOpen, editingId, nodes]);
+
+  //  Generate Code logic
+  useEffect(() => {
+    if (!selectedClassId) {
+        // eslint-disable-next-line react-hooks/set-state-in-effect
+        setGeneratedCode("// " + t('modals.codePreview.noClassSelected', "No class selected"));
+        return;
+    }
+
+    const node = nodes.find(n => n.id === selectedClassId) as UmlClassNode;
+    if (node && node.type === 'umlClass') {
+        if (language === 'java') {
+            const code = JavaGeneratorService.generate(node);
+            setGeneratedCode(code);
+        } else {
+            setGeneratedCode("// Coming soon...");
+        }
+    } else {
+        setGeneratedCode("// " + t('modals.codePreview.invalidNode', "Selected node is not a valid Class/Interface"));
+    }
+  }, [selectedClassId, nodes, language, t]);
+
+  const allClasses = useMemo(() => 
+    nodes.filter(n => n.type === 'umlClass') as UmlClassNode[], 
+  [nodes]);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(generatedCode);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
 
   if (!isOpen) return null;
 
-  const handleGenerate = async () => {
-    setIsGenerating(true);
-    try {
-      await ProjectZipperService.generateAndDownloadZip({
-        projectName: artifactId, 
-        groupId,
-        artifactId,
-        packageName, 
-        nodes: classNodes,
-        javaVersion, 
-        buildTool    
-      });
-      onClose();
-    } catch (error) {
-      console.error(error);
-      alert("Error generating project");
-    } finally {
-      setIsGenerating(false);
-    }
-  };
-
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm animate-in fade-in">
-      <div className="bg-surface-primary border border-surface-border rounded-xl shadow-2xl w-137.5 overflow-hidden">
+      <div className="bg-surface-primary border border-surface-border rounded-xl shadow-2xl w-150 flex flex-col max-h-[85vh]">
         
         {/* Header */}
-        <div className="px-6 py-4 border-b border-surface-border bg-surface-secondary/50 flex items-center gap-3">
-          <div className="p-2 bg-purple-500/20 rounded-lg text-purple-400">
-            <Package className="w-5 h-5" />
+        <div className="px-6 py-4 border-b border-surface-border flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <div className="p-2 bg-blue-500/20 rounded-lg text-blue-400">
+                <FileCode className="w-5 h-5" />
+            </div>
+            <div>
+                <h3 className="font-bold text-text-primary">{t('modals.codePreview.title', 'Code Preview')}</h3>
+                <p className="text-xs text-text-muted">{t('modals.codePreview.subtitle', 'Generate code for a single class')}</p>
+            </div>
           </div>
-          <div>
-            <h3 className="font-bold text-text-primary">Generate Project</h3>
-            <p className="text-xs text-text-muted">Export structure ready for IDEs</p>
-          </div>
+          <button onClick={onClose} className="text-text-secondary hover:text-text-primary">
+            <X className="w-5 h-5" />
+          </button>
         </div>
 
-        {/* Body */}
-        <div className="p-6 space-y-6">
-          
-          {/* Stats Bar */}
-          <div className="flex items-center justify-between p-3 bg-surface-secondary/30 rounded-lg border border-surface-border">
-             <div className="flex items-center gap-2 text-sm text-text-secondary">
-                <Box className="w-4 h-4 text-purple-400" />
-                <span className="font-mono">{classNodes.length} Classes</span>
-             </div>
-             <div className="w-px h-4 bg-surface-border" />
-             <div className="flex items-center gap-2 text-sm text-text-secondary">
-                 <span className="text-xs text-text-muted">Target Package:</span>
-                 <span className="font-mono text-purple-300">{packageName}</span>
-             </div>
-          </div>
+        {/* Toolbar: Selectors */}
+        <div className="px-6 py-3 border-b border-surface-border bg-surface-secondary/30 flex items-center gap-4">
+            
+            {/* Language Selector */}
+            <div className="flex items-center gap-2">
+                <label className="text-xs font-bold text-text-secondary uppercase">
+                    {t('modals.codePreview.languageLabel', 'Language:')}
+                </label>
+                <select 
+                    className="bg-surface-secondary border border-surface-border rounded px-2 py-1 text-sm text-text-primary outline-none focus:border-blue-500"
+                    value={language}
+                    onChange={(e) => setLanguage(e.target.value)}
+                >
+                    <option value="java">Java</option>
+                    <option value="python" disabled>Python (Soon)</option>
+                    <option value="csharp" disabled>C# (Soon)</option>
+                    <option value="sql" disabled>SQL (Soon)</option>
+                </select>
+            </div>
 
-          <div className="grid grid-cols-2 gap-4">
-             {/* Left Col: Identifiers */}
-             <div className="space-y-4">
-                 <div className="space-y-1">
-                   <label className="text-xs font-bold text-text-secondary uppercase">Group ID</label>
-                   <input 
-                     className="w-full bg-surface-secondary border border-surface-border rounded p-2 text-sm font-mono text-text-primary focus:border-purple-500 outline-none transition-colors"
-                     value={groupId}
-                     onChange={e => setGroupId(e.target.value)}
-                     placeholder="com.example"
-                   />
-                 </div>
-                 
-                 <div className="space-y-1">
-                   <label className="text-xs font-bold text-text-secondary uppercase">Artifact ID</label>
-                   <input 
-                     className="w-full bg-surface-secondary border border-surface-border rounded p-2 text-sm font-mono text-text-primary focus:border-purple-500 outline-none transition-colors"
-                     value={artifactId}
-                     onChange={e => setArtifactId(e.target.value)}
-                     placeholder="myapp"
-                   />
-                 </div>
-             </div>
+            <div className="w-px h-4 bg-surface-border" />
 
-             {/* Right Col: Tech Stack */}
-             <div className="space-y-4">
-                {/* Build Tool Selector */}
-                <div className="space-y-1">
-                   <label className="text-xs font-bold text-text-secondary uppercase flex items-center gap-1">
-                      <Hammer className="w-3 h-3" /> Build System
-                   </label>
-                   <div className="grid grid-cols-2 gap-2">
-                      <button
-                        onClick={() => setBuildTool("maven")}
-                        className={`text-xs py-2 rounded border transition-all ${buildTool === 'maven' ? 'bg-purple-600 border-purple-600 text-white' : 'bg-surface-secondary border-surface-border text-text-muted hover:border-text-secondary'}`}
-                      >
-                        Maven
-                      </button>
-                      <button
-                        onClick={() => setBuildTool("gradle")}
-                        className={`text-xs py-2 rounded border transition-all ${buildTool === 'gradle' ? 'bg-purple-600 border-purple-600 text-white' : 'bg-surface-secondary border-surface-border text-text-muted hover:border-text-secondary'}`}
-                      >
-                        Gradle
-                      </button>
-                   </div>
-                </div>
+            {/* Class Selector */}
+            <div className="flex items-center gap-2 flex-1">
+                <label className="text-xs font-bold text-text-secondary uppercase">
+                    {t('modals.codePreview.classLabel', 'Class:')}
+                </label>
+                <select 
+                    className="bg-surface-secondary border border-surface-border rounded px-2 py-1 text-sm text-text-primary outline-none focus:border-blue-500 w-full"
+                    value={selectedClassId}
+                    onChange={(e) => setSelectedClassId(e.target.value)}
+                >
+                    {allClasses.map(node => (
+                        <option key={node.id} value={node.id}>
+                            {node.data.label} {node.data.stereotype !== 'class' ? `(${node.data.stereotype})` : ''}
+                        </option>
+                    ))}
+                </select>
+            </div>
+        </div>
 
-                {/* Java Version Selector */}
-                <div className="space-y-1">
-                   <label className="text-xs font-bold text-text-secondary uppercase flex items-center gap-1">
-                      <Coffee className="w-3 h-3" /> Java Version
-                   </label>
-                   <select
-                     value={javaVersion}
-                     onChange={(e) => setJavaVersion(e.target.value)}
-                     className="w-full bg-surface-secondary border border-surface-border rounded p-2 text-sm font-mono text-text-primary focus:border-purple-500 outline-none"
-                   >
-                     <option value="21">Java 21 (LTS)</option>
-                     <option value="17">Java 17 (LTS)</option>
-                     <option value="11">Java 11 (LTS)</option>
-                     <option value="8">Java 8</option>
-                   </select>
-                </div>
-             </div>
-          </div>
+        {/* Code Viewer */}
+        <div className="flex-1 overflow-auto p-0 bg-[#1e1e1e] custom-scrollbar group relative">
+            <pre className="p-6 text-sm font-mono text-gray-300 leading-relaxed">
+                {generatedCode}
+            </pre>
+            
+            <button 
+                onClick={handleCopy}
+                className="absolute top-4 right-4 p-2 bg-surface-primary/10 border border-white/10 rounded hover:bg-white/10 text-white transition-all opacity-0 group-hover:opacity-100"
+                title={t('modals.codePreview.copyTitle', "Copy to clipboard")}
+            >
+                {copied ? <Check className="w-4 h-4 text-green-400" /> : <Copy className="w-4 h-4" />}
+            </button>
         </div>
 
         {/* Footer */}
         <div className="px-6 py-4 border-t border-surface-border bg-surface-secondary/50 flex justify-end gap-3">
-          <button onClick={onClose} className="px-4 py-2 text-sm text-text-secondary hover:text-text-primary">
-             Cancel
+          <button 
+            onClick={onClose} 
+            className="px-4 py-2 text-sm text-text-secondary hover:text-text-primary"
+          >
+             {t('modals.codePreview.close', 'Close')}
           </button>
           <button 
-            onClick={handleGenerate}
-            disabled={isGenerating}
-            className="flex items-center gap-2 px-6 py-2 bg-purple-600 text-white rounded hover:bg-purple-500 font-medium shadow-md active:scale-95 transition-all disabled:opacity-50"
+            onClick={handleCopy}
+            className="flex items-center gap-2 px-6 py-2 bg-blue-600 text-white rounded hover:bg-blue-500 font-medium shadow-md active:scale-95 transition-all"
           >
-            {isGenerating ? "Zipping..." : (
+            {copied ? (
                <>
-                 <Download className="w-4 h-4" /> Download .zip
+                 <Check className="w-4 h-4" /> {t('modals.codePreview.copied', 'Copied!')}
+               </>
+            ) : (
+               <>
+                 <Copy className="w-4 h-4" /> {t('modals.codePreview.copy', 'Copy Code')}
                </>
             )}
           </button>

--- a/src/features/diagram/components/nodes/uml/UmlClassNode.tsx
+++ b/src/features/diagram/components/nodes/uml/UmlClassNode.tsx
@@ -31,15 +31,15 @@ const STYLE_CONFIG: Record<
     showStereotype: true,
   },
   enum: {
-    // Preparing for future Enum support (Clean Code foresight)
-    container: "bg-purple-50 border-purple-300",
-    header: "bg-purple-100 border-purple-300",
-    badgeColor: "text-purple-500",
+    container:
+      "bg-purple-100 dark:bg-purple-900/20 border-purple-400 dark:border-purple-500",
+    header:
+      "bg-purple-200 dark:bg-purple-900/50 border-purple-400 dark:border-purple-500",
+    badgeColor: "text-purple-700 dark:text-purple-300",
     labelFormat: "font-bold",
     showStereotype: true,
   },
   class: {
-    // Default fallback
     container: "bg-uml-class-bg border-uml-class-border",
     header: "bg-surface-hover border-uml-class-border",
     badgeColor: "text-uml-class-border",

--- a/src/features/diagram/hooks/useDiagramMenus.ts
+++ b/src/features/diagram/hooks/useDiagramMenus.ts
@@ -2,6 +2,7 @@ import { useCallback } from "react";
 import { useReactFlow } from "reactflow";
 import { useTranslation } from "react-i18next";
 import { useDiagramStore } from "../../../store/diagramStore";
+import { useUiStore } from "../../../store/uiStore"; 
 import type { UmlRelationType } from "../types/diagram.types";
 
 export type ContextMenuType = "pane" | "node" | "edge";
@@ -26,6 +27,8 @@ export const useDiagramMenus = ({
 }: UseDiagramMenusProps) => {
   const { screenToFlowPosition } = useReactFlow();
   const { t } = useTranslation();
+  
+  const openSingleGenerator = useUiStore((s) => s.openSingleGenerator);
 
   const {
     addNode,
@@ -34,7 +37,8 @@ export const useDiagramMenus = ({
     reverseEdge,
     changeEdgeType,
     deleteEdge,
-    edges, 
+    edges,
+    nodes, 
   } = useDiagramStore();
 
   const getMenuOptions = useCallback(
@@ -76,7 +80,10 @@ export const useDiagramMenus = ({
       if (menu.type === "node" && menu.id) {
         const nodeId = menu.id; 
         
-        return [
+        const node = nodes.find(n => n.id === nodeId);
+        const isClassType = node?.type === 'umlClass';
+
+        const baseOptions = [
           { 
             label: t('contextMenu.node.duplicate'), 
             onClick: () => duplicateNode(nodeId) 
@@ -85,12 +92,21 @@ export const useDiagramMenus = ({
             label: t('contextMenu.node.edit'),
             onClick: () => onEditNode(nodeId),
           },
-          { 
+        ];
+
+        if (isClassType) {
+            baseOptions.push({
+                label: t('contextMenu.node.generateCode'),
+                onClick: () => openSingleGenerator(nodeId),
+            });
+        }
+
+        baseOptions.push({ 
             label: t('contextMenu.node.delete'), 
             onClick: () => deleteNode(nodeId), 
-            danger: true 
-          },
-        ];
+        });
+
+        return baseOptions;
       }
 
       // Edge Menu
@@ -174,10 +190,12 @@ export const useDiagramMenus = ({
       changeEdgeType,
       deleteEdge,
       edges,
+      nodes, 
       onClearCanvas,
       onEditNode,
       onEditEdgeMultiplicity,
       screenToFlowPosition,
+      openSingleGenerator,
       t
     ]
   );

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -130,7 +130,8 @@
     "node": {
       "duplicate": "Duplicate",
       "edit": "Edit Properties",
-      "delete": "Delete"
+      "delete": "Delete",
+      "generateCode": "Generate Code..."
     },
     "edge": {
       "reverse": "Reverse Direction ⇄",
@@ -238,6 +239,18 @@
       "javaVersion": "JAVA VERSION",
       "zipping": "Zipping...",
       "download": "Download .zip"
+    },
+   "codePreview": {
+      "title": "Code Preview",
+      "subtitle": "Generate code for a single class",
+      "languageLabel": "Language:",
+      "classLabel": "Class:",
+      "copyTitle": "Copy to clipboard",
+      "close": "Close",
+      "copy": "Copy Code",
+      "copied": "Copied!",
+      "noClassSelected": "No class selected",
+      "invalidNode": "Selected node is not a valid Class/Interface"
     }
   },
   "alerts": {

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -130,7 +130,8 @@
     "node": {
       "duplicate": "Duplicar",
       "edit": "Editar Propiedades",
-      "delete": "Eliminar"
+      "delete": "Eliminar",
+      "generateCode": "Generar Código..."
     },
     "edge": {
       "reverse": "Invertir Dirección ⇄",
@@ -238,7 +239,19 @@
       "javaVersion": "VERSIÓN JAVA",
       "zipping": "Comprimiendo...",
       "download": "Descargar .zip"
-    }
+    },
+    "codePreview": {
+    "title": "Vista Previa de Código",
+    "subtitle": "Generar código para una clase individual",
+    "languageLabel": "Lenguaje:",
+    "classLabel": "Clase:",
+    "copyTitle": "Copiar al portapapeles",
+    "close": "Cerrar",
+    "copy": "Copiar Código",
+    "copied": "¡Copiado!",
+    "noClassSelected": "No hay clase seleccionada",
+    "invalidNode": "El nodo seleccionado no es una Clase/Interfaz válida"
+  }
   },
   "alerts": {
     "exportError": "No se pudo generar la imagen. Intenta de nuevo.",

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -23,7 +23,7 @@ interface UiStoreState {
   openMultiplicityEditor: (edgeId: string) => void;
   openClearConfirmation: () => void;
   openExportModal: () => void;
-  openSingleGenerator: () => void;
+  openSingleGenerator: (nodeId?: string) => void; 
   openProjectGenerator: () => void;
   openReverseEngineering: () => void;
   openImportCode: () => void;
@@ -45,8 +45,8 @@ export const useUiStore = create<UiStoreState>((set) => ({
 
   openExportModal: () => set({ activeModal: "export-modal", editingId: null }),
 
-  openSingleGenerator: () =>
-    set({ activeModal: "engineering-single", editingId: null }),
+  openSingleGenerator: (nodeId?: string) =>
+    set({ activeModal: "engineering-single", editingId: nodeId || null }),
 
   openProjectGenerator: () =>
     set({ activeModal: "engineering-project", editingId: null }),


### PR DESCRIPTION
- Fix: Enable 'Save' action in Web environment (browser download) and disable 'Save As'.
- Feat: Add 'Enum' node support to Sidebar with drag-and-drop capability.
- UI: Implement distinct visual styling for Enum nodes with full Dark Mode support.
- Feat: Add 'Generate Java Code' context menu action for Class nodes.
- Refactor: Update SingleClassGeneratorModal to display interactive code preview instead of zip download.
- Feat: Add language selector to Code Preview modal (Java enabled, others placeholders).
- Chore: Update English and Spanish translations for the new Code Preview interface.