### PR TITLE
feat(diagram): replace bug report tab with external form link

### DIFF
--- a/src/features/diagram/components/layout/ActivityBar.tsx
+++ b/src/features/diagram/components/layout/ActivityBar.tsx
@@ -1,7 +1,7 @@
 import { FolderTree, Package, Wrench, UserCircle, Cloud, Github, Bug } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
-export type ActivityTab = "structure" | "packages" | "tools" | "profile" | "cloud" | "github" | "bug" | null;
+export type ActivityTab = "structure" | "packages" | "tools" | "profile" | "cloud" | "github" | null;
 
 interface ActivityBarProps {
   activeTab: ActivityTab;
@@ -59,12 +59,15 @@ export default function ActivityBar({ activeTab, onTabChange }: ActivityBarProps
         onClick={() => handleTabClick("github")}
       />
 
-      <ActivityBarIcon
-        icon={<Bug className="w-5 h-5" />}
-        label={t('activityBar.bugReport')}
-        isActive={activeTab === "bug"}
-        onClick={() => handleTabClick("bug")}
-      />
+      <a
+        href="https://forms.gle/GBTnWcmEMV1EryMZ8"
+        target="_blank"
+        rel="noopener noreferrer"
+        title="Report Bug"
+        className="mt-auto w-10 h-10 flex items-center justify-center rounded-md text-text-muted hover:text-text-primary hover:bg-surface-hover transition-all duration-200"
+      >
+        <Bug className="w-5 h-5" />
+      </a>
     </aside>
   );
 }

--- a/src/features/diagram/components/layout/PrimarySideBar.tsx
+++ b/src/features/diagram/components/layout/PrimarySideBar.tsx
@@ -21,7 +21,6 @@ export default function PrimarySideBar({ activeTab }: PrimarySideBarProps) {
       {activeTab === "profile" && <div className="flex-1 p-4 text-text-secondary">{t("primarySidebar.userProfile")}</div>}
       {activeTab === "cloud" && <div className="flex-1 p-4 text-text-secondary">{t("primarySidebar.cloudSync")}</div>}
       {activeTab === "github" && <div className="flex-1 p-4 text-text-secondary">{t("primarySidebar.githubIntegration")}</div>}
-      {activeTab === "bug" && <div className="flex-1 p-4 text-text-secondary">{t("primarySidebar.bugReport")}</div>}
     </div>
   );
 }


### PR DESCRIPTION
- Remove "bug" from ActivityTab type union
- Replace ActivityBarIcon component with direct anchor link to bug report form
- Link opens Google Form in new tab with proper security attributes
- Simplifies bug reporting workflow by directing users to external form
- Maintains consistent styling with other activity bar icons