### PR TITLE
feat(editor): add drag-and-drop XMI import and improve file handling

### DIFF
--- a/src/features/diagram/components/layout/DiagramCanvas.tsx
+++ b/src/features/diagram/components/layout/DiagramCanvas.tsx
@@ -30,7 +30,6 @@ import SpotlightModal from "../modals/SpotlightModal";
 import MultiplicityModal from "../modals/MultiplicityModal";
 import VfsEdgeActionModal from "../modals/VfsEdgeActionModal";
 import { AutoLayoutLockedWarningModal } from "../modals/AutoLayoutLockedWarningModal";
-import { OpenFileModal } from "../modals/OpenFileModal";
 import MethodGeneratorModal from "../modals/MethodGeneratorModal";
 
 import { useContextMenu } from "../../hooks/useContextMenu";
@@ -55,6 +54,7 @@ export default function DiagramCanvas() {
 
   const {
     nodes: legacyNodes,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     edges: _edges,
     onNodesChange,
     onEdgesChange,
@@ -490,8 +490,7 @@ export default function DiagramCanvas() {
 
       <VfsEdgeActionModal />
       <AutoLayoutLockedWarningModal />
-      <OpenFileModal />
-      <CodeExportConfigModal 
+      <CodeExportConfigModal
         isOpen={activeModal === 'code-export-config'}
         onClose={closeModals}
       />

--- a/src/features/diagram/components/layout/DiagramEditor.tsx
+++ b/src/features/diagram/components/layout/DiagramEditor.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { ReactFlowProvider } from "reactflow";
 import DiagramCanvas from "./DiagramCanvas";
 import AppMenubar from "../menubar/AppMenubar";
@@ -14,12 +14,14 @@ import SSoTElementEditorModal from "../modals/SSoTElementEditorModal";
 import SSoTClassEditorModal from "../modals/SSoTClassEditorModal";
 import GlobalDeleteModal from "../modals/GlobalDeleteModal";
 import ToastContainer from "../../../../components/shared/ToastContainer";
+import { OpenFileModal } from "../modals/OpenFileModal";
 import { useAutoSave } from "../../../../hooks/actions/useAutoSave";
 import { useAutoRestore } from "../../../../hooks/useAutoRestore";
 import { useThemeSystem } from "../../../../hooks/useThemeSystem";
 import { useVFSStore } from "../../../../store/project-vfs.store";
 import { useWorkspaceStore } from "../../../../store/workspace.store";
 import { useLayoutStore } from "../../../../store/layout.store";
+import { injectXmiIntoVFS } from "../../../../services/openFileService";
 
 function EditorLogic() {
   const [activeTab, setActiveTab] = useState<ActivityTab>("structure");
@@ -30,6 +32,40 @@ function EditorLogic() {
   useAutoSave();
   useAutoRestore();
   useThemeSystem();
+
+  useEffect(() => {
+    const handleDragOver = (e: DragEvent) => {
+      if (e.dataTransfer?.types.includes('Files')) {
+        e.preventDefault();
+      }
+    };
+
+    const handleDrop = (e: DragEvent) => {
+      const files = Array.from(e.dataTransfer?.files ?? []);
+      const xmiFile = files.find((f) => /\.(xmi|xmin)$/i.test(f.name));
+      if (!xmiFile) return;
+      e.preventDefault();
+      if (!useVFSStore.getState().project) return;
+      const reader = new FileReader();
+      reader.onload = async (ev) => {
+        try {
+          const content = ev.target?.result as string;
+          const baseName = xmiFile.name.replace(/\.[^/.]+$/, '');
+          await injectXmiIntoVFS(content, baseName, 'project');
+        } catch (err) {
+          console.error('[LibreUML] XMI drop import failed:', err);
+        }
+      };
+      reader.readAsText(xmiFile);
+    };
+
+    window.addEventListener('dragover', handleDragOver);
+    window.addEventListener('drop', handleDrop);
+    return () => {
+      window.removeEventListener('dragover', handleDragOver);
+      window.removeEventListener('drop', handleDrop);
+    };
+  }, []);
 
   if (!project) {
     return (
@@ -49,7 +85,7 @@ function EditorLogic() {
         {/* ── Left panel (slides in/out) ─────────────────────────────── */}
         <div
           className={`h-full overflow-hidden transition-all duration-200 ease-in-out shrink-0 min-w-0 ${
-            isLeftPanelOpen ? "w-64" : "w-0"
+            isLeftPanelOpen && activeTab ? "w-64" : "w-0"
           }`}
         >
           <PrimarySideBar activeTab={activeTab} />
@@ -89,6 +125,7 @@ function EditorLogic() {
       <StatusBar />
 
       {/* ── VFS-native modals (portal-rendered, outside layout tree) ──── */}
+      <OpenFileModal />
       <SSoTElementEditorModal />
       <SSoTClassEditorModal />
       <GlobalDeleteModal />

--- a/src/features/diagram/components/modals/OpenFileModal.tsx
+++ b/src/features/diagram/components/modals/OpenFileModal.tsx
@@ -49,7 +49,7 @@ export function OpenFileModal() {
       if (ext === 'luml') {
         await openLumlFile(file, mode);
         closeModals();
-      } else if (ext === 'xmi' || ext === 'xml') {
+      } else if (ext === 'xmi' || ext === 'xml' || ext === 'xmin') {
         await new Promise<void>((resolve, reject) => {
           const reader = new FileReader();
           reader.onload = async (ev) => {
@@ -68,7 +68,7 @@ export function OpenFileModal() {
         closeModals();
       } else {
         setError(
-          `Unsupported file type ".${ext}". Supported formats: .luml, .xmi`,
+          `Unsupported file type ".${ext}". Supported formats: .luml, .xmi, .xmin`,
         );
       }
     } catch (err) {
@@ -194,7 +194,7 @@ export function OpenFileModal() {
           type="file"
           ref={fileInputRef}
           onChange={handleFileSelected}
-          accept=".luml,.xmi,.xml"
+          accept=".luml,.xmi,.xml,.xmin"
           className="hidden"
           aria-hidden="true"
         />

--- a/src/services/vfsExport.service.ts
+++ b/src/services/vfsExport.service.ts
@@ -243,7 +243,7 @@ export function downloadVfsDiagramJson(
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
   a.href = url;
-  a.download = `${safeName}.json`;
+  a.download = `${safeName}.luml`;
   document.body.appendChild(a);
   a.click();
   document.body.removeChild(a);


### PR DESCRIPTION
- Add drag-and-drop support for XMI/XMIN file import directly into editor
- Implement file type detection and validation for dropped files
- Add XMIN file extension support alongside existing XMI format
- Move OpenFileModal from DiagramCanvas to DiagramEditor for better modal hierarchy
- Fix left panel collapse logic to account for active tab state
- Update file input accept attribute to include .xmin extension
- Change diagram export filename extension from .json to .luml for consistency
- Add useEffect hook to DiagramEditor for drag event listener management
- Improves user experience by enabling direct file import via drag-and-drop