### PR TITLE
feat(ssot): SSOT editing, node hydration, and sidebar fixes

### DIFF
--- a/src/components/shared/ToastContainer.tsx
+++ b/src/components/shared/ToastContainer.tsx
@@ -1,0 +1,32 @@
+import { createPortal } from "react-dom";
+import { X, Info } from "lucide-react";
+import { useToastStore } from "../../store/toast.store";
+
+export default function ToastContainer() {
+  const toasts = useToastStore((s) => s.toasts);
+  const dismiss = useToastStore((s) => s.dismiss);
+
+  if (toasts.length === 0) return null;
+
+  return createPortal(
+    <div className="fixed bottom-8 right-6 z-[9999] flex flex-col gap-2 pointer-events-none">
+      {toasts.map((t) => (
+        <div
+          key={t.id}
+          className="flex items-start gap-3 bg-[#1a2235] border border-[#2d3f5c] text-slate-300 text-xs px-4 py-3 rounded-lg shadow-2xl pointer-events-auto w-80"
+        >
+          <Info className="w-3.5 h-3.5 shrink-0 mt-0.5 text-blue-400" />
+          <span className="flex-1 leading-relaxed">{t.message}</span>
+          <button
+            onClick={() => dismiss(t.id)}
+            className="shrink-0 text-slate-600 hover:text-slate-300 transition-colors -mt-0.5"
+            title="Dismiss"
+          >
+            <X className="w-3.5 h-3.5" />
+          </button>
+        </div>
+      ))}
+    </div>,
+    document.body,
+  );
+}

--- a/src/features/diagram/components/layout/BottomTerminal.tsx
+++ b/src/features/diagram/components/layout/BottomTerminal.tsx
@@ -1,0 +1,44 @@
+import { Terminal, PanelBottomClose } from "lucide-react";
+import { useLayoutStore } from "../../../../store/layout.store";
+
+export default function BottomTerminal() {
+  const { toggleBottomPanel } = useLayoutStore();
+
+  return (
+    <div className="h-48 border-t border-surface-border bg-[#0d1117] flex flex-col">
+      {/* Title bar */}
+      <div
+        className="px-4 py-2 border-b border-[#1e2738] shrink-0 flex items-center justify-between select-none cursor-default group"
+        onDoubleClick={toggleBottomPanel}
+      >
+        <div className="flex items-center gap-2">
+          <Terminal className="w-3.5 h-3.5 text-[#64748b]" />
+          <span className="text-xs font-semibold uppercase tracking-wider text-[#64748b]">
+            Terminal
+          </span>
+        </div>
+        <button
+          onClick={(e) => { e.stopPropagation(); toggleBottomPanel(); }}
+          className="p-1 rounded transition-colors opacity-0 group-hover:opacity-100 hover:bg-[#1e2738]"
+          title="Close Panel"
+        >
+          <PanelBottomClose className="w-3.5 h-3.5 text-[#64748b]" />
+        </button>
+      </div>
+
+      {/* Body */}
+      <div className="flex-1 px-4 py-3 font-mono overflow-y-auto">
+        <p className="text-sm text-[#4ade80] mb-2">
+          &gt;_ Terminal{" "}
+          <span className="text-[#334155]">(Coming Soon)</span>
+        </p>
+        <p className="text-xs text-[#334155] leading-relaxed">
+          Available commands will include:{" "}
+          <span className="text-[#475569]">
+            /errors, /warnings, login, cloud, cd...
+          </span>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/features/diagram/components/layout/DiagramCanvas.tsx
+++ b/src/features/diagram/components/layout/DiagramCanvas.tsx
@@ -4,6 +4,8 @@ import ReactFlow, {
   MiniMap,
   BackgroundVariant,
   ConnectionMode,
+  type Node,
+  type Edge,
 } from "reactflow";
 import "reactflow/dist/style.css";
 import { useRef, useEffect, useCallback, useMemo } from "react";
@@ -12,12 +14,13 @@ import { useProjectStore } from "../../../../store/project.store";
 import { useSettingsStore } from "../../../../store/settingsStore";
 import { useWorkspaceStore } from "../../../../store/workspace.store";
 import { useVFSStore } from "../../../../store/vfs.store";
-import { useModelStore } from "../../../../store/model.store";
 import { useDiagram } from "../../../workspace/hooks/useDiagram";
 import { canvasConfig, miniMapColors } from "../../../../config/theme.config";
 import { getDiagramRegistry } from "../../../../core/registry/diagram-registry";
+import type { RelationKind } from "../../../../core/domain/vfs/vfs.types";
+import type { AssociationEdge, AggregationEdge, CompositionEdge } from "../../../../core/domain/models/edges";
+import type { ClassDiagramMetadata } from "../../../../core/domain/workspace/diagram-file.types";
 
-// Components (Modals only - node/edge components now come from registry)
 import ContextMenu from "../ui/ContextMenu";
 import ClassEditorModal from "../modals/ClassEditorModal";
 import ConfirmationModal from "../../../../components/shared/ConfirmationModal";
@@ -25,7 +28,6 @@ import SpotlightModal from "../modals/SpotlightModal";
 import MultiplicityModal from "../modals/MultiplicityModal";
 import MethodGeneratorModal from "../modals/MethodGeneratorModal";
 
-// Hooks
 import { useContextMenu } from "../../hooks/useContextMenu";
 import { useDiagramDnD } from "../../hooks/useDiagramDnD";
 import { useVFSCanvasController } from "../../hooks/useVFSCanvasController";
@@ -43,10 +45,9 @@ import ImportCodeModal from "../modals/ImportCodeModal";
 export default function DiagramCanvas() {
   const { t } = useTranslation();
 
-  // === NEW: Use Integration Hook (SSOT Architecture) ===
   const {
     nodes: legacyNodes,
-    edges: _edges, // Renamed to indicate intentionally unused
+    edges: _edges,
     onNodesChange,
     onEdgesChange,
     onConnect,
@@ -54,23 +55,13 @@ export default function DiagramCanvas() {
     isReady,
   } = useDiagram();
 
-  // === VFS Canvas Controller (3-layer architecture) ===
-  // Provides tab isolation and semantic-model-driven rendering for VFS .luml files.
   const vfsController = useVFSCanvasController();
 
-  // Select the correct node/edge source based on whether the active tab is a VFS file.
-  // ISOLATION: nodes are always derived exclusively from the active tab's content.
   const nodes = vfsController.isVFSFile ? vfsController.nodes : legacyNodes;
-
-  // Canvas is ready either when the legacy system is ready OR when a VFS file is active.
   const isCanvasReady = isReady || vfsController.isVFSFile;
 
-  // PHASE 3: Get diagram type and registry.
-  // VFS DiagramType has many variants; getDiagramRegistry only supports 'CLASS_DIAGRAM' | 'USE_CASE_DIAGRAM'.
-  // Always fall back to 'CLASS_DIAGRAM' for unsupported VFS diagram types.
   const diagramType = file?.diagramType ?? 'CLASS_DIAGRAM';
   const registry = useMemo(() => {
-    // Determine effective type: prefer legacy file type, else try VFS file type, then default.
     const vfsDiagramType = vfsController.vfsFile?.diagramType;
     const effectiveType =
       vfsDiagramType === 'CLASS_DIAGRAM' || vfsDiagramType === 'USE_CASE_DIAGRAM'
@@ -78,22 +69,18 @@ export default function DiagramCanvas() {
         : diagramType;
     try {
       return getDiagramRegistry(effectiveType);
-    } catch (error) {
-      console.error('Failed to get diagram registry:', error);
-      return getDiagramRegistry('CLASS_DIAGRAM'); // Fallback
+    } catch {
+      return getDiagramRegistry('CLASS_DIAGRAM');
     }
   }, [diagramType, vfsController.vfsFile]);
 
-  // PHASE 3: Extract node and edge components from registry
   const nodeTypes = useMemo(() => registry.nodeComponents, [registry]);
   const edgeTypes = useMemo(() => registry.edgeComponents, [registry]);
 
-  // === Settings (UI Preferences from SettingsStore) ===
   const showMiniMap = useSettingsStore((s) => s.showMiniMap);
   const showGrid = useSettingsStore((s) => s.showGrid);
   const snapToGrid = useSettingsStore((s) => s.snapToGrid);
 
-  // === Domain Data Accessors (ProjectStore) ===
   const updateNode = useProjectStore((s) => s.updateNode);
   const updateEdge = useProjectStore((s) => s.updateEdge);
   const getNode = useProjectStore((s) => s.getNode);
@@ -101,36 +88,30 @@ export default function DiagramCanvas() {
   const removeNode = useProjectStore((s) => s.removeNode);
   const removeEdge = useProjectStore((s) => s.removeEdge);
 
-  // === Workspace Actions ===
   const removeNodeFromFile = useWorkspaceStore((s) => s.removeNodeFromFile);
   const removeEdgeFromFile = useWorkspaceStore((s) => s.removeEdgeFromFile);
   const updateFile = useWorkspaceStore((s) => s.updateFile);
   const markFileDirty = useWorkspaceStore((s) => s.markFileDirty);
 
-  // --- UI STATE (Modals & Interactions) ---
-  const { 
-    activeModal, 
-    editingId, 
-    openClassEditor, 
-    openMultiplicityEditor, 
+  const {
+    activeModal,
+    editingId,
+    openClassEditor,
+    openMultiplicityEditor,
     openClearConfirmation,
     openMethodGenerator,
-    closeModals 
+    openSSoTClassEditor,
+    closeModals
   } = useUiStore();
 
-  // === Fetch editing entities from ProjectStore ===
   const editingNode = editingId ? getNode(editingId) : undefined;
   const editingEdge = editingId ? getEdge(editingId) : undefined;
 
-  // Ref for Drag & Drop
   const nodesRef = useRef(nodes);
   useEffect(() => {
     nodesRef.current = nodes;
   }, [nodes]);
 
-  // Route onNodesChange to the correct handler:
-  // - VFS files: useVFSCanvasController's handler (persists x,y to VFS; deletes from ModelStore)
-  // - Legacy files: useDiagram's handler (persists to WorkspaceStore positionMap / ProjectStore)
   const effectiveOnNodesChange = vfsController.isVFSFile
     ? vfsController.onNodesChange
     : onNodesChange;
@@ -143,24 +124,12 @@ export default function DiagramCanvas() {
     ? vfsController.onConnect
     : onConnect;
 
-  // Functional Hooks
   useKeyboardShortcuts();
   const { displayEdges, setHoveredNodeId, setHoveredEdgeId } = useEdgeStyling();
   const { onDragOver, onDrop } = useDiagramDnD();
 
-  // Bug 1 fix: VFS-aware clear canvas.
   const clearCanvas = useCallback(() => {
-    // VFS path: cascade-delete semantic elements + wipe DiagramView.
     if (vfsController.isVFSFile && vfsController.diagramView && vfsController.activeTabId) {
-      const ms = useModelStore.getState();
-      if (ms.model) {
-        vfsController.diagramView.nodes.forEach((vn) => {
-          if (!vn.elementId) return; // Skip notes (no semantic backing)
-          if (ms.model!.classes[vn.elementId]) ms.deleteClass(vn.elementId);
-          else if (ms.model!.interfaces[vn.elementId]) ms.deleteInterface(vn.elementId);
-          else if (ms.model!.enums[vn.elementId]) ms.deleteEnum(vn.elementId);
-        });
-      }
       useVFSStore.getState().updateFileContent(vfsController.activeTabId, {
         ...vfsController.diagramView,
         nodes: [],
@@ -169,7 +138,6 @@ export default function DiagramCanvas() {
       return;
     }
 
-    // Legacy path (unchanged).
     if (!file) return;
 
     const nodeIds = [...file.nodeIds];
@@ -187,38 +155,52 @@ export default function DiagramCanvas() {
 
     updateFile(file.id, {
       metadata: {
-        ...file.metadata,
+        ...(file.metadata as ClassDiagramMetadata | undefined),
         positionMap: {},
-      } as any,
+      } as ClassDiagramMetadata,
     });
 
     markFileDirty(file.id);
   }, [vfsController, file, removeEdgeFromFile, removeEdge, removeNodeFromFile, removeNode, updateFile, markFileDirty]);
 
-  // VFS edge operations — translate legacy type string → IRRelation.kind.
-  // useDiagramMenus calls onChangeEdgeKind with 'INHERITANCE', 'IMPLEMENTATION', etc.
-  // (legacy DomainEdge.type vocabulary); map those to IRRelation.kind strings.
-  const VFS_TYPE_TO_RELATION_KIND: Record<string, string> = {
-    ASSOCIATION:    'ASSOCIATION',
-    INHERITANCE:    'GENERALIZATION',
-    IMPLEMENTATION: 'REALIZATION',
-    DEPENDENCY:     'DEPENDENCY',
-    AGGREGATION:    'AGGREGATION',
-    COMPOSITION:    'COMPOSITION',
+  const VFS_TYPE_TO_RELATION_KIND: Record<string, RelationKind> = {
+    ASSOCIATION: "ASSOCIATION",
+    INHERITANCE: "GENERALIZATION",
+    IMPLEMENTATION: "REALIZATION",
+    DEPENDENCY: "DEPENDENCY",
+    AGGREGATION: "AGGREGATION",
+    COMPOSITION: "COMPOSITION",
   };
 
   const { getMenuOptions } = useDiagramMenus({
-    onEditNode: (id) => openClassEditor(id),
+    onEditNode: vfsController.isVFSFile
+      ? (nodeId) => {
+          const viewNode = vfsController.diagramView?.nodes.find(
+            (vn) => vn.id === nodeId,
+          );
+          if (viewNode?.elementId) openSSoTClassEditor(viewNode.elementId);
+        }
+      : (id) => openClassEditor(id),
     onClearCanvas: () => openClearConfirmation(),
     onEditEdgeMultiplicity: (id) => openMultiplicityEditor(id),
     onGenerateMethods: (id) => openMethodGenerator(id),
-    onDeleteNode:          vfsController.isVFSFile ? vfsController.removeNodeFromDiagram  : undefined,
-    onDeleteNodeFromModel: vfsController.isVFSFile ? vfsController.deleteElementFromModel : undefined,
-    onDeleteEdge:          vfsController.isVFSFile ? vfsController.deleteEdgeById         : undefined,
-    onReverseEdge:     vfsController.isVFSFile ? vfsController.reverseEdgeById : undefined,
-    onChangeEdgeKind:  vfsController.isVFSFile
+    onDeleteNode: vfsController.isVFSFile
+      ? vfsController.removeNodeFromDiagram
+      : undefined,
+    onDeleteNodeFromModel: vfsController.isVFSFile
+      ? vfsController.deleteElementFromModel
+      : undefined,
+    onDeleteEdge: vfsController.isVFSFile
+      ? vfsController.deleteEdgeById
+      : undefined,
+    onReverseEdge: vfsController.isVFSFile
+      ? vfsController.reverseEdgeById
+      : undefined,
+    onChangeEdgeKind: vfsController.isVFSFile
       ? (edgeId, legacyType) => {
-          const kind = (VFS_TYPE_TO_RELATION_KIND[legacyType] ?? legacyType) as any;
+          const kind =
+            VFS_TYPE_TO_RELATION_KIND[legacyType] ??
+            (legacyType as RelationKind);
           vfsController.changeEdgeKind(edgeId, kind);
         }
       : undefined,
@@ -234,10 +216,8 @@ export default function DiagramCanvas() {
   
   useThemeSystem();
   
-  // History Logic on Drag
   const { onNodeDragStart, onNodeDragStop } = useNodeDragging();
 
-  // === Loading State ===
   if (!isCanvasReady) {
     return (
       <div className="flex w-full h-full items-center justify-center bg-canvas-base">
@@ -249,24 +229,21 @@ export default function DiagramCanvas() {
   return (
     <div className="w-full h-full bg-canvas-base">
       <ReactFlow
-        nodes={nodes as any}
-        edges={(vfsController.isVFSFile ? vfsController.edges : displayEdges) as any}
+        nodes={nodes as Node[]}
+        edges={(vfsController.isVFSFile ? vfsController.edges : displayEdges) as Edge[]}
         onNodesChange={effectiveOnNodesChange}
         onEdgesChange={effectiveOnEdgesChange}
         onConnect={effectiveOnConnect}
         nodeTypes={nodeTypes}
         edgeTypes={edgeTypes}
-        // Hover Interaction
         onNodeMouseEnter={(_, node) => setHoveredNodeId(node.id)}
         onNodeMouseLeave={() => setHoveredNodeId(null)}
         onEdgeMouseEnter={(_, edge) => setHoveredEdgeId(edge.id)}
         onEdgeMouseLeave={() => setHoveredEdgeId(null)}
-        // Context Menus
         onPaneContextMenu={onPaneContextMenu}
         onNodeContextMenu={onNodeContextMenu}
         onEdgeContextMenu={onEdgeContextMenu}
         onPaneClick={closeMenu}
-        // Drag & Drop
         onDragOver={onDragOver}
         onDrop={onDrop}
         onNodeDragStart={onNodeDragStart}
@@ -295,15 +272,10 @@ export default function DiagramCanvas() {
             className="shadow-2xl rounded-lg overflow-hidden border border-surface-border bg-surface-primary bottom-4! right-4!"
             maskColor="rgba(11, 15, 26, 0.7)"
             nodeColor={(node) => {
-              // Note: node.type in ReactFlow view is the component type (umlClass, umlNote)
-              // node.data contains the domain node data
               if (node.type === "umlNote") return miniMapColors.note;
-              
-              // Access domain node type from node.data
-              const domainType = (node.data as any)?.type;
+              const domainType = node.data.type;
               if (domainType === "INTERFACE") return miniMapColors.interface;
               if (domainType === "ABSTRACT_CLASS") return miniMapColors.abstract;
-              
               return miniMapColors.class;
             }}
           />
@@ -325,9 +297,8 @@ export default function DiagramCanvas() {
           key={editingId}
           isOpen={true}
           umlData={
-            // Map domain node to modal's expected format
-            editingNode.type === 'CLASS' || 
-            editingNode.type === 'INTERFACE' || 
+            editingNode.type === 'CLASS' ||
+            editingNode.type === 'INTERFACE' ||
             editingNode.type === 'ABSTRACT_CLASS'
               ? {
                   label: editingNode.name,
@@ -356,7 +327,6 @@ export default function DiagramCanvas() {
           }
           onClose={closeModals}
           onSave={(newData) => {
-            // Map modal data back to domain node structure
             if (editingNode.type === 'CLASS' || editingNode.type === 'ABSTRACT_CLASS') {
               updateNode(editingNode.id, {
                 name: newData.label,
@@ -387,17 +357,17 @@ export default function DiagramCanvas() {
         <MultiplicityModal
           isOpen={true}
           initialSource={
-            (editingEdge.type === 'ASSOCIATION' || 
-             editingEdge.type === 'AGGREGATION' || 
+            (editingEdge.type === 'ASSOCIATION' ||
+             editingEdge.type === 'AGGREGATION' ||
              editingEdge.type === 'COMPOSITION')
-              ? (editingEdge as any).sourceMultiplicity || ""
+              ? (editingEdge as AssociationEdge | AggregationEdge | CompositionEdge).sourceMultiplicity ?? ""
               : ""
           }
           initialTarget={
-            (editingEdge.type === 'ASSOCIATION' || 
-             editingEdge.type === 'AGGREGATION' || 
+            (editingEdge.type === 'ASSOCIATION' ||
+             editingEdge.type === 'AGGREGATION' ||
              editingEdge.type === 'COMPOSITION')
-              ? (editingEdge as any).targetMultiplicity || ""
+              ? (editingEdge as AssociationEdge | AggregationEdge | CompositionEdge).targetMultiplicity ?? ""
               : ""
           }
           onClose={closeModals}
@@ -405,7 +375,7 @@ export default function DiagramCanvas() {
             updateEdge(editingEdge.id, {
               sourceMultiplicity: source,
               targetMultiplicity: target,
-            } as any);
+            } as Partial<AssociationEdge>);
             closeModals();
           }}
         />

--- a/src/features/diagram/components/layout/DiagramEditor.tsx
+++ b/src/features/diagram/components/layout/DiagramEditor.tsx
@@ -4,20 +4,28 @@ import DiagramCanvas from "./DiagramCanvas";
 import AppMenubar from "../menubar/AppMenubar";
 import ActivityBar, { type ActivityTab } from "./ActivityBar";
 import PrimarySideBar from "./PrimarySideBar";
+import RightSidebar from "./RightSidebar";
+import BottomTerminal from "./BottomTerminal";
 import StatusBar from "./StatusBar";
 import TabBar from "./TabBar";
 import WelcomeScreen from "../../../workspace/components/WelcomeScreen";
 import SleepScreen from "../../../workspace/components/SleepScreen";
+import SSoTElementEditorModal from "../modals/SSoTElementEditorModal";
+import SSoTClassEditorModal from "../modals/SSoTClassEditorModal";
+import GlobalDeleteModal from "../modals/GlobalDeleteModal";
+import ToastContainer from "../../../../components/shared/ToastContainer";
 import { useAutoSave } from "../../../../hooks/actions/useAutoSave";
 import { useAutoRestore } from "../../../../hooks/useAutoRestore";
 import { useThemeSystem } from "../../../../hooks/useThemeSystem";
 import { useVFSStore } from "../../../../store/vfs.store";
 import { useWorkspaceStore } from "../../../../store/workspace.store";
+import { useLayoutStore } from "../../../../store/layout.store";
 
 function EditorLogic() {
   const [activeTab, setActiveTab] = useState<ActivityTab>("structure");
   const { project } = useVFSStore();
   const activeTabId = useWorkspaceStore((s) => s.activeTabId);
+  const { isLeftPanelOpen, isRightPanelOpen, isBottomPanelOpen } = useLayoutStore();
 
   useAutoSave();
   useAutoRestore();
@@ -35,19 +43,56 @@ function EditorLogic() {
     <div className="flex flex-col w-screen h-screen overflow-hidden bg-gray-50">
       <AppMenubar />
 
-      <div className="flex flex-1 overflow-hidden">
+      <div className="flex flex-1 overflow-hidden min-h-0">
         <ActivityBar activeTab={activeTab} onTabChange={setActiveTab} />
-        <PrimarySideBar activeTab={activeTab} />
 
-        <div className="flex-1 flex flex-col relative bg-slate-50 min-w-0">
+        {/* ── Left panel (slides in/out) ─────────────────────────────── */}
+        <div
+          className={`h-full overflow-hidden transition-all duration-200 ease-in-out shrink-0 min-w-0 ${
+            isLeftPanelOpen ? "w-64" : "w-0"
+          }`}
+        >
+          <PrimarySideBar activeTab={activeTab} />
+        </div>
+
+        {/* ── Center column: tabs + canvas + bottom terminal ─────────── */}
+        <div className="flex-1 flex flex-col min-w-0 overflow-hidden bg-slate-50">
           <TabBar />
-          <div className="flex-1 overflow-hidden">
-            {activeTabId ? <DiagramCanvas /> : <SleepScreen />}
+
+          {/* Canvas row: diagram + right sidebar */}
+          <div className="flex flex-1 min-h-0 overflow-hidden">
+            <div className="flex-1 overflow-hidden">
+              {activeTabId ? <DiagramCanvas /> : <SleepScreen />}
+            </div>
+
+            {/* ── Right sidebar (slides in/out) ───────────────────────── */}
+            <div
+              className={`overflow-hidden transition-all duration-200 ease-in-out shrink-0 ${
+                isRightPanelOpen ? "w-64" : "w-0"
+              }`}
+            >
+              <RightSidebar />
+            </div>
+          </div>
+
+          {/* ── Bottom terminal (slides in/out) ─────────────────────── */}
+          <div
+            className={`overflow-hidden transition-all duration-200 ease-in-out shrink-0 ${
+              isBottomPanelOpen ? "h-48" : "h-0"
+            }`}
+          >
+            <BottomTerminal />
           </div>
         </div>
       </div>
 
       <StatusBar />
+
+      {/* ── VFS-native modals (portal-rendered, outside layout tree) ──── */}
+      <SSoTElementEditorModal />
+      <SSoTClassEditorModal />
+      <GlobalDeleteModal />
+      <ToastContainer />
     </div>
   );
 }

--- a/src/features/diagram/components/layout/PrimarySideBar.tsx
+++ b/src/features/diagram/components/layout/PrimarySideBar.tsx
@@ -11,14 +11,14 @@ export default function PrimarySideBar({ activeTab }: PrimarySideBarProps) {
   if (!activeTab) return null;
 
   return (
-    <div className="w-64 border-r border-surface-border bg-surface-primary flex flex-col z-10 shadow-xl">
+    <div className="w-full h-full border-r border-surface-border bg-surface-primary flex flex-col overflow-hidden">
       {activeTab === "structure" && <ProjectStructure />}
       {activeTab === "packages" && <PackageExplorer />}
       {activeTab === "tools" && <ToolPalette />}
-      {activeTab === "profile" && <div className="p-4 text-text-secondary">User profile coming soon</div>}
-      {activeTab === "cloud" && <div className="p-4 text-text-secondary">Cloud sync coming soon</div>}
-      {activeTab === "github" && <div className="p-4 text-text-secondary">GitHub integration coming soon</div>}
-      {activeTab === "bug" && <div className="p-4 text-text-secondary">Bug report coming soon</div>}
+      {activeTab === "profile" && <div className="flex-1 p-4 text-text-secondary">User profile coming soon</div>}
+      {activeTab === "cloud" && <div className="flex-1 p-4 text-text-secondary">Cloud sync coming soon</div>}
+      {activeTab === "github" && <div className="flex-1 p-4 text-text-secondary">GitHub integration coming soon</div>}
+      {activeTab === "bug" && <div className="flex-1 p-4 text-text-secondary">Bug report coming soon</div>}
     </div>
   );
 }

--- a/src/features/diagram/components/layout/ProjectStructure.tsx
+++ b/src/features/diagram/components/layout/ProjectStructure.tsx
@@ -13,54 +13,18 @@ import {
   Edit2,
   Info,
   Edit3,
-  List,
+  CheckCheck,
+  PanelLeftClose,
 } from "lucide-react";
 import { useVFSStore } from "../../../../store/vfs.store";
 import { useWorkspaceStore } from "../../../../store/workspace.store";
-import { useModelStore } from "../../../../store/model.store";
+import { useLayoutStore } from "../../../../store/layout.store";
 import CreateFileModal from "./CreateFileModal";
 import CreateFolderModal from "./CreateFolderModal";
 import ViewDescriptionModal from "./ViewDescriptionModal";
 import type { VFSFolder, VFSFile } from "../../../../core/domain/vfs/vfs.types";
 
 type VFSNode = VFSFolder | VFSFile;
-
-// ─── Type badge (VS Code–style inline symbol kind indicator) ─────────────────
-
-function ElementBadge({
-  kind,
-  isAbstract,
-}: {
-  kind: "CLASS" | "INTERFACE" | "ENUM";
-  isAbstract?: boolean;
-}) {
-  if (kind === "CLASS" && isAbstract) {
-    return (
-      <span className="inline-flex items-center justify-center w-4 h-4 rounded text-[9px] font-bold bg-indigo-400/10 text-indigo-400 shrink-0">
-        A
-      </span>
-    );
-  }
-  if (kind === "CLASS") {
-    return (
-      <span className="inline-flex items-center justify-center w-4 h-4 rounded text-[9px] font-bold bg-blue-400/10 text-blue-400 shrink-0">
-        C
-      </span>
-    );
-  }
-  if (kind === "INTERFACE") {
-    return (
-      <span className="inline-flex items-center justify-center w-4 h-4 rounded text-[9px] font-bold bg-violet-400/10 text-violet-400 shrink-0">
-        I
-      </span>
-    );
-  }
-  return (
-    <span className="inline-flex items-center justify-center w-4 h-4 rounded text-[9px] font-bold bg-amber-400/10 text-amber-400 shrink-0">
-      E
-    </span>
-  );
-}
 
 // ─── Context menu state ───────────────────────────────────────────────────────
 
@@ -272,7 +236,7 @@ function TreeItem({
 export default function ProjectStructure() {
   const { project, deleteNode, renameNode } = useVFSStore();
   const { openTab } = useWorkspaceStore();
-  const model = useModelStore((s) => s.model);
+  const { toggleLeftPanel } = useLayoutStore();
 
   const [expandedFolders, setExpandedFolders] = useState<Set<string>>(new Set());
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
@@ -287,20 +251,8 @@ export default function ProjectStructure() {
   const [viewDescriptionNode, setViewDescriptionNode] = useState<{ name: string; description: string } | null>(null);
   const [createFileParentId, setCreateFileParentId] = useState<string | null>(null);
   const [createFolderParentId, setCreateFolderParentId] = useState<string | null>(null);
-  const [isOutlineExpanded, setIsOutlineExpanded] = useState(true);
+  const [isLocalFilesExpanded, setIsLocalFilesExpanded] = useState(true);
   const inputRef = useRef<HTMLInputElement>(null);
-
-  // ── Outline data (derived from SemanticModel) ──────────────────────────────
-  const classes = model
-    ? Object.values(model.classes).sort((a, b) => a.name.localeCompare(b.name))
-    : [];
-  const interfaces = model
-    ? Object.values(model.interfaces).sort((a, b) => a.name.localeCompare(b.name))
-    : [];
-  const enums = model
-    ? Object.values(model.enums).sort((a, b) => a.name.localeCompare(b.name))
-    : [];
-  const outlineCount = classes.length + interfaces.length + enums.length;
 
   useEffect(() => {
     const handleClickOutside = () => setContextMenu(null);
@@ -460,13 +412,23 @@ export default function ProjectStructure() {
   if (!project || !project.nodes) {
     return (
       <div className="flex flex-col h-full bg-surface-primary overflow-hidden">
-        <div className="px-4 py-3 border-b border-surface-border shrink-0">
+        <div
+          className="px-4 py-3 border-b border-surface-border shrink-0 flex items-center justify-between select-none cursor-default group"
+          onDoubleClick={toggleLeftPanel}
+        >
           <div className="flex items-center gap-2">
             <FolderTree className="w-4 h-4 text-text-muted" />
             <h3 className="text-xs font-semibold uppercase tracking-wider text-text-muted">
               Project Files
             </h3>
           </div>
+          <button
+            onClick={(e) => { e.stopPropagation(); toggleLeftPanel(); }}
+            className="p-1 hover:bg-surface-hover rounded transition-colors"
+            title="Close Panel"
+          >
+            <PanelLeftClose className="w-3.5 h-3.5 text-text-muted" />
+          </button>
         </div>
         <div className="flex-1 flex items-center justify-center min-h-0">
           <div className="text-center">
@@ -495,7 +457,10 @@ export default function ProjectStructure() {
       {/* ── File Tree ────────────────────────────────────────────────────── */}
       <div className="flex flex-col flex-1 min-h-0 overflow-hidden">
         {/* Header */}
-        <div className="px-4 py-3 border-b border-surface-border flex items-center justify-between shrink-0">
+        <div
+          className="px-4 py-3 border-b border-surface-border flex items-center justify-between shrink-0 select-none cursor-default group"
+          onDoubleClick={toggleLeftPanel}
+        >
           <div className="flex items-center gap-2">
             <FolderTree className="w-4 h-4 text-text-muted" />
             <h3 className="text-xs font-semibold uppercase tracking-wider text-text-muted">
@@ -504,18 +469,25 @@ export default function ProjectStructure() {
           </div>
           <div className="flex items-center gap-1">
             <button
-              onClick={handleNewFileAtRoot}
+              onClick={(e) => { e.stopPropagation(); handleNewFileAtRoot(); }}
               className="p-1 hover:bg-surface-hover rounded transition-colors"
               title="New File"
             >
               <PlusSquare className="w-3.5 h-3.5 text-text-muted hover:text-text-primary" />
             </button>
             <button
-              onClick={handleNewFolderAtRoot}
+              onClick={(e) => { e.stopPropagation(); handleNewFolderAtRoot(); }}
               className="p-1 hover:bg-surface-hover rounded transition-colors"
               title="New Folder"
             >
               <FolderPlus className="w-3.5 h-3.5 text-text-muted hover:text-text-primary" />
+            </button>
+            <button
+              onClick={(e) => { e.stopPropagation(); toggleLeftPanel(); }}
+              className="p-1 hover:bg-surface-hover rounded transition-colors"
+              title="Close Panel"
+            >
+              <PanelLeftClose className="w-3.5 h-3.5 text-text-muted" />
             </button>
           </div>
         </div>
@@ -556,110 +528,30 @@ export default function ProjectStructure() {
         </div>
       </div>
 
-      {/* ── Outline Panel ────────────────────────────────────────────────── */}
+      {/* ── Unsynced Changes Panel ───────────────────────────────────────── */}
       <div className="flex flex-col shrink-0 border-t border-surface-border">
-        {/* Outline header — always visible, click to collapse/expand */}
         <button
           className="flex items-center justify-between px-4 py-2 w-full hover:bg-surface-hover transition-colors group"
-          onClick={() => setIsOutlineExpanded((v) => !v)}
+          onClick={() => setIsLocalFilesExpanded((v) => !v)}
         >
           <div className="flex items-center gap-2">
-            <List className="w-3.5 h-3.5 text-text-muted" />
+            <CheckCheck className="w-3.5 h-3.5 text-text-muted" />
             <span className="text-xs font-semibold uppercase tracking-wider text-text-muted group-hover:text-text-primary transition-colors">
-              Outline
+              Unsynced Changes
             </span>
-            {outlineCount > 0 && (
-              <span className="text-[10px] text-text-muted/60 tabular-nums">
-                ({outlineCount})
-              </span>
-            )}
           </div>
-          {isOutlineExpanded ? (
+          {isLocalFilesExpanded ? (
             <ChevronDown className="w-3 h-3 text-text-muted" />
           ) : (
             <ChevronRight className="w-3 h-3 text-text-muted" />
           )}
         </button>
 
-        {/* Outline body */}
-        {isOutlineExpanded && (
-          <div className="overflow-y-auto custom-scrollbar max-h-52 pb-1">
-            {outlineCount === 0 ? (
-              <p className="px-4 py-3 text-xs text-text-muted/60 italic">
-                No elements in model
-              </p>
-            ) : (
-              <>
-                {/* Classes */}
-                {classes.length > 0 && (
-                  <div>
-                    <div className="px-4 pt-2 pb-0.5 text-[10px] font-medium text-text-muted/50 uppercase tracking-wider">
-                      Classes
-                    </div>
-                    {classes.map((cls) => (
-                      <div
-                        key={cls.id}
-                        className="flex items-center gap-2 px-4 py-1 hover:bg-surface-hover transition-colors"
-                        title={cls.isAbstract ? `${cls.name} (abstract)` : cls.name}
-                      >
-                        <ElementBadge kind="CLASS" isAbstract={cls.isAbstract} />
-                        <span
-                          className={`text-xs truncate ${
-                            cls.isAbstract
-                              ? "italic text-text-muted"
-                              : "text-text-secondary"
-                          }`}
-                        >
-                          {cls.name}
-                        </span>
-                      </div>
-                    ))}
-                  </div>
-                )}
-
-                {/* Interfaces */}
-                {interfaces.length > 0 && (
-                  <div>
-                    <div className="px-4 pt-2 pb-0.5 text-[10px] font-medium text-text-muted/50 uppercase tracking-wider">
-                      Interfaces
-                    </div>
-                    {interfaces.map((iface) => (
-                      <div
-                        key={iface.id}
-                        className="flex items-center gap-2 px-4 py-1 hover:bg-surface-hover transition-colors"
-                        title={iface.name}
-                      >
-                        <ElementBadge kind="INTERFACE" />
-                        <span className="text-xs text-text-secondary truncate">
-                          {iface.name}
-                        </span>
-                      </div>
-                    ))}
-                  </div>
-                )}
-
-                {/* Enums */}
-                {enums.length > 0 && (
-                  <div>
-                    <div className="px-4 pt-2 pb-0.5 text-[10px] font-medium text-text-muted/50 uppercase tracking-wider">
-                      Enums
-                    </div>
-                    {enums.map((enm) => (
-                      <div
-                        key={enm.id}
-                        className="flex items-center gap-2 px-4 py-1 hover:bg-surface-hover transition-colors"
-                        title={enm.name}
-                      >
-                        <ElementBadge kind="ENUM" />
-                        <span className="text-xs text-text-secondary truncate">
-                          {enm.name}
-                        </span>
-                      </div>
-                    ))}
-                  </div>
-                )}
-              </>
-            )}
+        {isLocalFilesExpanded && (
+          <div className="px-4 py-3">
+            <p className="text-xs text-text-muted/50 italic">
+              All files are synced.
+            </p>
           </div>
         )}
       </div>

--- a/src/features/diagram/components/layout/RightSidebar.tsx
+++ b/src/features/diagram/components/layout/RightSidebar.tsx
@@ -1,0 +1,422 @@
+import { useState, useEffect, useCallback } from "react";
+import {
+  Network,
+  PanelRightClose,
+  ChevronRight,
+  ChevronDown,
+  Pencil,
+  Trash2,
+  Plus,
+} from "lucide-react";
+import { useLayoutStore } from "../../../../store/layout.store";
+import { useModelStore } from "../../../../store/model.store";
+import { useVFSStore } from "../../../../store/vfs.store";
+import { useUiStore } from "../../../../store/uiStore";
+import { DRAG_TYPE_EXISTING, getNextVFSName } from "../../hooks/useDiagramDnD";
+import type {
+  IRClass,
+  IRInterface,
+  IREnum,
+  IRAttribute,
+  IROperation,
+} from "../../../../core/domain/vfs/vfs.types";
+
+interface CtxMenuState {
+  id: string;
+  x: number;
+  y: number;
+}
+
+function Badge({ label, className }: { label: string; className: string }) {
+  return (
+    <span
+      className={`inline-flex items-center justify-center w-4 h-4 text-[9px] font-bold rounded shrink-0 ${className}`}
+    >
+      {label}
+    </span>
+  );
+}
+
+function MemberRow({
+  label,
+  badgeClass,
+  text,
+}: {
+  label: string;
+  badgeClass: string;
+  text: string;
+}) {
+  return (
+    <div className="flex items-center gap-1.5 py-0.5 pl-10 pr-2">
+      <Badge label={label} className={badgeClass} />
+      <span className="text-[11px] text-text-muted truncate font-mono">{text}</span>
+    </div>
+  );
+}
+
+interface ElementRowProps {
+  id: string;
+  name: string;
+  badge: string;
+  badgeClass: string;
+  attributes?: IRAttribute[];
+  operations?: IROperation[];
+  onShowContextMenu: (id: string, x: number, y: number) => void;
+}
+
+function ElementRow({
+  id,
+  name,
+  badge,
+  badgeClass,
+  attributes = [],
+  operations = [],
+  onShowContextMenu,
+}: ElementRowProps) {
+  const [expanded, setExpanded] = useState(false);
+  const hasMembers = attributes.length > 0 || operations.length > 0;
+
+  const handleDragStart = (e: React.DragEvent) => {
+    e.dataTransfer.setData(DRAG_TYPE_EXISTING, id);
+    e.dataTransfer.effectAllowed = "move";
+  };
+
+  const handleContextMenu = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    onShowContextMenu(id, e.clientX, e.clientY);
+  };
+
+  return (
+    <div>
+      <div
+        draggable
+        onDragStart={handleDragStart}
+        onDoubleClick={(e) => { e.stopPropagation(); if (hasMembers) setExpanded((v) => !v); }}
+        onContextMenu={handleContextMenu}
+        className="flex items-center gap-1 px-2 py-0.5 hover:bg-surface-hover cursor-grab active:cursor-grabbing select-none"
+        title="Drag to canvas · Double-click to expand · Right-click for more"
+      >
+        <button
+          draggable={false}
+          onMouseDown={(e) => { e.stopPropagation(); e.preventDefault(); }}
+          className="shrink-0 p-0.5 rounded hover:bg-white/5"
+          onClick={(e) => {
+            e.stopPropagation();
+            if (hasMembers) setExpanded((v) => !v);
+          }}
+        >
+          {hasMembers ? (
+            expanded ? (
+              <ChevronDown className="w-3 h-3 text-text-muted" />
+            ) : (
+              <ChevronRight className="w-3 h-3 text-text-muted" />
+            )
+          ) : (
+            <span className="w-3 h-3 block" />
+          )}
+        </button>
+        <Badge label={badge} className={badgeClass} />
+        <span className="text-xs text-text-primary flex-1 truncate ml-1">{name}</span>
+      </div>
+
+      {expanded && hasMembers && (
+        <div>
+          {attributes.map((attr) => (
+            <MemberRow
+              key={attr.id}
+              label="f"
+              badgeClass="bg-slate-500/20 text-slate-400"
+              text={`${attr.name}: ${attr.type}`}
+            />
+          ))}
+          {operations.map((op) => (
+            <MemberRow
+              key={op.id}
+              label="m"
+              badgeClass="bg-teal-500/20 text-teal-400"
+              text={`${op.name}(): ${op.returnType ?? "void"}`}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface SectionProps {
+  title: string;
+  count: number;
+  children?: React.ReactNode;
+  onCreate?: () => void;
+  createTitle?: string;
+}
+
+function Section({ title, count, children, onCreate, createTitle }: SectionProps) {
+  const [open, setOpen] = useState(true);
+
+  return (
+    <div>
+      <div className="flex items-center">
+        <button
+          onClick={() => setOpen((v) => !v)}
+          className="flex items-center gap-1 px-2 py-1 hover:bg-surface-hover select-none flex-1 min-w-0"
+        >
+          {open ? (
+            <ChevronDown className="w-3 h-3 text-text-muted/60 shrink-0" />
+          ) : (
+            <ChevronRight className="w-3 h-3 text-text-muted/60 shrink-0" />
+          )}
+          <span className="text-[10px] font-semibold uppercase tracking-wider text-text-muted flex-1 text-left truncate">
+            {title}
+          </span>
+          <span className="text-[10px] text-text-muted/40 font-mono tabular-nums mr-1">
+            {count}
+          </span>
+        </button>
+
+        {onCreate && (
+          <button
+            onClick={(e) => { e.stopPropagation(); onCreate(); }}
+            className="px-1.5 py-1 hover:bg-surface-hover rounded transition-colors mr-1"
+            title={createTitle ?? `New ${title.replace(/s$/, "")}`}
+          >
+            <Plus className="w-3 h-3 text-text-muted hover:text-text-primary" />
+          </button>
+        )}
+      </div>
+
+      {open && (
+        <div>
+          {children}
+          {count === 0 && (
+            <p className="text-[10px] text-text-muted/30 italic px-8 py-0.5">
+              — none —
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function RightSidebar() {
+  const { toggleRightPanel } = useLayoutStore();
+  const model = useModelStore((s) => s.model);
+  const initModel = useModelStore((s) => s.initModel);
+  const createClass = useModelStore((s) => s.createClass);
+  const createInterface = useModelStore((s) => s.createInterface);
+  const createEnum = useModelStore((s) => s.createEnum);
+  const project = useVFSStore((s) => s.project);
+  const openSSoTClassEditor = useUiStore((s) => s.openSSoTClassEditor);
+  const openGlobalDelete = useUiStore((s) => s.openGlobalDelete);
+
+  const [ctxMenu, setCtxMenu] = useState<CtxMenuState | null>(null);
+
+  const dismissCtxMenu = useCallback(() => setCtxMenu(null), []);
+
+  useEffect(() => {
+    if (!ctxMenu) return;
+    window.addEventListener("mousedown", dismissCtxMenu);
+    return () => window.removeEventListener("mousedown", dismissCtxMenu);
+  }, [ctxMenu, dismissCtxMenu]);
+
+  const handleShowContextMenu = useCallback(
+    (id: string, x: number, y: number) => setCtxMenu({ id, x, y }),
+    [],
+  );
+
+  const ensureModel = useCallback(() => {
+    if (!useModelStore.getState().model) {
+      initModel(project?.domainModelId ?? crypto.randomUUID());
+    }
+  }, [initModel, project]);
+
+  const handleCreate = useCallback(
+    (kind: "class" | "abstract" | "interface" | "enum") => {
+      ensureModel();
+      const m = useModelStore.getState().model!;
+      let id: string;
+
+      if (kind === "class") {
+        const name = getNextVFSName(
+          Object.values(m.classes).filter((c) => !c.isAbstract).map((c) => c.name),
+          "Class",
+        );
+        id = createClass({ name, attributeIds: [], operationIds: [] });
+      } else if (kind === "abstract") {
+        const name = getNextVFSName(
+          Object.values(m.classes).filter((c) => !!c.isAbstract).map((c) => c.name),
+          "Abstract",
+        );
+        id = createClass({ name, isAbstract: true, attributeIds: [], operationIds: [] });
+      } else if (kind === "interface") {
+        const name = getNextVFSName(
+          Object.values(m.interfaces).map((i) => i.name),
+          "Interface",
+        );
+        id = createInterface({ name, operationIds: [] });
+      } else {
+        const name = getNextVFSName(
+          Object.values(m.enums).map((e) => e.name),
+          "Enum",
+        );
+        id = createEnum({ name, literals: [] });
+      }
+
+      openSSoTClassEditor(id);
+    },
+    [ensureModel, createClass, createInterface, createEnum, openSSoTClassEditor],
+  );
+
+  const resolveAttrs = (ids: string[]): IRAttribute[] =>
+    model ? ids.map((id) => model.attributes[id]).filter(Boolean) : [];
+
+  const resolveOps = (ids: string[]): IROperation[] =>
+    model ? ids.map((id) => model.operations[id]).filter(Boolean) : [];
+
+  const classes: IRClass[] = model
+    ? Object.values(model.classes).filter((c) => !c.isAbstract)
+    : [];
+  const abstractClasses: IRClass[] = model
+    ? Object.values(model.classes).filter((c) => !!c.isAbstract)
+    : [];
+  const interfaces: IRInterface[] = model ? Object.values(model.interfaces) : [];
+  const enums: IREnum[] = model ? Object.values(model.enums) : [];
+
+  return (
+    <div className="w-64 h-full border-l border-surface-border bg-surface-primary flex flex-col">
+      <div
+        className="px-4 py-3 border-b border-surface-border shrink-0 flex items-center justify-between select-none cursor-default group"
+        onDoubleClick={toggleRightPanel}
+      >
+        <div className="flex items-center gap-2">
+          <Network className="w-4 h-4 text-text-muted" />
+          <h3 className="text-xs font-semibold uppercase tracking-wider text-text-muted">
+            Model Explorer
+          </h3>
+        </div>
+        <button
+          onClick={(e) => { e.stopPropagation(); toggleRightPanel(); }}
+          className="p-1 hover:bg-surface-hover rounded transition-colors opacity-0 group-hover:opacity-100"
+          title="Close Panel"
+        >
+          <PanelRightClose className="w-3.5 h-3.5 text-text-muted" />
+        </button>
+      </div>
+
+      {!model && !project ? (
+        <div className="flex-1 flex items-center justify-center p-4">
+          <p className="text-xs text-text-muted/40 text-center leading-relaxed">
+            Open a .luml diagram and drop elements to populate the model.
+          </p>
+        </div>
+      ) : (
+        <div className="flex-1 overflow-y-auto py-1">
+          <Section
+            title="Classes"
+            count={classes.length}
+            onCreate={() => handleCreate("class")}
+            createTitle="New Class"
+          >
+            {classes.map((cls) => (
+              <ElementRow
+                key={cls.id}
+                id={cls.id}
+                name={cls.name}
+                badge="C"
+                badgeClass="bg-blue-500/20 text-blue-400"
+                attributes={resolveAttrs(cls.attributeIds)}
+                operations={resolveOps(cls.operationIds)}
+                onShowContextMenu={handleShowContextMenu}
+              />
+            ))}
+          </Section>
+
+          <Section
+            title="Abstract Classes"
+            count={abstractClasses.length}
+            onCreate={() => handleCreate("abstract")}
+            createTitle="New Abstract Class"
+          >
+            {abstractClasses.map((cls) => (
+              <ElementRow
+                key={cls.id}
+                id={cls.id}
+                name={cls.name}
+                badge="A"
+                badgeClass="bg-purple-500/20 text-purple-400"
+                attributes={resolveAttrs(cls.attributeIds)}
+                operations={resolveOps(cls.operationIds)}
+                onShowContextMenu={handleShowContextMenu}
+              />
+            ))}
+          </Section>
+
+          <Section
+            title="Interfaces"
+            count={interfaces.length}
+            onCreate={() => handleCreate("interface")}
+            createTitle="New Interface"
+          >
+            {interfaces.map((iface) => (
+              <ElementRow
+                key={iface.id}
+                id={iface.id}
+                name={iface.name}
+                badge="I"
+                badgeClass="bg-emerald-500/20 text-emerald-400"
+                operations={resolveOps(iface.operationIds)}
+                onShowContextMenu={handleShowContextMenu}
+              />
+            ))}
+          </Section>
+
+          <Section
+            title="Enums"
+            count={enums.length}
+            onCreate={() => handleCreate("enum")}
+            createTitle="New Enum"
+          >
+            {enums.map((en) => (
+              <ElementRow
+                key={en.id}
+                id={en.id}
+                name={en.name}
+                badge="E"
+                badgeClass="bg-amber-500/20 text-amber-400"
+                onShowContextMenu={handleShowContextMenu}
+              />
+            ))}
+          </Section>
+        </div>
+      )}
+
+      {ctxMenu && (
+        <div
+          className="fixed z-[9000] bg-[#1a2235] border border-[#2d3f5c] rounded-lg shadow-2xl py-1 min-w-[180px]"
+          style={{ top: ctxMenu.y, left: ctxMenu.x }}
+          onMouseDown={(e) => e.stopPropagation()}
+        >
+          <button
+            className="w-full flex items-center gap-2.5 px-3 py-1.5 text-xs text-slate-300 hover:bg-white/5 transition-colors"
+            onClick={() => { openSSoTClassEditor(ctxMenu.id); dismissCtxMenu(); }}
+          >
+            <Pencil className="w-3.5 h-3.5 text-slate-400" />
+            Edit...
+          </button>
+
+          <div className="border-t border-[#2d3f5c] my-1" />
+
+          <button
+            className="w-full flex items-center gap-2.5 px-3 py-1.5 text-xs text-red-400 hover:bg-red-950/40 transition-colors"
+            onClick={() => { openGlobalDelete(ctxMenu.id); dismissCtxMenu(); }}
+          >
+            <Trash2 className="w-3.5 h-3.5" />
+            Delete from Project
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/diagram/components/menubar/AppMenubar.tsx
+++ b/src/features/diagram/components/menubar/AppMenubar.tsx
@@ -1,4 +1,4 @@
-import { Pencil, FileOutput, Settings, GraduationCap, HelpCircle, SlidersHorizontal } from "lucide-react";
+import { Pencil, FileOutput, Settings, GraduationCap, HelpCircle, SlidersHorizontal, PanelLeft, PanelBottom, PanelRight } from "lucide-react";
 import { useWorkspaceStore } from "../../../../store/workspace.store";
 import { useVFSStore } from "../../../../store/vfs.store";
 import WindowControls from "../../../../components/ui/menubar/WindowControls";
@@ -20,6 +20,7 @@ import { CodeMenu } from "./modules/CodeMenu";
 import { EduMenu, EduMenuContent } from "./modules/EduMenu";
 import { HelpMenu, HelpMenuContent } from "./modules/HelpMenu";
 import { useTranslation } from "react-i18next";
+import { useLayoutStore } from "../../../../store/layout.store";
 
 export default function AppMenubar() {
   const { t } = useTranslation();
@@ -41,6 +42,15 @@ export default function AppMenubar() {
 
   const actions = useDiagramActions();
   const { modalState } = actions;
+
+  const {
+    isLeftPanelOpen,
+    isRightPanelOpen,
+    isBottomPanelOpen,
+    toggleLeftPanel,
+    toggleRightPanel,
+    toggleBottomPanel,
+  } = useLayoutStore();
 
   useEffect(() => {
     if (isEditing && inputRef.current) {
@@ -167,6 +177,42 @@ export default function AppMenubar() {
         </div>
 
         <div className="flex items-center no-drag shrink-0">
+          {/* Panel toggle buttons */}
+          <div className="flex items-center gap-0.5 px-2 border-r border-surface-border mr-0.5">
+            <button
+              onClick={toggleLeftPanel}
+              title={isLeftPanelOpen ? "Hide Left Panel" : "Show Left Panel"}
+              className={`p-1.5 rounded transition-colors ${
+                isLeftPanelOpen
+                  ? "text-blue-400 bg-white/10"
+                  : "text-text-muted hover:text-text-primary hover:bg-white/5"
+              }`}
+            >
+              <PanelLeft className="w-3.5 h-3.5" />
+            </button>
+            <button
+              onClick={toggleBottomPanel}
+              title={isBottomPanelOpen ? "Hide Bottom Panel" : "Show Bottom Panel"}
+              className={`p-1.5 rounded transition-colors ${
+                isBottomPanelOpen
+                  ? "text-blue-400 bg-white/10"
+                  : "text-text-muted hover:text-text-primary hover:bg-white/5"
+              }`}
+            >
+              <PanelBottom className="w-3.5 h-3.5" />
+            </button>
+            <button
+              onClick={toggleRightPanel}
+              title={isRightPanelOpen ? "Hide Right Panel" : "Show Right Panel"}
+              className={`p-1.5 rounded transition-colors ${
+                isRightPanelOpen
+                  ? "text-blue-400 bg-white/10"
+                  : "text-text-muted hover:text-text-primary hover:bg-white/5"
+              }`}
+            >
+              <PanelRight className="w-3.5 h-3.5" />
+            </button>
+          </div>
           <WindowControls />
         </div>
       </header>

--- a/src/features/diagram/components/modals/ClassEditorModal.tsx
+++ b/src/features/diagram/components/modals/ClassEditorModal.tsx
@@ -8,15 +8,28 @@ import type {
   UmlMethod,
   visibility as Visibility,
 } from "../../types/diagram.types";
+import type {
+  ClassNode,
+  InterfaceNode,
+  AbstractClassNode,
+  EnumNode,
+} from "../../../../core/domain/models";
+import type { ClassDiagramMetadata } from "../../../../core/domain/workspace/diagram-file.types";
 import { Plus, Trash2, ArrowUp, ArrowDown, Wand2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useUiStore } from "../../../../store/uiStore";
+
+interface SSoTContext {
+  elementNames: string[];
+  availableTypeNames: string[];
+}
 
 interface ClassEditorModalProps {
   isOpen: boolean;
   umlData: UmlClassData;
   onSave: (data: UmlClassData) => void;
   onClose: () => void;
+  ssotContext?: SSoTContext;
 }
 
 const PRIMITIVE_TYPES = [
@@ -32,96 +45,147 @@ const PRIMITIVE_TYPES = [
 
 const VISIBILITY_OPTIONS: Visibility[] = ["+", "-", "#", "~"];
 
+type PackageableClassNode = ClassNode | InterfaceNode | AbstractClassNode | EnumNode;
+
+function isPackageableNode(
+  node: { type: string },
+): node is PackageableClassNode {
+  return (
+    node.type === "CLASS" ||
+    node.type === "INTERFACE" ||
+    node.type === "ABSTRACT_CLASS" ||
+    node.type === "ENUM"
+  );
+}
+
 export default function ClassEditorModal({
   isOpen,
   umlData,
   onSave,
   onClose,
+  ssotContext,
 }: ClassEditorModalProps) {
   const projectNodes = useProjectStore((state) => state.nodes);
-  const nodes = useMemo(() => Object.values(projectNodes), [projectNodes]);
-  
-  // Get packages from WorkspaceStore file metadata (SSOT)
+  const nodes = useMemo(
+    () => (ssotContext ? [] : Object.values(projectNodes)),
+    [projectNodes, ssotContext],
+  );
+
   const activeFileId = useWorkspaceStore((s) => s.activeFileId);
   const getFile = useWorkspaceStore((s) => s.getFile);
-  
+
   const packages = useMemo(() => {
+    if (ssotContext) return [];
     if (!activeFileId) return [];
     const file = getFile(activeFileId);
     if (!file) return [];
-    
-    const filePackages = (file.metadata as any)?.packages || [];
-    
-    // Also include packages from nodes (for XMI imports)
+
+    const classMeta = file.metadata as ClassDiagramMetadata | undefined;
+    const filePackages = classMeta?.packages ?? [];
+
     const nodePackages = new Set<string>();
-    nodes.forEach(node => {
-      const pkg = (node as any)?.package;
-      if (pkg && pkg.trim() !== "") nodePackages.add(pkg);
+    nodes.forEach((node) => {
+      if (!isPackageableNode(node)) return;
+      const pkg = node.package;
+      if (pkg?.trim()) nodePackages.add(pkg);
     });
-    
-    // Merge explicit packages with implicit ones
+
     const allPackageNames = new Set([
-      ...filePackages.map((p: any) => p.name),
-      ...Array.from(nodePackages)
+      ...filePackages.map((p) => p.name),
+      ...Array.from(nodePackages),
     ]);
-    
+
     return Array.from(allPackageNames)
       .sort()
-      .map(name => ({ id: name, name }));
-  }, [activeFileId, getFile, nodes]);
+      .map((name) => ({ id: name, name }));
+  }, [activeFileId, getFile, nodes, ssotContext]);
 
   const editingId = useUiStore((state) => state.editingId);
   const { t } = useTranslation();
 
   const availableTypes = useMemo(() => {
+    if (ssotContext) {
+      return [...PRIMITIVE_TYPES, ...ssotContext.availableTypeNames];
+    }
     const classTypes = nodes
-      .filter((node) => node.type === "CLASS" || node.type === "INTERFACE" || node.type === "ABSTRACT_CLASS" || node.type === "ENUM")
+      .filter(
+        (node): node is PackageableClassNode => isPackageableNode(node),
+      )
       .map((node) => node.name);
     return [...PRIMITIVE_TYPES, ...classTypes];
-  }, [nodes]);
+  }, [nodes, ssotContext]);
 
   const [draft, setDraft] = useState<UmlClassData>(() => ({
     ...umlData,
-    attributes: Array.isArray(umlData.attributes) && typeof umlData.attributes[0] === "string" ? [] : umlData.attributes || [],
-    methods: Array.isArray(umlData.methods) && typeof umlData.methods[0] === "string" ? [] : umlData.methods?.map((m) => ({ ...m, parameters: m.parameters || [] })) || [],
+    attributes:
+      Array.isArray(umlData.attributes) &&
+      typeof umlData.attributes[0] === "string"
+        ? []
+        : umlData.attributes || [],
+    methods:
+      Array.isArray(umlData.methods) && typeof umlData.methods[0] === "string"
+        ? []
+        : umlData.methods?.map((m) => ({
+            ...m,
+            parameters: m.parameters || [],
+          })) || [],
   }));
 
   const [classNameError, setClassNameError] = useState(false);
-  const [attributeErrors, setAttributeErrors] = useState<Set<number>>(new Set());
+  const [attributeErrors, setAttributeErrors] = useState<Set<number>>(
+    new Set(),
+  );
   const [methodErrors, setMethodErrors] = useState<Set<number>>(new Set());
   const classNameInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
     setDraft((prev) => {
-      const updatedMethods = prev.methods.map(m => 
-        m.isConstructor ? { ...m, name: prev.label } : m
+      const updatedMethods = prev.methods.map((m) =>
+        m.isConstructor ? { ...m, name: prev.label } : m,
       );
       return { ...prev, methods: updatedMethods };
     });
   }, [draft.label]);
 
   const validateClassName = (name: string): boolean => {
-    const currentPackage = draft.package || "";
-    return nodes.some(node => {
+    if (ssotContext) {
+      return ssotContext.elementNames.some(
+        (n) => n !== umlData.label && n === name,
+      );
+    }
+    const currentPackage = draft.package ?? "";
+    return nodes.some((node) => {
       if (node.id === editingId) return false;
-      const nodePackage = (node as any).package || "";
-      return (node as any).name === name && nodePackage === currentPackage;
+      if (!isPackageableNode(node)) return false;
+      return (
+        node.name === name && (node.package ?? "") === currentPackage
+      );
     });
   };
 
-  const validateAttributeName = (name: string, currentIndex: number): boolean => {
-    return draft.attributes.some((attr, idx) => idx !== currentIndex && attr.name === name);
+  const validateAttributeName = (
+    name: string,
+    currentIndex: number,
+  ): boolean => {
+    return draft.attributes.some(
+      (attr, idx) => idx !== currentIndex && attr.name === name,
+    );
   };
 
-  const validateMethodSignature = (method: UmlMethod, currentIndex: number): boolean => {
+  const validateMethodSignature = (
+    method: UmlMethod,
+    currentIndex: number,
+  ): boolean => {
     return draft.methods.some((m, idx) => {
       if (idx === currentIndex) return false;
       if (m.name !== method.name) return false;
       if (m.parameters.length !== method.parameters.length) return false;
       return m.parameters.every((p, i) => {
         const otherParam = method.parameters[i];
-        return p.type === otherParam.type && (p.isArray || false) === (otherParam.isArray || false);
+        return (
+          p.type === otherParam.type &&
+          (p.isArray || false) === (otherParam.isArray || false)
+        );
       });
     });
   };
@@ -130,7 +194,7 @@ export default function ClassEditorModal({
     if (validateClassName(newName)) {
       setClassNameError(true);
       setTimeout(() => {
-        setDraft(prev => ({ ...prev, label: umlData.label }));
+        setDraft((prev) => ({ ...prev, label: umlData.label }));
         setClassNameError(false);
       }, 2000);
     } else {
@@ -139,21 +203,34 @@ export default function ClassEditorModal({
   };
 
   const addAttribute = () => {
-    const newAttr: UmlAttribute = { id: crypto.randomUUID(), visibility: "-", name: "newAttr", type: "String", isArray: false };
+    const newAttr: UmlAttribute = {
+      id: crypto.randomUUID(),
+      visibility: "-",
+      name: "newAttr",
+      type: "String",
+      isArray: false,
+    };
     setDraft((prev) => ({ ...prev, attributes: [...prev.attributes, newAttr] }));
   };
 
-  const updateAttribute = (index: number, field: keyof UmlAttribute, value: string | boolean) => {
+  const updateAttribute = (
+    index: number,
+    field: keyof UmlAttribute,
+    value: string | boolean,
+  ) => {
     if (field === "name" && typeof value === "string") {
       if (validateAttributeName(value, index)) {
-        setAttributeErrors(prev => new Set(prev).add(index));
+        setAttributeErrors((prev) => new Set(prev).add(index));
         setTimeout(() => {
-          setDraft(prev => {
+          setDraft((prev) => {
             const newAttrs = [...prev.attributes];
-            newAttrs[index] = { ...newAttrs[index], name: prev.attributes[index].name };
+            newAttrs[index] = {
+              ...newAttrs[index],
+              name: prev.attributes[index].name,
+            };
             return { ...prev, attributes: newAttrs };
           });
-          setAttributeErrors(prev => {
+          setAttributeErrors((prev) => {
             const next = new Set(prev);
             next.delete(index);
             return next;
@@ -162,14 +239,17 @@ export default function ClassEditorModal({
         return;
       }
     }
-    
+
     const newAttrs = [...draft.attributes];
     newAttrs[index] = { ...newAttrs[index], [field]: value };
     setDraft((prev) => ({ ...prev, attributes: newAttrs }));
   };
 
   const removeAttribute = (index: number) => {
-    setDraft((prev) => ({ ...prev, attributes: prev.attributes.filter((_, i) => i !== index) }));
+    setDraft((prev) => ({
+      ...prev,
+      attributes: prev.attributes.filter((_, i) => i !== index),
+    }));
   };
 
   const moveAttribute = (index: number, direction: "up" | "down") => {
@@ -177,7 +257,10 @@ export default function ClassEditorModal({
     if (direction === "down" && index === draft.attributes.length - 1) return;
     const newAttrs = [...draft.attributes];
     const targetIndex = direction === "up" ? index - 1 : index + 1;
-    [newAttrs[index], newAttrs[targetIndex]] = [newAttrs[targetIndex], newAttrs[index]];
+    [newAttrs[index], newAttrs[targetIndex]] = [
+      newAttrs[targetIndex],
+      newAttrs[index],
+    ];
     setDraft((prev) => ({ ...prev, attributes: newAttrs }));
   };
 
@@ -186,36 +269,59 @@ export default function ClassEditorModal({
       id: crypto.randomUUID(),
       visibility: "+",
       name: draft.label,
-      returnType: "void", 
+      returnType: "void",
       isReturnArray: false,
       isConstructor: true,
-      parameters: fromAttributes 
-        ? draft.attributes.map(attr => ({ name: attr.name, type: attr.type, isArray: attr.isArray }))
+      parameters: fromAttributes
+        ? draft.attributes.map((attr) => ({
+            name: attr.name,
+            type: attr.type,
+            isArray: attr.isArray,
+          }))
         : [],
     };
-    setDraft((prev) => ({ ...prev, methods: [newConstructor, ...prev.methods] }));
+    setDraft((prev) => ({
+      ...prev,
+      methods: [newConstructor, ...prev.methods],
+    }));
   };
 
   const addMethod = () => {
-    const newMethod: UmlMethod = { id: crypto.randomUUID(), visibility: "+", name: "newMethod", returnType: "void", isReturnArray: false, parameters: [], isConstructor: false };
+    const newMethod: UmlMethod = {
+      id: crypto.randomUUID(),
+      visibility: "+",
+      name: "newMethod",
+      returnType: "void",
+      isReturnArray: false,
+      parameters: [],
+      isConstructor: false,
+    };
     setDraft((prev) => ({ ...prev, methods: [...prev.methods, newMethod] }));
   };
 
-  const updateMethod = (index: number, field: keyof UmlMethod, value: string | boolean) => {
+  const updateMethod = (
+    index: number,
+    field: keyof UmlMethod,
+    value: string | boolean,
+  ) => {
     const newMethods = [...draft.methods];
     newMethods[index] = { ...newMethods[index], [field]: value };
-    if (field === "returnType" && value === "void") newMethods[index].isReturnArray = false;
-    
+    if (field === "returnType" && value === "void")
+      newMethods[index].isReturnArray = false;
+
     if (field === "name") {
       if (validateMethodSignature(newMethods[index], index)) {
-        setMethodErrors(prev => new Set(prev).add(index));
+        setMethodErrors((prev) => new Set(prev).add(index));
         setTimeout(() => {
-          setDraft(prev => {
+          setDraft((prev) => {
             const revertMethods = [...prev.methods];
-            revertMethods[index] = { ...revertMethods[index], name: prev.methods[index].name };
+            revertMethods[index] = {
+              ...revertMethods[index],
+              name: prev.methods[index].name,
+            };
             return { ...prev, methods: revertMethods };
           });
-          setMethodErrors(prev => {
+          setMethodErrors((prev) => {
             const next = new Set(prev);
             next.delete(index);
             return next;
@@ -224,12 +330,15 @@ export default function ClassEditorModal({
         return;
       }
     }
-    
+
     setDraft((prev) => ({ ...prev, methods: newMethods }));
   };
 
   const removeMethod = (index: number) => {
-    setDraft((prev) => ({ ...prev, methods: prev.methods.filter((_, i) => i !== index) }));
+    setDraft((prev) => ({
+      ...prev,
+      methods: prev.methods.filter((_, i) => i !== index),
+    }));
   };
 
   const moveMethod = (index: number, direction: "up" | "down") => {
@@ -237,18 +346,25 @@ export default function ClassEditorModal({
     if (direction === "down" && index === draft.methods.length - 1) return;
     const newMethods = [...draft.methods];
     const targetIndex = direction === "up" ? index - 1 : index + 1;
-    [newMethods[index], newMethods[targetIndex]] = [newMethods[targetIndex], newMethods[index]];
+    [newMethods[index], newMethods[targetIndex]] = [
+      newMethods[targetIndex],
+      newMethods[index],
+    ];
     setDraft((prev) => ({ ...prev, methods: newMethods }));
   };
 
   const addParameter = (methodIndex: number) => {
     const newMethods = [...draft.methods];
-    newMethods[methodIndex].parameters.push({ name: "param", type: "String", isArray: false });
-    
+    newMethods[methodIndex].parameters.push({
+      name: "param",
+      type: "String",
+      isArray: false,
+    });
+
     if (validateMethodSignature(newMethods[methodIndex], methodIndex)) {
-      setMethodErrors(prev => new Set(prev).add(methodIndex));
+      setMethodErrors((prev) => new Set(prev).add(methodIndex));
       setTimeout(() => {
-        setMethodErrors(prev => {
+        setMethodErrors((prev) => {
           const next = new Set(prev);
           next.delete(methodIndex);
           return next;
@@ -256,24 +372,34 @@ export default function ClassEditorModal({
       }, 2000);
       return;
     }
-    
+
     setDraft((prev) => ({ ...prev, methods: newMethods }));
   };
 
-  const updateParameter = (methodIndex: number, paramIndex: number, field: "name" | "type" | "isArray", value: string | boolean) => {
+  const updateParameter = (
+    methodIndex: number,
+    paramIndex: number,
+    field: "name" | "type" | "isArray",
+    value: string | boolean,
+  ) => {
     const newMethods = [...draft.methods];
-    newMethods[methodIndex].parameters[paramIndex] = { ...newMethods[methodIndex].parameters[paramIndex], [field]: value };
-    
+    newMethods[methodIndex].parameters[paramIndex] = {
+      ...newMethods[methodIndex].parameters[paramIndex],
+      [field]: value,
+    };
+
     if (field === "type" || field === "isArray") {
       if (validateMethodSignature(newMethods[methodIndex], methodIndex)) {
-        setMethodErrors(prev => new Set(prev).add(methodIndex));
+        setMethodErrors((prev) => new Set(prev).add(methodIndex));
         setTimeout(() => {
-          setDraft(prev => {
+          setDraft((prev) => {
             const revertMethods = [...prev.methods];
-            revertMethods[methodIndex].parameters[paramIndex] = { ...prev.methods[methodIndex].parameters[paramIndex] };
+            revertMethods[methodIndex].parameters[paramIndex] = {
+              ...prev.methods[methodIndex].parameters[paramIndex],
+            };
             return { ...prev, methods: revertMethods };
           });
-          setMethodErrors(prev => {
+          setMethodErrors((prev) => {
             const next = new Set(prev);
             next.delete(methodIndex);
             return next;
@@ -282,35 +408,41 @@ export default function ClassEditorModal({
         return;
       }
     }
-    
+
     setDraft((prev) => ({ ...prev, methods: newMethods }));
   };
 
   const removeParameter = (methodIndex: number, paramIndex: number) => {
     const newMethods = [...draft.methods];
-    newMethods[methodIndex].parameters = newMethods[methodIndex].parameters.filter((_, i) => i !== paramIndex);
+    newMethods[methodIndex].parameters = newMethods[
+      methodIndex
+    ].parameters.filter((_, i) => i !== paramIndex);
     setDraft((prev) => ({ ...prev, methods: newMethods }));
   };
 
-  const isAutoGenerateDisabled = draft.attributes.length === 0 || draft.methods.some((m) => {
-    if (!m.isConstructor) return false;
-    if (m.parameters.length !== draft.attributes.length) return false;
-    return m.parameters.every((p, i) => 
-      p.name === draft.attributes[i].name && 
-      p.type === draft.attributes[i].type &&
-      p.isArray === draft.attributes[i].isArray
-    );
-  });
+  const isAutoGenerateDisabled =
+    draft.attributes.length === 0 ||
+    draft.methods.some((m) => {
+      if (!m.isConstructor) return false;
+      if (m.parameters.length !== draft.attributes.length) return false;
+      return m.parameters.every(
+        (p, i) =>
+          p.name === draft.attributes[i].name &&
+          p.type === draft.attributes[i].type &&
+          p.isArray === draft.attributes[i].isArray,
+      );
+    });
 
   if (!isOpen) return null;
 
   return createPortal(
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm font-sans p-4">
       <div className="bg-surface-primary border border-surface-border p-6 rounded-xl shadow-2xl w-200 max-w-[95vw] text-text-primary max-h-[95vh] flex flex-col">
-        
         <div className="shrink-0 mb-6">
           <h2 className="text-xl font-bold mb-4 flex items-center gap-2">
-            <span className="text-uml-class-border">{t("modals.classEditor.title")}</span>
+            <span className="text-uml-class-border">
+              {t("modals.classEditor.title")}
+            </span>
             {draft.label}
           </h2>
           <div className="space-y-4">
@@ -321,44 +453,57 @@ export default function ClassEditorModal({
               <input
                 ref={classNameInputRef}
                 className={`w-full bg-surface-secondary border rounded p-2 text-text-primary outline-none transition-colors ${
-                  classNameError ? 'border-red-500 text-red-500' : 'border-surface-border focus:border-uml-class-border'
+                  classNameError
+                    ? "border-red-500 text-red-500"
+                    : "border-surface-border focus:border-uml-class-border"
                 }`}
                 value={draft.label}
                 onChange={(e) => handleClassNameChange(e.target.value)}
               />
               {classNameError && (
-                <p className="text-xs text-red-500 mt-1">Class name already exists in this package</p>
+                <p className="text-xs text-red-500 mt-1">
+                  Class name already exists in this package
+                </p>
               )}
             </div>
 
-            <div>
-              <label className="block text-xs font-bold text-text-secondary uppercase tracking-wider mb-2">
-                {t("modals.classEditor.package")}
-              </label>
-              <select
-                className="w-full bg-surface-secondary border border-surface-border rounded p-2 text-text-primary focus:border-uml-class-border outline-none"
-                value={draft.package || ""}
-                onChange={(e) => setDraft({ ...draft, package: e.target.value || undefined })}
-              >
-                <option value="">{t("modals.classEditor.noPackage")}</option>
-                {packages.map((pkg) => (
-                  <option key={pkg.id} value={pkg.name}>
-                    {pkg.name}
-                  </option>
-                ))}
-              </select>
-            </div>
+            {!ssotContext && (
+              <div>
+                <label className="block text-xs font-bold text-text-secondary uppercase tracking-wider mb-2">
+                  {t("modals.classEditor.package")}
+                </label>
+                <select
+                  className="w-full bg-surface-secondary border border-surface-border rounded p-2 text-text-primary focus:border-uml-class-border outline-none"
+                  value={draft.package || ""}
+                  onChange={(e) =>
+                    setDraft({
+                      ...draft,
+                      package: e.target.value || undefined,
+                    })
+                  }
+                >
+                  <option value="">{t("modals.classEditor.noPackage")}</option>
+                  {packages.map((pkg) => (
+                    <option key={pkg.id} value={pkg.name}>
+                      {pkg.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
           </div>
         </div>
 
         <div className="flex-1 overflow-y-auto pr-2 custom-scrollbar space-y-6">
-          
           <div className="flex flex-col">
             <div className="flex justify-between items-center mb-2">
               <label className="text-xs font-bold text-text-secondary uppercase tracking-wider">
                 {t("modals.classEditor.attributes")}
               </label>
-              <button onClick={addAttribute} className="text-xs flex items-center gap-1 text-green-400 hover:text-green-300 bg-green-400/10 px-2 py-1 rounded">
+              <button
+                onClick={addAttribute}
+                className="text-xs flex items-center gap-1 text-green-400 hover:text-green-300 bg-green-400/10 px-2 py-1 rounded"
+              >
                 <Plus className="w-3 h-3" /> {t("modals.classEditor.add")}
               </button>
             </div>
@@ -366,36 +511,92 @@ export default function ClassEditorModal({
             <div className="space-y-2">
               {draft.attributes.map((attr, idx) => (
                 <div key={attr.id}>
-                  <div className={`flex items-center gap-3 bg-surface-secondary p-2 rounded border group transition-colors ${
-                    attributeErrors.has(idx) ? 'border-red-500' : 'border-surface-border'
-                  }`}>
-                    <select className="bg-transparent text-uml-abstract-border font-mono outline-none cursor-pointer" value={attr.visibility} onChange={(e) => updateAttribute(idx, "visibility", e.target.value)}>
-                      {VISIBILITY_OPTIONS.map((v) => <option key={v} value={v}>{v}</option>)}
+                  <div
+                    className={`flex items-center gap-3 bg-surface-secondary p-2 rounded border group transition-colors ${
+                      attributeErrors.has(idx)
+                        ? "border-red-500"
+                        : "border-surface-border"
+                    }`}
+                  >
+                    <select
+                      className="bg-transparent text-uml-abstract-border font-mono outline-none cursor-pointer"
+                      value={attr.visibility}
+                      onChange={(e) =>
+                        updateAttribute(idx, "visibility", e.target.value)
+                      }
+                    >
+                      {VISIBILITY_OPTIONS.map((v) => (
+                        <option key={v} value={v}>
+                          {v}
+                        </option>
+                      ))}
                     </select>
-                    <input 
+                    <input
                       className={`bg-transparent border-b outline-none flex-1 min-w-0 text-sm transition-colors ${
-                        attributeErrors.has(idx) ? 'border-red-500 text-red-500' : 'border-transparent focus:border-uml-class-border'
+                        attributeErrors.has(idx)
+                          ? "border-red-500 text-red-500"
+                          : "border-transparent focus:border-uml-class-border"
                       }`}
-                      placeholder={t("modals.classEditor.placeholders.name")} 
-                      value={attr.name} 
-                      onChange={(e) => updateAttribute(idx, "name", e.target.value)} 
+                      placeholder={t("modals.classEditor.placeholders.name")}
+                      value={attr.name}
+                      onChange={(e) =>
+                        updateAttribute(idx, "name", e.target.value)
+                      }
                     />
                     <span className="text-text-muted font-mono">:</span>
-                    <select className="bg-surface-primary border border-surface-border rounded px-2 py-1 text-xs text-uml-interface-border outline-none w-32" value={attr.type} onChange={(e) => updateAttribute(idx, "type", e.target.value)}>
-                      {availableTypes.map((t) => <option key={t} value={t}>{t}</option>)}
+                    <select
+                      className="bg-surface-primary border border-surface-border rounded px-2 py-1 text-xs text-uml-interface-border outline-none w-32"
+                      value={attr.type}
+                      onChange={(e) =>
+                        updateAttribute(idx, "type", e.target.value)
+                      }
+                    >
+                      {availableTypes.map((t) => (
+                        <option key={t} value={t}>
+                          {t}
+                        </option>
+                      ))}
                     </select>
                     <label className="flex items-center gap-1.5 cursor-pointer bg-surface-primary px-2 py-1 rounded border border-surface-border hover:border-uml-class-border transition-colors">
-                      <input type="checkbox" checked={attr.isArray} onChange={(e) => updateAttribute(idx, "isArray", e.target.checked)} className="accent-uml-class-border w-3 h-3" />
-                      <span className="text-xs font-mono text-text-muted">[]</span>
+                      <input
+                        type="checkbox"
+                        checked={attr.isArray}
+                        onChange={(e) =>
+                          updateAttribute(idx, "isArray", e.target.checked)
+                        }
+                        className="accent-uml-class-border w-3 h-3"
+                      />
+                      <span className="text-xs font-mono text-text-muted">
+                        []
+                      </span>
                     </label>
                     <div className="flex items-center gap-1 border-l border-surface-border pl-3 ml-1">
-                      <button onClick={() => moveAttribute(idx, "up")} disabled={idx === 0} className="text-text-muted hover:text-white disabled:opacity-30"><ArrowUp className="w-4 h-4" /></button>
-                      <button onClick={() => moveAttribute(idx, "down")} disabled={idx === draft.attributes.length - 1} className="text-text-muted hover:text-white disabled:opacity-30"><ArrowDown className="w-4 h-4" /></button>
-                      <button onClick={() => removeAttribute(idx)} className="text-red-400 hover:text-red-300 ml-1"><Trash2 className="w-4 h-4" /></button>
+                      <button
+                        onClick={() => moveAttribute(idx, "up")}
+                        disabled={idx === 0}
+                        className="text-text-muted hover:text-white disabled:opacity-30"
+                      >
+                        <ArrowUp className="w-4 h-4" />
+                      </button>
+                      <button
+                        onClick={() => moveAttribute(idx, "down")}
+                        disabled={idx === draft.attributes.length - 1}
+                        className="text-text-muted hover:text-white disabled:opacity-30"
+                      >
+                        <ArrowDown className="w-4 h-4" />
+                      </button>
+                      <button
+                        onClick={() => removeAttribute(idx)}
+                        className="text-red-400 hover:text-red-300 ml-1"
+                      >
+                        <Trash2 className="w-4 h-4" />
+                      </button>
                     </div>
                   </div>
                   {attributeErrors.has(idx) && (
-                    <p className="text-xs text-red-500 mt-1 ml-2">Attribute name already exists in this class</p>
+                    <p className="text-xs text-red-500 mt-1 ml-2">
+                      Attribute name already exists in this class
+                    </p>
                   )}
                 </div>
               ))}
@@ -403,28 +604,39 @@ export default function ClassEditorModal({
           </div>
 
           <div className="flex flex-col pt-4 border-t border-surface-border">
-            
             <div className="flex justify-between items-center mb-2">
               <label className="text-xs font-bold text-text-secondary uppercase tracking-wider">
                 {t("modals.classEditor.constructorsAndMethods")}
               </label>
               <div className="flex gap-2">
-               <button 
-                  onClick={() => addConstructor(true)} 
+                <button
+                  onClick={() => addConstructor(true)}
                   disabled={isAutoGenerateDisabled}
                   className={`text-xs flex items-center gap-1 px-2 py-1 rounded border transition-colors ${
-                    isAutoGenerateDisabled 
-                      ? 'text-purple-400/50 bg-purple-400/5 border-purple-500/10 cursor-not-allowed' 
-                      : 'text-purple-400 hover:text-purple-300 bg-purple-400/10 border-purple-500/30'
-                  }`} 
-                  title={isAutoGenerateDisabled ? t("modals.classEditor.autoGenerateDisabledTooltip") : t("modals.classEditor.autoGenerateTooltip")}
+                    isAutoGenerateDisabled
+                      ? "text-purple-400/50 bg-purple-400/5 border-purple-500/10 cursor-not-allowed"
+                      : "text-purple-400 hover:text-purple-300 bg-purple-400/10 border-purple-500/30"
+                  }`}
+                  title={
+                    isAutoGenerateDisabled
+                      ? t("modals.classEditor.autoGenerateDisabledTooltip")
+                      : t("modals.classEditor.autoGenerateTooltip")
+                  }
                 >
-                  <Wand2 className="w-3 h-3" /> {t("modals.classEditor.autoGenerate")}
+                  <Wand2 className="w-3 h-3" />{" "}
+                  {t("modals.classEditor.autoGenerate")}
                 </button>
-                <button onClick={() => addConstructor(false)} className="text-xs flex items-center gap-1 text-purple-400 hover:text-purple-300 bg-purple-400/10 px-2 py-1 rounded">
-                  <Plus className="w-3 h-3" /> {t("modals.classEditor.constructor")}
+                <button
+                  onClick={() => addConstructor(false)}
+                  className="text-xs flex items-center gap-1 text-purple-400 hover:text-purple-300 bg-purple-400/10 px-2 py-1 rounded"
+                >
+                  <Plus className="w-3 h-3" />{" "}
+                  {t("modals.classEditor.constructor")}
                 </button>
-                <button onClick={addMethod} className="text-xs flex items-center gap-1 text-blue-400 hover:text-blue-300 bg-blue-400/10 px-2 py-1 rounded ml-2">
+                <button
+                  onClick={addMethod}
+                  className="text-xs flex items-center gap-1 text-blue-400 hover:text-blue-300 bg-blue-400/10 px-2 py-1 rounded ml-2"
+                >
                   <Plus className="w-3 h-3" /> {t("modals.classEditor.add")}
                 </button>
               </div>
@@ -433,98 +645,241 @@ export default function ClassEditorModal({
             <div className="space-y-3">
               {draft.methods.map((method, methodIdx) => (
                 <div key={method.id}>
-                  <div className={`flex flex-col bg-surface-secondary rounded border overflow-hidden transition-colors ${
-                    methodErrors.has(methodIdx) ? 'border-red-500' : method.isConstructor ? 'border-purple-500/30' : 'border-surface-border'
-                  }`}>
-                  
-                    <div className={`flex items-center gap-3 p-2 border-b border-surface-border/50 ${method.isConstructor ? 'bg-purple-900/10' : 'bg-surface-secondary'}`}>
-                    <select className={`bg-transparent font-mono outline-none cursor-pointer ${method.isConstructor ? 'text-purple-400' : 'text-uml-abstract-border'}`} value={method.visibility} onChange={(e) => updateMethod(methodIdx, "visibility", e.target.value)}>
-                      {VISIBILITY_OPTIONS.map((v) => <option key={v} value={v}>{v}</option>)}
-                    </select>
-
-                    <input
-                      className={`bg-transparent border-b outline-none flex-1 min-w-0 text-sm font-medium transition-colors ${
-                        method.isConstructor 
-                          ? 'opacity-60 cursor-not-allowed border-transparent' 
-                          : methodErrors.has(methodIdx)
-                            ? 'border-red-500 text-red-500'
-                            : 'border-transparent focus:border-uml-class-border'
-                      }`}
-                      placeholder={t("modals.classEditor.placeholders.methodName")}
-                      value={method.isConstructor ? draft.label : method.name}
-                      disabled={method.isConstructor}
-                      onChange={(e) => updateMethod(methodIdx, "name", e.target.value)}
-                    />
-
-                    <span className="text-text-muted font-mono">():</span>
-
-                    {method.isConstructor ? (
-                      <span className="bg-purple-500/20 text-purple-300 px-2 py-1 rounded text-[10px] font-bold uppercase tracking-wider border border-purple-500/30 w-32 text-center">
-                        &lt;&lt;create&gt;&gt;
-                      </span>
-                    ) : (
-                      <>
-                        <select className="bg-surface-primary border border-surface-border rounded px-2 py-1 text-xs text-uml-interface-border outline-none w-32" value={method.returnType} onChange={(e) => updateMethod(methodIdx, "returnType", e.target.value)}>
-                          {availableTypes.map((t) => <option key={t} value={t}>{t}</option>)}
-                        </select>
-                        <label className={`flex items-center gap-1.5 px-2 py-1 rounded border transition-colors ${method.returnType === 'void' ? 'opacity-40 cursor-not-allowed bg-surface-primary/50 border-surface-border/50' : 'cursor-pointer bg-surface-primary border-surface-border hover:border-uml-class-border'}`}>
-                          <input type="checkbox" disabled={method.returnType === 'void'} checked={!!method.isReturnArray} onChange={(e) => updateMethod(methodIdx, "isReturnArray", e.target.checked)} className="accent-uml-class-border w-3 h-3 disabled:grayscale" />
-                          <span className="text-xs font-mono text-text-muted">[]</span>
-                        </label>
-                      </>
-                    )}
-
-                    <div className="flex items-center gap-1 border-l border-surface-border pl-3 ml-1">
-                      <button onClick={() => moveMethod(methodIdx, "up")} disabled={methodIdx === 0} className="text-text-muted hover:text-white disabled:opacity-30"><ArrowUp className="w-4 h-4" /></button>
-                      <button onClick={() => moveMethod(methodIdx, "down")} disabled={methodIdx === draft.methods.length - 1} className="text-text-muted hover:text-white disabled:opacity-30"><ArrowDown className="w-4 h-4" /></button>
-                      <button onClick={() => removeMethod(methodIdx)} className="text-red-400 hover:text-red-300 ml-1"><Trash2 className="w-4 h-4" /></button>
-                    </div>
-                  </div>
-
-                  <div className="bg-black/20 p-3 flex flex-col gap-2">
-                    <div className="flex justify-between items-center">
-                      <span className="text-[10px] font-bold text-text-muted uppercase tracking-wider">
-                        {t("modals.classEditor.parameters")} {method.isConstructor && `(${t("modals.classEditor.constructor")})`}
-                      </span>
-                      <button onClick={() => addParameter(methodIdx)} className="text-[10px] flex items-center gap-1 text-blue-400/80 hover:text-blue-300">
-                        <Plus className="w-3 h-3" /> {t("modals.classEditor.addParameter")}
-                      </button>
-                    </div>
-
-                    {method.parameters?.length === 0 ? (
-                      <span className="text-[10px] text-text-muted italic">{t("modals.classEditor.noParameters")}</span>
-                    ) : (
-                      <div className="flex flex-col gap-1.5">
-                        {method.parameters?.map((param, paramIdx) => (
-                          <div key={paramIdx} className="flex items-center gap-2 bg-surface-primary/50 px-2 py-1.5 rounded border border-surface-border/50">
-                            <input className="bg-transparent border-b border-transparent focus:border-uml-class-border outline-none flex-1 min-w-0 text-xs text-text-secondary" placeholder={t("modals.classEditor.parameterNamePlaceholder")} value={param.name} onChange={(e) => updateParameter(methodIdx, paramIdx, "name", e.target.value)} />
-                            <span className="text-text-muted text-xs font-mono">:</span>
-                            <select className="bg-surface-primary border border-surface-border rounded px-1.5 py-0.5 text-[11px] text-uml-interface-border outline-none w-28" value={param.type} onChange={(e) => updateParameter(methodIdx, paramIdx, "type", e.target.value)}>
-                              {availableTypes.map((t) => <option key={t} value={t}>{t}</option>)}
-                            </select>
-                            <label className="flex items-center gap-1 cursor-pointer bg-surface-primary px-1.5 py-0.5 rounded border border-surface-border hover:border-uml-class-border transition-colors">
-                              <input type="checkbox" checked={!!param.isArray} onChange={(e) => updateParameter(methodIdx, paramIdx, "isArray", e.target.checked)} className="accent-uml-class-border w-2.5 h-2.5" />
-                              <span className="text-[10px] font-mono text-text-muted">[]</span>
-                            </label>
-                            <button onClick={() => removeParameter(methodIdx, paramIdx)} className="text-red-400/70 hover:text-red-400 ml-1"><Trash2 className="w-3.5 h-3.5" /></button>
-                          </div>
+                  <div
+                    className={`flex flex-col bg-surface-secondary rounded border overflow-hidden transition-colors ${
+                      methodErrors.has(methodIdx)
+                        ? "border-red-500"
+                        : method.isConstructor
+                          ? "border-purple-500/30"
+                          : "border-surface-border"
+                    }`}
+                  >
+                    <div
+                      className={`flex items-center gap-3 p-2 border-b border-surface-border/50 ${method.isConstructor ? "bg-purple-900/10" : "bg-surface-secondary"}`}
+                    >
+                      <select
+                        className={`bg-transparent font-mono outline-none cursor-pointer ${method.isConstructor ? "text-purple-400" : "text-uml-abstract-border"}`}
+                        value={method.visibility}
+                        onChange={(e) =>
+                          updateMethod(methodIdx, "visibility", e.target.value)
+                        }
+                      >
+                        {VISIBILITY_OPTIONS.map((v) => (
+                          <option key={v} value={v}>
+                            {v}
+                          </option>
                         ))}
+                      </select>
+
+                      <input
+                        className={`bg-transparent border-b outline-none flex-1 min-w-0 text-sm font-medium transition-colors ${
+                          method.isConstructor
+                            ? "opacity-60 cursor-not-allowed border-transparent"
+                            : methodErrors.has(methodIdx)
+                              ? "border-red-500 text-red-500"
+                              : "border-transparent focus:border-uml-class-border"
+                        }`}
+                        placeholder={t(
+                          "modals.classEditor.placeholders.methodName",
+                        )}
+                        value={method.isConstructor ? draft.label : method.name}
+                        disabled={method.isConstructor}
+                        onChange={(e) =>
+                          updateMethod(methodIdx, "name", e.target.value)
+                        }
+                      />
+
+                      <span className="text-text-muted font-mono">():</span>
+
+                      {method.isConstructor ? (
+                        <span className="bg-purple-500/20 text-purple-300 px-2 py-1 rounded text-[10px] font-bold uppercase tracking-wider border border-purple-500/30 w-32 text-center">
+                          &lt;&lt;create&gt;&gt;
+                        </span>
+                      ) : (
+                        <>
+                          <select
+                            className="bg-surface-primary border border-surface-border rounded px-2 py-1 text-xs text-uml-interface-border outline-none w-32"
+                            value={method.returnType}
+                            onChange={(e) =>
+                              updateMethod(
+                                methodIdx,
+                                "returnType",
+                                e.target.value,
+                              )
+                            }
+                          >
+                            {availableTypes.map((t) => (
+                              <option key={t} value={t}>
+                                {t}
+                              </option>
+                            ))}
+                          </select>
+                          <label
+                            className={`flex items-center gap-1.5 px-2 py-1 rounded border transition-colors ${method.returnType === "void" ? "opacity-40 cursor-not-allowed bg-surface-primary/50 border-surface-border/50" : "cursor-pointer bg-surface-primary border-surface-border hover:border-uml-class-border"}`}
+                          >
+                            <input
+                              type="checkbox"
+                              disabled={method.returnType === "void"}
+                              checked={!!method.isReturnArray}
+                              onChange={(e) =>
+                                updateMethod(
+                                  methodIdx,
+                                  "isReturnArray",
+                                  e.target.checked,
+                                )
+                              }
+                              className="accent-uml-class-border w-3 h-3 disabled:grayscale"
+                            />
+                            <span className="text-xs font-mono text-text-muted">
+                              []
+                            </span>
+                          </label>
+                        </>
+                      )}
+
+                      <div className="flex items-center gap-1 border-l border-surface-border pl-3 ml-1">
+                        <button
+                          onClick={() => moveMethod(methodIdx, "up")}
+                          disabled={methodIdx === 0}
+                          className="text-text-muted hover:text-white disabled:opacity-30"
+                        >
+                          <ArrowUp className="w-4 h-4" />
+                        </button>
+                        <button
+                          onClick={() => moveMethod(methodIdx, "down")}
+                          disabled={methodIdx === draft.methods.length - 1}
+                          className="text-text-muted hover:text-white disabled:opacity-30"
+                        >
+                          <ArrowDown className="w-4 h-4" />
+                        </button>
+                        <button
+                          onClick={() => removeMethod(methodIdx)}
+                          className="text-red-400 hover:text-red-300 ml-1"
+                        >
+                          <Trash2 className="w-4 h-4" />
+                        </button>
                       </div>
-                    )}
+                    </div>
+
+                    <div className="bg-black/20 p-3 flex flex-col gap-2">
+                      <div className="flex justify-between items-center">
+                        <span className="text-[10px] font-bold text-text-muted uppercase tracking-wider">
+                          {t("modals.classEditor.parameters")}{" "}
+                          {method.isConstructor &&
+                            `(${t("modals.classEditor.constructor")})`}
+                        </span>
+                        <button
+                          onClick={() => addParameter(methodIdx)}
+                          className="text-[10px] flex items-center gap-1 text-blue-400/80 hover:text-blue-300"
+                        >
+                          <Plus className="w-3 h-3" />{" "}
+                          {t("modals.classEditor.addParameter")}
+                        </button>
+                      </div>
+
+                      {method.parameters?.length === 0 ? (
+                        <span className="text-[10px] text-text-muted italic">
+                          {t("modals.classEditor.noParameters")}
+                        </span>
+                      ) : (
+                        <div className="flex flex-col gap-1.5">
+                          {method.parameters?.map((param, paramIdx) => (
+                            <div
+                              key={paramIdx}
+                              className="flex items-center gap-2 bg-surface-primary/50 px-2 py-1.5 rounded border border-surface-border/50"
+                            >
+                              <input
+                                className="bg-transparent border-b border-transparent focus:border-uml-class-border outline-none flex-1 min-w-0 text-xs text-text-secondary"
+                                placeholder={t(
+                                  "modals.classEditor.parameterNamePlaceholder",
+                                )}
+                                value={param.name}
+                                onChange={(e) =>
+                                  updateParameter(
+                                    methodIdx,
+                                    paramIdx,
+                                    "name",
+                                    e.target.value,
+                                  )
+                                }
+                              />
+                              <span className="text-text-muted text-xs font-mono">
+                                :
+                              </span>
+                              <select
+                                className="bg-surface-primary border border-surface-border rounded px-1.5 py-0.5 text-[11px] text-uml-interface-border outline-none w-28"
+                                value={param.type}
+                                onChange={(e) =>
+                                  updateParameter(
+                                    methodIdx,
+                                    paramIdx,
+                                    "type",
+                                    e.target.value,
+                                  )
+                                }
+                              >
+                                {availableTypes.map((t) => (
+                                  <option key={t} value={t}>
+                                    {t}
+                                  </option>
+                                ))}
+                              </select>
+                              <label className="flex items-center gap-1 cursor-pointer bg-surface-primary px-1.5 py-0.5 rounded border border-surface-border hover:border-uml-class-border transition-colors">
+                                <input
+                                  type="checkbox"
+                                  checked={!!param.isArray}
+                                  onChange={(e) =>
+                                    updateParameter(
+                                      methodIdx,
+                                      paramIdx,
+                                      "isArray",
+                                      e.target.checked,
+                                    )
+                                  }
+                                  className="accent-uml-class-border w-2.5 h-2.5"
+                                />
+                                <span className="text-[10px] font-mono text-text-muted">
+                                  []
+                                </span>
+                              </label>
+                              <button
+                                onClick={() =>
+                                  removeParameter(methodIdx, paramIdx)
+                                }
+                                className="text-red-400/70 hover:text-red-400 ml-1"
+                              >
+                                <Trash2 className="w-3.5 h-3.5" />
+                              </button>
+                            </div>
+                          ))}
+                        </div>
+                      )}
+                    </div>
                   </div>
+                  {methodErrors.has(methodIdx) && (
+                    <p className="text-xs text-red-500 mt-1 ml-2">
+                      Method signature already exists in this class
+                    </p>
+                  )}
                 </div>
-                {methodErrors.has(methodIdx) && (
-                  <p className="text-xs text-red-500 mt-1 ml-2">Method signature already exists in this class</p>
-                )}
-              </div>
               ))}
             </div>
           </div>
         </div>
 
         <div className="shrink-0 flex justify-end gap-3 pt-4 mt-4 border-t border-surface-border">
-          <button onClick={onClose} className="px-4 py-2 text-sm text-text-secondary hover:text-text-primary">{t("modals.classEditor.cancel")}</button>
-          <button onClick={() => onSave(draft)} className="px-6 py-2 text-sm bg-uml-class-border text-white rounded font-medium hover:brightness-110 shadow-md transition-all active:scale-95">{t("modals.classEditor.save")}</button>
+          <button
+            onClick={onClose}
+            className="px-4 py-2 text-sm text-text-secondary hover:text-text-primary"
+          >
+            {t("modals.classEditor.cancel")}
+          </button>
+          <button
+            onClick={() => onSave(draft)}
+            className="px-6 py-2 text-sm bg-uml-class-border text-white rounded font-medium hover:brightness-110 shadow-md transition-all active:scale-95"
+          >
+            {t("modals.classEditor.save")}
+          </button>
         </div>
       </div>
     </div>,

--- a/src/features/diagram/components/modals/GlobalDeleteModal.tsx
+++ b/src/features/diagram/components/modals/GlobalDeleteModal.tsx
@@ -1,0 +1,160 @@
+import { createPortal } from "react-dom";
+import { TriangleAlert, X } from "lucide-react";
+import { useUiStore } from "../../../../store/uiStore";
+import { useModelStore } from "../../../../store/model.store";
+import { useVFSStore } from "../../../../store/vfs.store";
+import { useToastStore } from "../../../../store/toast.store";
+import type {
+  IRClass,
+  IRInterface,
+  IREnum,
+  SemanticModel,
+} from "../../../../core/domain/vfs/vfs.types";
+
+// ─── Element resolution (shared with SSoTElementEditorModal) ─────────────────
+
+type EditableElement =
+  | { kind: "CLASS"; data: IRClass }
+  | { kind: "INTERFACE"; data: IRInterface }
+  | { kind: "ENUM"; data: IREnum };
+
+function resolveElement(model: SemanticModel, id: string): EditableElement | null {
+  if (model.classes[id]) return { kind: "CLASS", data: model.classes[id] };
+  if (model.interfaces[id]) return { kind: "INTERFACE", data: model.interfaces[id] };
+  if (model.enums[id]) return { kind: "ENUM", data: model.enums[id] };
+  return null;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export default function GlobalDeleteModal() {
+  const { activeModal, editingId, closeModals } = useUiStore();
+  const model = useModelStore((s) => s.model);
+  const deleteClass = useModelStore((s) => s.deleteClass);
+  const deleteInterface = useModelStore((s) => s.deleteInterface);
+  const deleteEnum = useModelStore((s) => s.deleteEnum);
+  const purgeElementFromAllDiagrams = useVFSStore((s) => s.purgeElementFromAllDiagrams);
+  const showToast = useToastStore((s) => s.show);
+
+  const isOpen = activeModal === "global-delete" && !!editingId;
+
+  if (!isOpen || !editingId || !model) return null;
+
+  const element = resolveElement(model, editingId);
+  if (!element) return null;
+
+  const kindLabel =
+    element.kind === "CLASS"
+      ? element.data.isAbstract
+        ? "abstract class"
+        : "class"
+      : element.kind === "INTERFACE"
+        ? "interface"
+        : "enum";
+
+  // ── Cascade deletion ───────────────────────────────────────────────────────
+
+  const handleConfirm = () => {
+    const elementName = element.data.name;
+
+    // Step 1: Snapshot all relation IDs that reference this element BEFORE
+    // ModelStore deletes them. The ModelStore's cascadeDeleteRelations runs
+    // inside immer — IDs are gone by the time the setter returns.
+    const deletedRelationIds = new Set(
+      Object.values(model.relations)
+        .filter((r) => r.sourceId === editingId || r.targetId === editingId)
+        .map((r) => r.id),
+    );
+
+    // Step 2: Remove the element (and its relations) from ModelStore.
+    if (element.kind === "CLASS") {
+      deleteClass(editingId);
+    } else if (element.kind === "INTERFACE") {
+      deleteInterface(editingId);
+    } else {
+      deleteEnum(editingId);
+    }
+
+    // Step 3: Purge every VFS diagram file — remove matching ViewNodes and
+    // ViewEdges so no ghost references remain, even in files not currently open.
+    purgeElementFromAllDiagrams(editingId, deletedRelationIds);
+
+    // Step 4: Feedback + close.
+    showToast(`"${elementName}" and all its references have been removed from the project.`);
+    closeModals();
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && !e.shiftKey) handleConfirm();
+    if (e.key === "Escape") closeModals();
+  };
+
+  // ── Render ─────────────────────────────────────────────────────────────────
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[10000] flex items-center justify-center bg-black/70 backdrop-blur-sm"
+      onClick={closeModals}
+    >
+      <div
+        className="bg-[#0d1117] border border-red-900/50 rounded-xl shadow-2xl w-[440px] text-slate-200"
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={handleKeyDown}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-4 border-b border-red-900/30">
+          <div className="flex items-center gap-2.5">
+            <TriangleAlert className="w-4 h-4 text-red-400 shrink-0" />
+            <h2 className="text-sm font-semibold text-red-300">Delete from Project</h2>
+          </div>
+          <button
+            onClick={closeModals}
+            className="p-1 rounded text-slate-500 hover:text-slate-300 transition-colors"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="px-5 py-5 space-y-3">
+          <p className="text-sm text-slate-300 leading-relaxed">
+            This will permanently delete{" "}
+            <span className="font-semibold text-white">
+              &ldquo;{element.data.name}&rdquo;
+            </span>{" "}
+            ({kindLabel}) from the entire project.
+          </p>
+          <p className="text-sm text-slate-400 leading-relaxed">
+            It will be removed from{" "}
+            <span className="text-red-400 font-medium">ALL diagrams</span>, along with
+            any associations, generalizations, or other relations that connect to it.
+          </p>
+          <div className="flex items-start gap-2 bg-red-950/30 border border-red-900/40 rounded-lg px-3 py-2.5 mt-1">
+            <TriangleAlert className="w-3.5 h-3.5 text-red-400 shrink-0 mt-0.5" />
+            <p className="text-xs text-red-300 leading-relaxed">
+              This action cannot be undone.
+            </p>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="flex justify-end gap-2 px-5 py-4 border-t border-red-900/30">
+          <button
+            autoFocus
+            onClick={closeModals}
+            className="px-4 py-1.5 text-sm text-slate-400 hover:text-slate-200 transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleConfirm}
+            className="px-5 py-1.5 text-sm bg-red-700 hover:bg-red-600 text-white rounded-lg font-medium transition-colors"
+          >
+            Delete from Project
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/features/diagram/components/modals/SSoTClassEditorModal.tsx
+++ b/src/features/diagram/components/modals/SSoTClassEditorModal.tsx
@@ -1,0 +1,219 @@
+import { useMemo } from "react";
+import { useUiStore } from "../../../../store/uiStore";
+import { useModelStore } from "../../../../store/model.store";
+import { useToastStore } from "../../../../store/toast.store";
+import ClassEditorModal from "./ClassEditorModal";
+import type {
+  UmlClassData,
+  UmlAttribute,
+  UmlMethod,
+  visibility as UmlVisibility,
+} from "../../types/diagram.types";
+import type {
+  Visibility,
+  IRAttribute,
+  IROperation,
+  SemanticModel,
+  IRClass,
+  IRInterface,
+  IREnum,
+} from "../../../../core/domain/vfs/vfs.types";
+
+type ResolvedElement =
+  | { kind: "CLASS"; data: IRClass }
+  | { kind: "INTERFACE"; data: IRInterface }
+  | { kind: "ENUM"; data: IREnum };
+
+function resolveElement(
+  model: SemanticModel,
+  id: string,
+): ResolvedElement | null {
+  if (model.classes[id]) return { kind: "CLASS", data: model.classes[id] };
+  if (model.interfaces[id])
+    return { kind: "INTERFACE", data: model.interfaces[id] };
+  if (model.enums[id]) return { kind: "ENUM", data: model.enums[id] };
+  return null;
+}
+
+function irVisToUml(v: Visibility | undefined): UmlVisibility {
+  if (v === "private") return "-";
+  if (v === "protected") return "#";
+  if (v === "package") return "~";
+  return "+";
+}
+
+function umlVisToIr(v: UmlVisibility): Visibility {
+  if (v === "-") return "private";
+  if (v === "#") return "protected";
+  if (v === "~") return "package";
+  return "public";
+}
+
+function toUmlData(model: SemanticModel, element: ResolvedElement): UmlClassData {
+  if (element.kind === "CLASS") {
+    const attributes: UmlAttribute[] = element.data.attributeIds
+      .map((id) => {
+        const a = model.attributes[id];
+        if (!a) return null;
+        return {
+          id: a.id,
+          name: a.name,
+          type: a.type,
+          visibility: irVisToUml(a.visibility),
+          isArray:
+            a.multiplicity === "*" || a.multiplicity === "0..*" || false,
+        } satisfies UmlAttribute;
+      })
+      .filter((a): a is UmlAttribute => a !== null);
+
+    const methods: UmlMethod[] = element.data.operationIds
+      .map((id) => {
+        const o = model.operations[id];
+        if (!o) return null;
+        return {
+          id: o.id,
+          name: o.name,
+          returnType: o.returnType ?? "void",
+          isReturnArray: false,
+          visibility: irVisToUml(o.visibility),
+          parameters: o.parameters.map((p) => ({
+            name: p.name,
+            type: p.type,
+          })),
+          isConstructor: false,
+        } satisfies UmlMethod;
+      })
+      .filter((o): o is UmlMethod => o !== null);
+
+    return {
+      label: element.data.name,
+      attributes,
+      methods,
+      stereotype: element.data.isAbstract ? "abstract" : "class",
+    };
+  }
+
+  if (element.kind === "INTERFACE") {
+    const methods: UmlMethod[] = element.data.operationIds
+      .map((id) => {
+        const o = model.operations[id];
+        if (!o) return null;
+        return {
+          id: o.id,
+          name: o.name,
+          returnType: o.returnType ?? "void",
+          isReturnArray: false,
+          visibility: irVisToUml(o.visibility),
+          parameters: o.parameters.map((p) => ({
+            name: p.name,
+            type: p.type,
+          })),
+          isConstructor: false,
+        } satisfies UmlMethod;
+      })
+      .filter((o): o is UmlMethod => o !== null);
+
+    return {
+      label: element.data.name,
+      attributes: [],
+      methods,
+      stereotype: "interface",
+    };
+  }
+
+  return {
+    label: element.data.name,
+    attributes: [],
+    methods: [],
+    stereotype: "enum",
+  };
+}
+
+function toIrMembers(newData: UmlClassData): {
+  attributes: IRAttribute[];
+  operations: IROperation[];
+} {
+  const attributes: IRAttribute[] = newData.attributes.map((a) => ({
+    id: a.id,
+    kind: "ATTRIBUTE" as const,
+    name: a.name,
+    type: a.type,
+    visibility: umlVisToIr(a.visibility),
+    ...(a.isArray ? { multiplicity: "*" } : {}),
+  }));
+
+  const operations: IROperation[] = newData.methods.map((m) => ({
+    id: m.id,
+    kind: "OPERATION" as const,
+    name: m.name,
+    returnType: m.returnType,
+    visibility: umlVisToIr(m.visibility),
+    parameters: m.parameters.map((p) => ({ name: p.name, type: p.type })),
+  }));
+
+  return { attributes, operations };
+}
+
+export default function SSoTClassEditorModal() {
+  const { activeModal, editingId, closeModals } = useUiStore();
+  const model = useModelStore((s) => s.model);
+  const updateClass = useModelStore((s) => s.updateClass);
+  const updateInterface = useModelStore((s) => s.updateInterface);
+  const updateEnum = useModelStore((s) => s.updateEnum);
+  const setElementMembers = useModelStore((s) => s.setElementMembers);
+  const showToast = useToastStore((s) => s.show);
+
+  const isOpen = activeModal === "ssot-class-editor" && !!editingId;
+
+  const element = useMemo(() => {
+    if (!isOpen || !editingId || !model) return null;
+    return resolveElement(model, editingId);
+  }, [isOpen, editingId, model]);
+
+  const umlData = useMemo(() => {
+    if (!element || !model) return null;
+    return toUmlData(model, element);
+  }, [element, model]);
+
+  const ssotContext = useMemo(() => {
+    if (!model) return { elementNames: [], availableTypeNames: [] };
+    const names = [
+      ...Object.values(model.classes).map((c) => c.name),
+      ...Object.values(model.interfaces).map((i) => i.name),
+      ...Object.values(model.enums).map((e) => e.name),
+    ];
+    return { elementNames: names, availableTypeNames: names };
+  }, [model]);
+
+  if (!isOpen || !umlData || !editingId || !element) return null;
+
+  const handleSave = (newData: UmlClassData) => {
+    if (!model) return;
+
+    if (element.kind === "CLASS") {
+      updateClass(editingId, { name: newData.label });
+      const { attributes, operations } = toIrMembers(newData);
+      setElementMembers(editingId, attributes, operations);
+    } else if (element.kind === "INTERFACE") {
+      updateInterface(editingId, { name: newData.label });
+      const { operations } = toIrMembers(newData);
+      setElementMembers(editingId, [], operations);
+    } else {
+      updateEnum(editingId, { name: newData.label });
+    }
+
+    showToast(`"${newData.label}" saved.`);
+    closeModals();
+  };
+
+  return (
+    <ClassEditorModal
+      key={editingId}
+      isOpen={true}
+      umlData={umlData}
+      onSave={handleSave}
+      onClose={closeModals}
+      ssotContext={ssotContext}
+    />
+  );
+}

--- a/src/features/diagram/components/modals/SSoTElementEditorModal.tsx
+++ b/src/features/diagram/components/modals/SSoTElementEditorModal.tsx
@@ -1,0 +1,217 @@
+import { useState, useEffect } from "react";
+import { createPortal } from "react-dom";
+import { X } from "lucide-react";
+import { useUiStore } from "../../../../store/uiStore";
+import { useModelStore } from "../../../../store/model.store";
+import { useToastStore } from "../../../../store/toast.store";
+import type {
+  IRClass,
+  IRInterface,
+  IREnum,
+  Visibility,
+  SemanticModel,
+} from "../../../../core/domain/vfs/vfs.types";
+
+// ─── Element resolution ───────────────────────────────────────────────────────
+
+type EditableElement =
+  | { kind: "CLASS"; data: IRClass }
+  | { kind: "INTERFACE"; data: IRInterface }
+  | { kind: "ENUM"; data: IREnum };
+
+function resolveElement(model: SemanticModel, id: string): EditableElement | null {
+  if (model.classes[id]) return { kind: "CLASS", data: model.classes[id] };
+  if (model.interfaces[id]) return { kind: "INTERFACE", data: model.interfaces[id] };
+  if (model.enums[id]) return { kind: "ENUM", data: model.enums[id] };
+  return null;
+}
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const VISIBILITY_OPTIONS: { value: Visibility; label: string }[] = [
+  { value: "public", label: "public" },
+  { value: "private", label: "private" },
+  { value: "protected", label: "protected" },
+  { value: "package", label: "package" },
+];
+
+const SSOT_TOAST_MESSAGE =
+  "Changes will be reflected across all diagrams in this project.";
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export default function SSoTElementEditorModal() {
+  const { activeModal, editingId, closeModals } = useUiStore();
+  const model = useModelStore((s) => s.model);
+  const updateClass = useModelStore((s) => s.updateClass);
+  const updateInterface = useModelStore((s) => s.updateInterface);
+  const updateEnum = useModelStore((s) => s.updateEnum);
+  const showToast = useToastStore((s) => s.show);
+
+  const isOpen = activeModal === "ssot-element-editor" && !!editingId;
+
+  const [name, setName] = useState("");
+  const [visibility, setVisibility] = useState<Visibility>("public");
+  const [isAbstract, setIsAbstract] = useState(false);
+
+  // Sync local form state with ModelStore element whenever the modal opens.
+  useEffect(() => {
+    if (!isOpen || !editingId || !model) return;
+    const el = resolveElement(model, editingId);
+    if (!el) return;
+    setName(el.data.name);
+    setVisibility(el.data.visibility ?? "public");
+    setIsAbstract(el.kind === "CLASS" ? !!el.data.isAbstract : false);
+  }, [isOpen, editingId, model]);
+
+  if (!isOpen || !editingId || !model) return null;
+
+  const element = resolveElement(model, editingId);
+  if (!element) return null;
+
+  // ── Derived display values ──────────────────────────────────────────────────
+
+  const isAbstractClass = element.kind === "CLASS" && !!element.data.isAbstract;
+  const kindLabel =
+    element.kind === "CLASS"
+      ? isAbstractClass
+        ? "Abstract Class"
+        : "Class"
+      : element.kind === "INTERFACE"
+        ? "Interface"
+        : "Enum";
+
+  const badgeLabel =
+    element.kind === "CLASS" ? (isAbstractClass ? "A" : "C") :
+    element.kind === "INTERFACE" ? "I" : "E";
+
+  const badgeClass =
+    element.kind === "CLASS"
+      ? isAbstractClass
+        ? "bg-purple-500/20 text-purple-400"
+        : "bg-blue-500/20 text-blue-400"
+      : element.kind === "INTERFACE"
+        ? "bg-emerald-500/20 text-emerald-400"
+        : "bg-amber-500/20 text-amber-400";
+
+  // ── Actions ────────────────────────────────────────────────────────────────
+
+  const handleSave = () => {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+
+    if (element.kind === "CLASS") {
+      updateClass(editingId, { name: trimmed, visibility, isAbstract });
+    } else if (element.kind === "INTERFACE") {
+      updateInterface(editingId, { name: trimmed, visibility });
+    } else {
+      updateEnum(editingId, { name: trimmed, visibility });
+    }
+
+    showToast(SSOT_TOAST_MESSAGE);
+    closeModals();
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && !e.shiftKey) handleSave();
+    if (e.key === "Escape") closeModals();
+  };
+
+  // ── Render ─────────────────────────────────────────────────────────────────
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[10000] flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      onClick={closeModals}
+    >
+      <div
+        className="bg-[#0d1117] border border-[#1e2738] rounded-xl shadow-2xl w-96 text-slate-200"
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={handleKeyDown}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-4 border-b border-[#1e2738]">
+          <div className="flex items-center gap-2.5">
+            <span
+              className={`inline-flex items-center justify-center w-5 h-5 text-[10px] font-bold rounded ${badgeClass}`}
+            >
+              {badgeLabel}
+            </span>
+            <h2 className="text-sm font-semibold">Edit {kindLabel}</h2>
+          </div>
+          <button
+            onClick={closeModals}
+            className="p-1 rounded text-slate-500 hover:text-slate-300 transition-colors"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="px-5 py-5 space-y-4">
+          {/* Name */}
+          <div>
+            <label className="block text-[10px] font-semibold uppercase tracking-wider text-slate-500 mb-1.5">
+              Name
+            </label>
+            <input
+              autoFocus
+              className="w-full bg-[#161b22] border border-[#1e2738] rounded-lg px-3 py-2 text-sm text-slate-100 focus:outline-none focus:border-blue-500/60 transition-colors"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+            />
+          </div>
+
+          {/* Visibility */}
+          <div>
+            <label className="block text-[10px] font-semibold uppercase tracking-wider text-slate-500 mb-1.5">
+              Visibility
+            </label>
+            <select
+              className="w-full bg-[#161b22] border border-[#1e2738] rounded-lg px-3 py-2 text-sm text-slate-100 focus:outline-none focus:border-blue-500/60 transition-colors"
+              value={visibility}
+              onChange={(e) => setVisibility(e.target.value as Visibility)}
+            >
+              {VISIBILITY_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Abstract toggle — classes only */}
+          {element.kind === "CLASS" && (
+            <label className="flex items-center gap-3 cursor-pointer select-none">
+              <input
+                type="checkbox"
+                checked={isAbstract}
+                onChange={(e) => setIsAbstract(e.target.checked)}
+                className="accent-purple-500 w-3.5 h-3.5"
+              />
+              <span className="text-sm text-slate-400">Abstract class</span>
+            </label>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex justify-end gap-2 px-5 py-4 border-t border-[#1e2738]">
+          <button
+            onClick={closeModals}
+            className="px-4 py-1.5 text-sm text-slate-400 hover:text-slate-200 transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={!name.trim()}
+            className="px-5 py-1.5 text-sm bg-blue-600 hover:bg-blue-500 disabled:opacity-40 disabled:cursor-not-allowed text-white rounded-lg font-medium transition-colors"
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/features/diagram/hooks/useDiagramDnD.ts
+++ b/src/features/diagram/hooks/useDiagramDnD.ts
@@ -10,6 +10,17 @@ import { useModelStore } from "../../../store/model.store";
 import { isDiagramView } from "./useVFSCanvasController";
 import type { DiagramView, ViewNode, VFSFile, SemanticModel } from "../../../core/domain/vfs/vfs.types";
 
+// ─── Drag type constants ──────────────────────────────────────────────────────
+
+/** Payload set by the tool palette — creates a NEW semantic element on drop. */
+export const DRAG_TYPE_NEW = "application/reactflow" as const;
+
+/**
+ * Payload set by the Model Explorer SSOT sidebar — the semantic element already
+ * exists. The drop handler must ONLY create a ViewNode; it must NOT touch ModelStore.
+ */
+export const DRAG_TYPE_EXISTING = "application/reactflow-existing-node" as const;
+
 // ─── VFS name helper ──────────────────────────────────────────────────────────
 
 /**
@@ -17,7 +28,7 @@ import type { DiagramView, ViewNode, VFSFile, SemanticModel } from "../../../cor
  * Mirrors the logic of getNextDefaultName but works with plain string arrays
  * so it can operate on SemanticModel collections without depending on DomainNode types.
  */
-function getNextVFSName(existingNames: string[], prefix: string): string {
+export function getNextVFSName(existingNames: string[], prefix: string): string {
   const pattern = new RegExp(`^${prefix}\\s+(\\d+)$`);
   let max = 0;
   for (const name of existingNames) {
@@ -153,13 +164,42 @@ export const useDiagramDnD = () => {
     (event: React.DragEvent) => {
       event.preventDefault();
 
-      const stereotype = event.dataTransfer.getData(
-        "application/reactflow",
-      ) as stereotype;
+      const position = getCenteredPosition(event.clientX, event.clientY);
+
+      // ===================================================================
+      // EXISTING ELEMENT DROP (Model Explorer SSOT sidebar)
+      // The semantic element already lives in ModelStore. Only create a
+      // ViewNode — do NOT touch ModelStore.
+      // ===================================================================
+      const existingElementId = event.dataTransfer.getData(DRAG_TYPE_EXISTING);
+      if (existingElementId) {
+        if (!activeTabId) return;
+
+        const freshProject = useVFSStore.getState().project;
+        if (!freshProject) return;
+        const freshFileNode = freshProject.nodes[activeTabId];
+        if (!freshFileNode || freshFileNode.type !== 'FILE') return;
+        const freshContent = (freshFileNode as VFSFile).content;
+        if (!isDiagramView(freshContent)) return;
+        const freshView = freshContent as DiagramView;
+
+        const viewNode: ViewNode = {
+          id: crypto.randomUUID(),
+          elementId: existingElementId,
+          x: position.x,
+          y: position.y,
+        };
+
+        updateFileContent(activeTabId, {
+          ...freshView,
+          nodes: [...freshView.nodes, viewNode],
+        });
+        return;
+      }
+
+      const stereotype = event.dataTransfer.getData(DRAG_TYPE_NEW) as stereotype;
 
       if (!stereotype) return;
-
-      const position = getCenteredPosition(event.clientX, event.clientY);
 
       // ===================================================================
       // VFS SEMANTIC DROP

--- a/src/features/diagram/hooks/useDiagramMenus.ts
+++ b/src/features/diagram/hooks/useDiagramMenus.ts
@@ -6,6 +6,8 @@ import { useWorkspaceStore } from "../../../store/workspace.store";
 import { useUiStore } from "../../../store/uiStore";
 import { useDiagram } from "../../workspace/hooks/useDiagram";
 import type { DomainEdge } from "../../../core/domain/models/edges";
+import type { DomainNode } from "../../../core/domain/models";
+import type { ClassDiagramMetadata } from "../../../core/domain/workspace/diagram-file.types";
 
 export type ContextMenuType = "pane" | "node" | "edge";
 
@@ -21,19 +23,10 @@ interface UseDiagramMenusProps {
   onClearCanvas: () => void;
   onEditEdgeMultiplicity: (edgeId: string) => void;
   onGenerateMethods?: (nodeId: string) => void;
-  /** VFS-aware view-only removal. Removes the node from this diagram only. */
   onDeleteNode?: (nodeId: string) => void;
-  /** VFS-aware full cascade. Deletes semantic element from model + all diagrams. */
   onDeleteNodeFromModel?: (nodeId: string) => void;
-  /** VFS-aware edge delete override. When provided, replaces the legacy ProjectStore deleteEdge path. */
   onDeleteEdge?: (edgeId: string) => void;
-  /** VFS-aware edge reverse override. When provided, replaces the legacy ProjectStore reverseEdge path. */
   onReverseEdge?: (edgeId: string) => void;
-  /**
-   * VFS-aware edge kind change override.
-   * Receives the ReactFlow edge ID and the legacy type string (e.g. 'INHERITANCE').
-   * The caller is responsible for translating to IRRelation.kind if needed.
-   */
   onChangeEdgeKind?: (edgeId: string, kind: string) => void;
 }
 
@@ -71,16 +64,13 @@ export const useDiagramMenus = ({
     (nodeId: string) => {
       if (!file) return;
 
-      // Get edge IDs BEFORE removing the node (cascade delete will remove edges from ProjectStore)
       const connectedEdgeIds = getEdgeIdsForNode(nodeId);
 
-      // Remove from WorkspaceStore
       removeNodeFromFile(file.id, nodeId);
       connectedEdgeIds.forEach((edgeId) => {
         removeEdgeFromFile(file.id, edgeId);
       });
 
-      // Remove from ProjectStore (cascade delete handles edges automatically)
       removeNode(nodeId);
       markFileDirty(file.id);
     },
@@ -94,28 +84,26 @@ export const useDiagramMenus = ({
       const originalNode = getNode(nodeId);
       if (!originalNode) return;
 
-      // Create a new node with the same type
       const newNode = registry.factories.createNode(originalNode.type);
 
-      // Copy all properties from original node except id, createdAt, updatedAt
+      const baseName = 'name' in originalNode
+        ? (originalNode as { name: string }).name
+        : 'Node';
+
       const duplicatedNode = {
         ...originalNode,
         id: newNode.id,
         createdAt: newNode.createdAt,
         updatedAt: newNode.updatedAt,
-        name: `${(originalNode as any).name}_copy`,
-      } as any;
+        ...('name' in originalNode ? { name: `${baseName}_copy` } : {}),
+      } as DomainNode;
 
-      // Add node to ProjectStore
       addNode(duplicatedNode);
-
-      // Add node to file
       addNodeToFile(file.id, newNode.id);
 
-      // Get original position and offset it
-      const metadata = file.metadata as any;
-      const positionMap = metadata?.positionMap || {};
-      const originalPosition = positionMap[nodeId] || { x: 0, y: 0 };
+      const classMeta = file.metadata as ClassDiagramMetadata | undefined;
+      const positionMap = classMeta?.positionMap ?? {};
+      const originalPosition = positionMap[nodeId] ?? { x: 0, y: 0 };
 
       const newPositionMap = {
         ...positionMap,
@@ -125,12 +113,11 @@ export const useDiagramMenus = ({
         },
       };
 
-      // Update file with new position
       updateFile(file.id, {
         metadata: {
-          ...file.metadata,
+          ...classMeta,
           positionMap: newPositionMap,
-        } as any,
+        } as ClassDiagramMetadata,
       });
 
       markFileDirty(file.id);
@@ -255,7 +242,6 @@ export const useDiagramMenus = ({
         }
 
         if (onDeleteNodeFromModel) {
-          // VFS mode: separate "Remove from Diagram" (view-only) and "Delete from Model" (cascade).
           baseOptions.push({
             label: t("contextMenu.node.removeFromDiagram") || "Remove from Diagram",
             onClick: () => onDeleteNode!(nodeId),
@@ -278,7 +264,6 @@ export const useDiagramMenus = ({
       if (menu.type === "edge" && menu.id) {
         const edgeId = menu.id;
 
-        // VFS path: overrides provided — build menu from VFS callbacks directly.
         if (onDeleteEdge) {
           const typeOptions = [
             {
@@ -321,7 +306,6 @@ export const useDiagramMenus = ({
           ];
         }
 
-        // Legacy path: use ProjectStore.
         const edge = getEdge(edgeId);
         const type = edge?.type || "ASSOCIATION";
         const isNoteEdge = type === "NOTE_LINK";

--- a/src/features/diagram/hooks/useVFSCanvasController.ts
+++ b/src/features/diagram/hooks/useVFSCanvasController.ts
@@ -17,7 +17,10 @@ import type {
   NodeViewModel,
   NoteViewModel,
   NodeStyleConfig,
+  NodeSection,
+  NodeSectionItem,
 } from '../../../adapters/react-flow/view-models/node.view-model';
+import type { Visibility } from '../../../core/domain/vfs/vfs.types';
 import type { RelationKind } from '../../../core/domain/vfs/vfs.types';
 
 // ─── Type guard ───────────────────────────────────────────────────────────────
@@ -87,6 +90,75 @@ const VFS_DISPLAY: Record<string, ElementDisplayConfig> = {
   },
 };
 
+// ─── Visibility symbol ────────────────────────────────────────────────────────
+
+function irVisSymbol(v: Visibility | undefined): string {
+  switch (v) {
+    case 'private':   return '-';
+    case 'protected': return '#';
+    case 'package':   return '~';
+    default:          return '+';
+  }
+}
+
+// ─── Section builder ──────────────────────────────────────────────────────────
+
+function buildSections(
+  model: SemanticModel,
+  element: IRClass | IRInterface | IREnum,
+  kind: SemanticKind,
+): NodeSection[] {
+  const sections: NodeSection[] = [];
+
+  if (kind === 'CLASS' || kind === 'ABSTRACT_CLASS') {
+    const cls = element as IRClass;
+    const attrs = cls.attributeIds.map((id) => model.attributes[id]).filter(Boolean);
+    const ops = cls.operationIds.map((id) => model.operations[id]).filter(Boolean);
+
+    sections.push({
+      id: 'attributes',
+      items: attrs.map((a) => ({
+        id: a.id,
+        text: `${irVisSymbol(a.visibility)}${a.name}: ${a.type}`,
+        isStatic: a.isStatic,
+      })),
+    });
+
+    sections.push({
+      id: 'operations',
+      items: ops.map((o) => ({
+        id: o.id,
+        text: `${irVisSymbol(o.visibility)}${o.name}(): ${o.returnType ?? 'void'}`,
+        isStatic: o.isStatic,
+        isAbstract: o.isAbstract,
+      })),
+    });
+  } else if (kind === 'INTERFACE') {
+    const iface = element as IRInterface;
+    const ops = iface.operationIds.map((id) => model.operations[id]).filter(Boolean);
+
+    sections.push({
+      id: 'operations',
+      items: ops.map((o) => ({
+        id: o.id,
+        text: `${irVisSymbol(o.visibility)}${o.name}(): ${o.returnType ?? 'void'}`,
+        isAbstract: o.isAbstract,
+      })),
+    });
+  } else if (kind === 'ENUM') {
+    const enm = element as IREnum;
+    sections.push({
+      id: 'literals',
+      items: enm.literals.map((lit, i) => ({
+        id: `${enm.id}-lit-${i}`,
+        text: lit.name,
+      })),
+    });
+  }
+
+  return sections;
+}
+
 // ─── Semantic resolution ──────────────────────────────────────────────────────
 
 type SemanticKind = 'CLASS' | 'ABSTRACT_CLASS' | 'INTERFACE' | 'ENUM' | 'NOTE' | 'UNKNOWN';
@@ -123,17 +195,17 @@ function makeReactFlowNode(
   viewNode: ViewNode,
   label: string,
   displayConfig: ElementDisplayConfig,
+  sections: NodeSection[],
   onRename: (name: string, generics?: string) => void,
 ) {
   const viewModel: NodeViewModel = {
     id: viewNode.id,
-    domainId: viewNode.elementId, // stable semantic ID used for updates
+    domainId: viewNode.elementId,
     label,
     stereotype: displayConfig.stereotype,
-    sections: [],
+    sections,
     style: displayConfig.style,
     metadata: {
-      // Callback for UmlClassNode inline rename — writes to ModelStore, not ProjectStore.
       onRename,
     },
   };
@@ -303,10 +375,10 @@ export function useVFSCanvasController(): VFSCanvasResult {
 
       const label = element?.name ?? 'NewClass';
       const displayConfig = VFS_DISPLAY[kind] ?? VFS_DISPLAY.CLASS;
+      const sections = element ? buildSections(model, element, kind) : [];
 
-      // Each node gets a stable closure over its own elementId and kind.
       const onRename = (name: string, generics?: string) => {
-        const ms = useModelStore.getState(); // safe: called from event handler
+        const ms = useModelStore.getState();
         if (!ms.model) return;
         switch (kind) {
           case 'CLASS':
@@ -325,7 +397,7 @@ export function useVFSCanvasController(): VFSCanvasResult {
         }
       };
 
-      return makeReactFlowNode(viewNode, label, displayConfig, onRename);
+      return makeReactFlowNode(viewNode, label, displayConfig, sections, onRename);
     });
   }, [diagramView, model]);
 

--- a/src/store/layout.store.ts
+++ b/src/store/layout.store.ts
@@ -1,0 +1,52 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import { storageAdapter } from '../adapters/storage/storage.adapter';
+
+interface LayoutStoreState {
+  isLeftPanelOpen: boolean;
+  isRightPanelOpen: boolean;
+  isBottomPanelOpen: boolean;
+
+  toggleLeftPanel: () => void;
+  toggleRightPanel: () => void;
+  toggleBottomPanel: () => void;
+}
+
+export const useLayoutStore = create<LayoutStoreState>()(
+  persist(
+    (set) => ({
+      isLeftPanelOpen: true,
+      isRightPanelOpen: true,
+      isBottomPanelOpen: false,
+
+      toggleLeftPanel: () =>
+        set((s) => ({ isLeftPanelOpen: !s.isLeftPanelOpen })),
+
+      toggleRightPanel: () =>
+        set((s) => ({ isRightPanelOpen: !s.isRightPanelOpen })),
+
+      toggleBottomPanel: () =>
+        set((s) => ({ isBottomPanelOpen: !s.isBottomPanelOpen })),
+    }),
+    {
+      name: 'libreuml-layout',
+      partialize: (state) => ({
+        isLeftPanelOpen: state.isLeftPanelOpen,
+        isRightPanelOpen: state.isRightPanelOpen,
+        isBottomPanelOpen: state.isBottomPanelOpen,
+      }),
+      storage: {
+        getItem: (name) => {
+          const value = storageAdapter.getItem(name);
+          return value ? JSON.parse(value) : null;
+        },
+        setItem: (name, value) => {
+          storageAdapter.setItem(name, JSON.stringify(value));
+        },
+        removeItem: (name) => {
+          storageAdapter.removeItem(name);
+        },
+      },
+    },
+  ),
+);

--- a/src/store/model.store.ts
+++ b/src/store/model.store.ts
@@ -46,6 +46,9 @@ interface ModelStoreState {
   updateEnum: (id: string, patch: Partial<IREnum>) => void;
   deleteEnum: (id: string) => void;
 
+  // ── Member management ──────────────────────────────────────────────────────
+  setElementMembers: (elementId: string, attributes: IRAttribute[], operations: IROperation[]) => void;
+
   // ── Relation CRUD ──────────────────────────────────────────────────────────
   createRelation: (data: Omit<IRRelation, 'id'>) => string;
   updateRelation: (id: string, patch: Partial<Omit<IRRelation, 'id'>>) => void;
@@ -179,6 +182,28 @@ export const useModelStore = create<ModelStoreState>()(
         if (!state.model) return;
         delete state.model.enums[id];
         cascadeDeleteRelations(state.model, id);
+        state.model.updatedAt = Date.now();
+      }),
+
+    // ── Member management ─────────────────────────────────────────────────────
+
+    setElementMembers: (elementId, attributes, operations) =>
+      set((state) => {
+        if (!state.model) return;
+        const cls = state.model.classes[elementId];
+        const iface = state.model.interfaces[elementId];
+        if (cls) {
+          cls.attributeIds.forEach((id) => { delete state.model!.attributes[id]; });
+          cls.operationIds.forEach((id) => { delete state.model!.operations[id]; });
+          attributes.forEach((a) => { state.model!.attributes[a.id] = a; });
+          operations.forEach((o) => { state.model!.operations[o.id] = o; });
+          state.model.classes[elementId].attributeIds = attributes.map((a) => a.id);
+          state.model.classes[elementId].operationIds = operations.map((o) => o.id);
+        } else if (iface) {
+          iface.operationIds.forEach((id) => { delete state.model!.operations[id]; });
+          operations.forEach((o) => { state.model!.operations[o.id] = o; });
+          state.model.interfaces[elementId].operationIds = operations.map((o) => o.id);
+        }
         state.model.updatedAt = Date.now();
       }),
 

--- a/src/store/toast.store.ts
+++ b/src/store/toast.store.ts
@@ -1,0 +1,29 @@
+import { create } from 'zustand';
+
+const AUTO_DISMISS_MS = 3500;
+
+interface Toast {
+  id: string;
+  message: string;
+}
+
+interface ToastStoreState {
+  toasts: Toast[];
+  show: (message: string) => void;
+  dismiss: (id: string) => void;
+}
+
+export const useToastStore = create<ToastStoreState>((set) => ({
+  toasts: [],
+
+  show: (message) => {
+    const id = crypto.randomUUID();
+    set((s) => ({ toasts: [...s.toasts, { id, message }] }));
+    setTimeout(() => {
+      set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) }));
+    }, AUTO_DISMISS_MS);
+  },
+
+  dismiss: (id) =>
+    set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) })),
+}));

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -12,6 +12,9 @@ export type ActiveModal =
   | "engineering-reverse"
   | "import-code"
   | "method-generator"
+  | "ssot-element-editor"
+  | "ssot-class-editor"
+  | "global-delete"
   | null;
 
 interface UiStoreState {
@@ -29,6 +32,9 @@ interface UiStoreState {
   openReverseEngineering: () => void;
   openImportCode: () => void;
   openMethodGenerator: (nodeId: string) => void;
+  openSSoTElementEditor: (elementId: string) => void;
+  openSSoTClassEditor: (elementId: string) => void;
+  openGlobalDelete: (elementId: string) => void;
   closeModals: () => void;
 }
 
@@ -61,6 +67,15 @@ export const useUiStore = create<UiStoreState>((set) => ({
 
   openMethodGenerator: (nodeId) =>
     set({ activeModal: "method-generator", editingId: nodeId }),
+
+  openSSoTElementEditor: (elementId) =>
+    set({ activeModal: "ssot-element-editor", editingId: elementId }),
+
+  openSSoTClassEditor: (elementId) =>
+    set({ activeModal: "ssot-class-editor", editingId: elementId }),
+
+  openGlobalDelete: (elementId) =>
+    set({ activeModal: "global-delete", editingId: elementId }),
 
   closeModals: () => set({ activeModal: null, editingId: null }),
 }));


### PR DESCRIPTION
- Unify class editing through ClassEditorModal with SSoTContext for VFS elements; add SSoTClassEditorModal portal that reads IR→UmlClassData and writes back via updateClass/Interface/Enum + setElementMembers
- Add setElementMembers to ModelStore for atomic attribute/operation replacement
- Add openSSoTClassEditor action to uiStore; wire RightSidebar and DiagramCanvas to open it instead of the legacy ProjectStore-based editor
- Fix clearCanvas in VFS mode: only clears ViewNodes/ViewEdges, never touches ModelStore semantic elements
- Fix node hydration on drop: buildSections populates NodeSection[] from ModelStore attributes/operations so canvas nodes immediately display members after drag-drop
- Fix RightSidebar tree expansion: double-click now toggles expand instead of opening editor; chevron onMouseDown prevents drag-event interference
- Fix Left Sidebar white-block collapse bug: PrimarySideBar root uses w-full instead of w-64 so it tracks parent width; DiagramEditor wrapper adds min-w-0 to guarantee full flex collapse to 0px
- Make PanelLeftClose button in ProjectStructure always visible (was opacity-0 until hover)
- Remove all 'as any' casts from modified files; strict TypeScript throughout