### PR TITLE
feat(help): add keyboard shortcuts modal with OS-aware key bindings

### DIFF
--- a/src/features/diagram/components/layout/DiagramCanvas.tsx
+++ b/src/features/diagram/components/layout/DiagramCanvas.tsx
@@ -46,6 +46,7 @@ import SingleClassGeneratorModal from "../modals/SingleClassGeneratorModal";
 import ProjectGeneratorModal from "../modals/ProjectGeneratorModal";
 import ImportCodeModal from "../modals/ImportCodeModal";
 import CodeExportConfigModal from "../modals/CodeExportConfigModal";
+import KeyboardShortcutsModal from "../modals/KeyboardShortcutsModal";
 
 export default function DiagramCanvas() {
   const { t } = useTranslation();
@@ -438,6 +439,10 @@ export default function DiagramCanvas() {
       <OpenFileModal />
       <CodeExportConfigModal 
         isOpen={activeModal === 'code-export-config'}
+        onClose={closeModals}
+      />
+      <KeyboardShortcutsModal 
+        isOpen={activeModal === 'keyboard-shortcuts'}
         onClose={closeModals}
       />
 

--- a/src/features/diagram/components/menubar/modules/HelpMenu.tsx
+++ b/src/features/diagram/components/menubar/modules/HelpMenu.tsx
@@ -3,14 +3,17 @@ import {
   Bug, 
   Map, 
   Info, 
-  Rocket 
+  Rocket,
+  Keyboard
 } from "lucide-react";
 import { MenubarTrigger } from "../../../../../components/ui/menubar/MenubarTrigger";
 import { MenubarItem } from "../../../../../components/ui/menubar/MenubarItem";
 import { useTranslation } from "react-i18next";
+import { useUiStore } from "../../../../../store/uiStore";
 
 export function HelpMenuContent() {
   const { t } = useTranslation();
+  const openKeyboardShortcuts = useUiStore((s) => s.openKeyboardShortcuts);
   
   const openDocs = () => window.open("https://github.com/The-Indigo0218/LibreUML#readme", "_blank");
   const reportIssue = () => window.open("https://github.com/The-Indigo0218/LibreUML/issues", "_blank");
@@ -27,6 +30,14 @@ export function HelpMenuContent() {
         icon={<Rocket className="w-4 h-4" />}
         disabled={true}
       />
+
+      <MenubarItem
+        label={t("menubar.help.keyboardShortcuts")}
+        icon={<Keyboard className="w-4 h-4" />}
+        onClick={openKeyboardShortcuts}
+      />
+
+      <div className="h-px bg-surface-border my-1" />
 
       <MenubarItem
         label={t("menubar.help.documentation")}

--- a/src/features/diagram/components/modals/KeyboardShortcutsModal.tsx
+++ b/src/features/diagram/components/modals/KeyboardShortcutsModal.tsx
@@ -1,0 +1,171 @@
+import { createPortal } from 'react-dom';
+import { X, Keyboard, Command } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { useEffect } from 'react';
+
+interface KeyboardShortcutsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+interface Shortcut {
+  keys: string[];
+  descriptionKey: string;
+}
+
+interface ShortcutCategory {
+  titleKey: string;
+  shortcuts: Shortcut[];
+}
+
+// ─── Detect OS for Cmd vs Ctrl ───────────────────────────────────────────────
+
+const isMac = typeof navigator !== 'undefined' && navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+const modKey = isMac ? '⌘' : 'Ctrl';
+
+// ─── Main Component ───────────────────────────────────────────────────────────
+
+export default function KeyboardShortcutsModal({ isOpen, onClose }: KeyboardShortcutsModalProps) {
+  const { t } = useTranslation();
+
+  useEffect(() => {
+    if (!isOpen) return;
+    
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    
+    document.addEventListener('keydown', handleEscape);
+    return () => document.removeEventListener('keydown', handleEscape);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  const categories: ShortcutCategory[] = [
+    {
+      titleKey: 'keyboardShortcuts.categories.general',
+      shortcuts: [
+        { keys: [modKey, 'O'], descriptionKey: 'keyboardShortcuts.shortcuts.openFile' },
+        { keys: [modKey, 'S'], descriptionKey: 'keyboardShortcuts.shortcuts.save' },
+        { keys: [modKey, 'K'], descriptionKey: 'keyboardShortcuts.shortcuts.spotlight' },
+        { keys: [modKey, 'Z'], descriptionKey: 'keyboardShortcuts.shortcuts.undo' },
+        { keys: [modKey, 'Y'], descriptionKey: 'keyboardShortcuts.shortcuts.redo' },
+      ],
+    },
+    {
+      titleKey: 'keyboardShortcuts.categories.canvas',
+      shortcuts: [
+        { keys: [modKey, 'L'], descriptionKey: 'keyboardShortcuts.shortcuts.magicLayout' },
+        { keys: [modKey, 'G'], descriptionKey: 'keyboardShortcuts.shortcuts.generateCode' },
+        { keys: [modKey, '+'], descriptionKey: 'keyboardShortcuts.shortcuts.zoomIn' },
+        { keys: [modKey, '-'], descriptionKey: 'keyboardShortcuts.shortcuts.zoomOut' },
+        { keys: [modKey, '0'], descriptionKey: 'keyboardShortcuts.shortcuts.fitView' },
+        { keys: ['Delete'], descriptionKey: 'keyboardShortcuts.shortcuts.delete' },
+      ],
+    },
+    {
+      titleKey: 'keyboardShortcuts.categories.terminal',
+      shortcuts: [
+        { keys: ['↑'], descriptionKey: 'keyboardShortcuts.shortcuts.commandHistoryUp' },
+        { keys: ['↓'], descriptionKey: 'keyboardShortcuts.shortcuts.commandHistoryDown' },
+        { keys: ['Tab'], descriptionKey: 'keyboardShortcuts.shortcuts.autocomplete' },
+        { keys: [modKey, 'C'], descriptionKey: 'keyboardShortcuts.shortcuts.clearInput' },
+      ],
+    },
+  ];
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        className="bg-surface-primary border border-surface-border rounded-xl shadow-2xl w-full max-w-3xl max-h-[90vh] flex flex-col animate-in fade-in zoom-in-95 duration-200"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* ── Header ──────────────────────────────────────────────────── */}
+        <div className="px-6 py-4 border-b border-surface-border flex items-center justify-between shrink-0">
+          <div className="flex items-center gap-3">
+            <div className="p-2 bg-purple-500/10 rounded-lg">
+              <Keyboard className="w-5 h-5 text-purple-400" />
+            </div>
+            <div>
+              <h2 className="text-lg font-bold text-text-primary">
+                {t('keyboardShortcuts.title')}
+              </h2>
+              <p className="text-xs text-text-muted mt-0.5">
+                {t('keyboardShortcuts.subtitle')}
+              </p>
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-2 hover:bg-surface-hover rounded-lg transition-colors text-text-muted hover:text-text-primary"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        {/* ── Content ────────────────────────────────────────────────── */}
+        <div className="flex-1 overflow-y-auto p-6">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+            {categories.map((category, categoryIndex) => (
+              <div key={categoryIndex} className="space-y-3">
+                {/* Category Title */}
+                <h3 className="text-xs font-bold text-text-secondary uppercase tracking-wider flex items-center gap-2">
+                  <Command className="w-3.5 h-3.5" />
+                  {t(category.titleKey)}
+                </h3>
+
+                {/* Shortcuts List */}
+                <div className="bg-surface-secondary border border-surface-border rounded-lg p-3 space-y-2">
+                  {category.shortcuts.map((shortcut, shortcutIndex) => (
+                    <div
+                      key={shortcutIndex}
+                      className="flex items-center justify-between py-2 px-2 rounded hover:bg-surface-hover transition-colors group"
+                    >
+                      {/* Description */}
+                      <span className="text-sm text-text-primary group-hover:text-text-primary">
+                        {t(shortcut.descriptionKey)}
+                      </span>
+
+                      {/* Keys */}
+                      <div className="flex items-center gap-1">
+                        {shortcut.keys.map((key, keyIndex) => (
+                          <kbd
+                            key={keyIndex}
+                            className="px-2 py-1 text-xs font-mono font-semibold bg-surface-primary border border-surface-border rounded shadow-sm text-text-primary min-w-[28px] text-center"
+                          >
+                            {key}
+                          </kbd>
+                        ))}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* ── Footer Note ────────────────────────────────────────────── */}
+          <div className="mt-6 p-4 bg-blue-500/10 border border-blue-500/30 rounded-lg">
+            <p className="text-xs text-text-muted text-center">
+              {t('keyboardShortcuts.footerNote')}
+            </p>
+          </div>
+        </div>
+
+        {/* ── Footer Button ──────────────────────────────────────────── */}
+        <div className="px-6 py-4 border-t border-surface-border flex items-center justify-end shrink-0">
+          <button
+            onClick={onClose}
+            className="px-6 py-2 text-sm font-medium bg-purple-600 hover:bg-purple-700 text-white rounded-lg transition-colors flex items-center gap-2"
+          >
+            {t('keyboardShortcuts.actions.close')}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -90,6 +90,7 @@
     "help": {
       "title": "Help",
       "gettingStarted": "Getting Started",
+      "keyboardShortcuts": "Keyboard Shortcuts",
       "documentation": "Documentation",
       "reportIssue": "Report Issue",
       "roadmap": "Roadmap",
@@ -596,6 +597,36 @@
       "cancel": "Cancel",
       "export": "Export Code",
       "exportDisabled": "Select at least one class to export"
+    }
+  },
+  "keyboardShortcuts": {
+    "title": "Keyboard Shortcuts",
+    "subtitle": "Master LibreUML with these shortcuts",
+    "footerNote": "Press ESC to close this dialog at any time",
+    "categories": {
+      "general": "General",
+      "canvas": "Canvas",
+      "terminal": "Terminal"
+    },
+    "shortcuts": {
+      "openFile": "Open File",
+      "save": "Save",
+      "spotlight": "Spotlight Search",
+      "undo": "Undo",
+      "redo": "Redo",
+      "magicLayout": "Magic Auto-Layout",
+      "generateCode": "Generate Code",
+      "zoomIn": "Zoom In",
+      "zoomOut": "Zoom Out",
+      "fitView": "Fit View",
+      "delete": "Delete Selected",
+      "commandHistoryUp": "Previous Command",
+      "commandHistoryDown": "Next Command",
+      "autocomplete": "Autocomplete",
+      "clearInput": "Clear Input"
+    },
+    "actions": {
+      "close": "Got it!"
     }
   }
 }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -89,6 +89,7 @@
     "help": {
       "title": "Ayuda",
       "gettingStarted": "Primeros Pasos",
+      "keyboardShortcuts": "Atajos de Teclado",
       "documentation": "Documentación",
       "reportIssue": "Reportar Error",
       "roadmap": "Hoja de Ruta",
@@ -596,6 +597,36 @@
       "cancel": "Cancelar",
       "export": "Exportar Código",
       "exportDisabled": "Selecciona al menos una clase para exportar"
+    }
+  },
+  "keyboardShortcuts": {
+    "title": "Atajos de Teclado",
+    "subtitle": "Domina LibreUML con estos atajos",
+    "footerNote": "Presiona ESC para cerrar este diálogo en cualquier momento",
+    "categories": {
+      "general": "General",
+      "canvas": "Lienzo",
+      "terminal": "Terminal"
+    },
+    "shortcuts": {
+      "openFile": "Abrir Archivo",
+      "save": "Guardar",
+      "spotlight": "Búsqueda Rápida",
+      "undo": "Deshacer",
+      "redo": "Rehacer",
+      "magicLayout": "Diseño Automático Mágico",
+      "generateCode": "Generar Código",
+      "zoomIn": "Acercar",
+      "zoomOut": "Alejar",
+      "fitView": "Ajustar Vista",
+      "delete": "Eliminar Seleccionado",
+      "commandHistoryUp": "Comando Anterior",
+      "commandHistoryDown": "Comando Siguiente",
+      "autocomplete": "Autocompletar",
+      "clearInput": "Limpiar Entrada"
+    },
+    "actions": {
+      "close": "¡Entendido!"
     }
   }
 }

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -19,6 +19,7 @@ export type ActiveModal =
   | "ssot-class-editor"
   | "global-delete"
   | "code-export-config"
+  | "keyboard-shortcuts"
   | null;
 
 interface UiStoreState {
@@ -43,6 +44,7 @@ interface UiStoreState {
   openVfsEdgeAction: (edgeId: string) => void;
   openAutoLayoutLockedWarning: () => void;
   openCodeExportConfig: () => void;
+  openKeyboardShortcuts: () => void;
   closeModals: () => void;
 }
 
@@ -96,6 +98,9 @@ export const useUiStore = create<UiStoreState>((set) => ({
 
   openCodeExportConfig: () =>
     set({ activeModal: "code-export-config", editingId: null }),
+
+  openKeyboardShortcuts: () =>
+    set({ activeModal: "keyboard-shortcuts", editingId: null }),
 
   closeModals: () => set({ activeModal: null, editingId: null }),
 }));


### PR DESCRIPTION
- Create KeyboardShortcutsModal component with categorized shortcuts (General, Canvas, Terminal)
- Add OS detection to display Cmd (Mac) or Ctrl (Windows/Linux) appropriately
- Integrate modal into DiagramCanvas with 'keyboard-shortcuts' modal state
- Add Keyboard Shortcuts menu item to Help menu with keyboard icon
- Add openKeyboardShortcuts action to uiStore for modal state management
- Add i18n translations for keyboard shortcuts, categories, and descriptions in English and Spanish
- Support Escape key to close modal and click-outside dismissal
- Display shortcuts in responsive grid layout with visual hierarchy and category grouping