### PR TITLE
feat(canvas): v0.9.0 architecture migration, advanced package nesting & VFS integration (v0.9.0)

### DIFF
--- a/src/canvas/interactions/useConnectionDraw.ts
+++ b/src/canvas/interactions/useConnectionDraw.ts
@@ -331,18 +331,22 @@ export function useConnectionDraw({
               const srcStereotype = resolveStereotype(srcNode.data);
               const tgtStereotype = resolveStereotype(tgtNode.data);
 
-              // Determine current connection kind from WorkspaceStore.
-              const wsState = useWorkspaceStore.getState();
-              const rawMode = wsState.connectionModes?.[activeTabId ?? ''] as string | undefined;
-              const kind: RelationKind = TOOL_TO_RELATION_KIND[rawMode ?? ''] ?? 'ASSOCIATION';
-              const umlType = RELATION_TO_UML[kind] ?? 'association';
-
-              if (!validateConnection(srcStereotype, tgtStereotype, umlType)) {
-                useToastStore.getState().show(
-                  '⚠️ Relación inválida según estereotipos UML',
-                );
-              } else {
+              // Package→package: always allowed. Kind is forced to DEPENDENCY in the handler.
+              if (srcStereotype === 'package' && tgtStereotype === 'package') {
                 onConnect(src.nodeId, snap.nodeId);
+              } else {
+                const wsState = useWorkspaceStore.getState();
+                const rawMode = wsState.connectionModes?.[activeTabId ?? ''] as string | undefined;
+                const kind: RelationKind = TOOL_TO_RELATION_KIND[rawMode ?? ''] ?? 'ASSOCIATION';
+                const umlType = RELATION_TO_UML[kind] ?? 'association';
+
+                if (!validateConnection(srcStereotype, tgtStereotype, umlType)) {
+                  useToastStore.getState().show(
+                    '⚠️ Relación inválida según estereotipos UML',
+                  );
+                } else {
+                  onConnect(src.nodeId, snap.nodeId);
+                }
               }
             } else {
               // Fallback: let onConnect handle validation if nodes not found.

--- a/src/config/theme.config.ts
+++ b/src/config/theme.config.ts
@@ -56,21 +56,39 @@ export const edgeConfig = {
     },
     aggregation: {
       style: { strokeWidth: 2, stroke: PALETTE.base },
-      marker: { color: PALETTE.aggregation, width: 25, height: 25 }, // Color propio
+      marker: { color: PALETTE.aggregation, width: 25, height: 25 }, 
       zIndex: 8,
-      highlight: PALETTE.aggregation, // Color al hacer hover
+      highlight: PALETTE.aggregation, 
     },
     composition: {
       style: { strokeWidth: 2.5, stroke: PALETTE.base },
-      marker: { color: PALETTE.composition, width: 25, height: 25 }, // Color propio
+      marker: { color: PALETTE.composition, width: 25, height: 25 }, 
       zIndex: 9,
-      highlight: PALETTE.composition, // Color al hacer hover
+      highlight: PALETTE.composition, 
     },
     note: {
       style: { strokeWidth: 1, strokeDasharray: "3,3", stroke: PALETTE.base },
       marker: { color: PALETTE.base, width: 15, height: 15 },
       zIndex: 1,
       highlight: PALETTE.note,
+    },
+    package_import: {
+      style: { strokeWidth: 1.5, strokeDasharray: "6,4", stroke: PALETTE.base },
+      marker: { color: PALETTE.base, width: 20, height: 20 },
+      zIndex: 3,
+      highlight: PALETTE.dependency,
+    },
+    package_access: {
+      style: { strokeWidth: 1.5, strokeDasharray: "6,4", stroke: PALETTE.base },
+      marker: { color: PALETTE.base, width: 20, height: 20 },
+      zIndex: 3,
+      highlight: PALETTE.dependency,
+    },
+    package_merge: {
+      style: { strokeWidth: 1.5, strokeDasharray: "6,4", stroke: PALETTE.base },
+      marker: { color: PALETTE.base, width: 20, height: 20 },
+      zIndex: 3,
+      highlight: PALETTE.dependency,
     },
   },
 };

--- a/src/core/domain/models/edges/class-diagram.types.ts
+++ b/src/core/domain/models/edges/class-diagram.types.ts
@@ -3,14 +3,17 @@ import type { BaseDomainEdge, Multiplicable, Labelable } from './base.types';
 /**
  * Class Diagram Edge Types (Discriminated Union)
  */
-export type ClassDiagramEdgeType = 
-  | 'ASSOCIATION' 
-  | 'INHERITANCE' 
-  | 'IMPLEMENTATION' 
-  | 'DEPENDENCY' 
-  | 'AGGREGATION' 
+export type ClassDiagramEdgeType =
+  | 'ASSOCIATION'
+  | 'INHERITANCE'
+  | 'IMPLEMENTATION'
+  | 'DEPENDENCY'
+  | 'AGGREGATION'
   | 'COMPOSITION'
-  | 'NOTE_LINK';
+  | 'NOTE_LINK'
+  | 'PACKAGE_IMPORT'
+  | 'PACKAGE_ACCESS'
+  | 'PACKAGE_MERGE';
 
 /**
  * Association Edge (SSOT Domain Model)
@@ -65,13 +68,34 @@ export interface NoteLinkEdge extends BaseDomainEdge {
 }
 
 /**
- * Discriminated Union of all Class Diagram edges
+ * Package Import Edge — «import» (public namespace import)
  */
-export type ClassDiagramEdge = 
-  | AssociationEdge 
-  | InheritanceEdge 
-  | ImplementationEdge 
-  | DependencyEdge 
-  | AggregationEdge 
+export interface PackageImportEdge extends BaseDomainEdge {
+  type: 'PACKAGE_IMPORT';
+}
+
+/**
+ * Package Access Edge — «access» (private namespace access)
+ */
+export interface PackageAccessEdge extends BaseDomainEdge {
+  type: 'PACKAGE_ACCESS';
+}
+
+/**
+ * Package Merge Edge — «merge» (extends/merges target package)
+ */
+export interface PackageMergeEdge extends BaseDomainEdge {
+  type: 'PACKAGE_MERGE';
+}
+
+export type ClassDiagramEdge =
+  | AssociationEdge
+  | InheritanceEdge
+  | ImplementationEdge
+  | DependencyEdge
+  | AggregationEdge
   | CompositionEdge
-  | NoteLinkEdge;
+  | NoteLinkEdge
+  | PackageImportEdge
+  | PackageAccessEdge
+  | PackageMergeEdge;

--- a/src/core/domain/vfs/vfs.types.ts
+++ b/src/core/domain/vfs/vfs.types.ts
@@ -61,6 +61,8 @@ export interface ViewNode {
   noteTitle?: string;
   parentPackageId?: string | null;
   collapsed?: boolean;
+  /** Package name for package container nodes. */
+  packageName?: string;
 }
 
 export interface ViewEdge {

--- a/src/core/registry/__tests__/diagram-registry.test.ts
+++ b/src/core/registry/__tests__/diagram-registry.test.ts
@@ -43,6 +43,9 @@ describe('Diagram Registry', () => {
         'AGGREGATION',
         'COMPOSITION',
         'NOTE_LINK',
+        'PACKAGE_IMPORT',
+        'PACKAGE_ACCESS',
+        'PACKAGE_MERGE',
       ]);
     });
 

--- a/src/core/registry/diagram-registry.ts
+++ b/src/core/registry/diagram-registry.ts
@@ -25,6 +25,9 @@ import type {
   AggregationEdge,
   CompositionEdge,
   NoteLinkEdge,
+  PackageImportEdge,
+  PackageAccessEdge,
+  PackageMergeEdge,
 } from '../domain/models/edges/class-diagram.types';
 import type {
   UseCaseAssociationEdge,
@@ -160,6 +163,24 @@ function createClassDiagramEdge(
         type: 'NOTE_LINK',
       } as NoteLinkEdge;
 
+    case 'PACKAGE_IMPORT':
+      return {
+        ...baseEdge,
+        type: 'PACKAGE_IMPORT',
+      } as PackageImportEdge;
+
+    case 'PACKAGE_ACCESS':
+      return {
+        ...baseEdge,
+        type: 'PACKAGE_ACCESS',
+      } as PackageAccessEdge;
+
+    case 'PACKAGE_MERGE':
+      return {
+        ...baseEdge,
+        type: 'PACKAGE_MERGE',
+      } as PackageMergeEdge;
+
     default:
       throw new Error(`Unknown Class Diagram edge type: ${type}`);
   }
@@ -274,6 +295,9 @@ const classDiagramRegistry: DiagramTypeRegistry = {
     'AGGREGATION',
     'COMPOSITION',
     'NOTE_LINK',
+    'PACKAGE_IMPORT',
+    'PACKAGE_ACCESS',
+    'PACKAGE_MERGE',
   ],
 
   defaultNodeType: 'CLASS',

--- a/src/features/diagram/components/layout/RightSidebar.tsx
+++ b/src/features/diagram/components/layout/RightSidebar.tsx
@@ -293,44 +293,21 @@ export default function RightSidebar() {
 
   const packageNames: string[] = useMemo(() => {
     const names = new Set<string>();
-    
+
+    // Semantic packages (not yet placed on canvas as visual nodes)
     if (model?.packageNames) {
-      model.packageNames.forEach(name => names.add(name));
+      model.packageNames.forEach((name) => names.add(name));
     }
-    
-    if (model?.packages && activeTabId && project) {
-      const file = project.nodes[activeTabId];
-      if (file && file.type === 'FILE') {
-        const vfsFile = file as VFSFile;
-        const content = vfsFile.content;
-        
-        if (content && typeof content === 'object' && 'nodes' in content) {
-          const viewNodes = (content as any).nodes || [];
-          
-          for (const vn of viewNodes) {
-            const pkg = model.packages[vn.elementId];
-            if (!pkg) continue;
-            
-            let effectivePath = pkg.name;
-            let currentVN = vn;
-            
-            while (currentVN.parentPackageId) {
-              const parentVN = viewNodes.find((n: any) => n.id === currentVN.parentPackageId);
-              if (!parentVN) break;
-              const parentPkg = model.packages[parentVN.elementId];
-              if (!parentPkg) break;
-              effectivePath = `${parentPkg.name}.${effectivePath}`;
-              currentVN = parentVN;
-            }
-            
-            names.add(effectivePath);
-          }
-        }
-      }
+
+    // Visual/canvas packages — removed from packageNames when dropped on canvas,
+    // so we gather them from model.packages. pkg.name already stores the full
+    // qualified path (e.g. "com.model"), no parent-walk needed.
+    if (model?.packages) {
+      Object.values(model.packages).forEach((pkg) => names.add(pkg.name));
     }
-    
+
     return Array.from(names).sort();
-  }, [model, activeTabId, project]);
+  }, [model]);
 
   const DEFAULT_PKG = "__default__";
 

--- a/src/features/diagram/components/modals/ExportModal.tsx
+++ b/src/features/diagram/components/modals/ExportModal.tsx
@@ -21,7 +21,7 @@ import { ExportService } from "../../../../services/export.service";
 import {
   downloadVfsDiagramXmi,
 } from "../../../../services/vfsExport.service";
-import { exportDiagram } from "../../../../services/projectIO.service";
+import { getDiagramIOService } from "../../../../services/diagram";
 import { isDiagramView } from "../../hooks/useVFSCanvasController";
 import { useKonvaCanvasController } from "../../../../canvas/hooks/useKonvaCanvasController";
 import type { VFSFile, DiagramView } from "../../../../core/domain/vfs/vfs.types";
@@ -188,9 +188,18 @@ export default function ExportModal({ isOpen, onClose }: ExportModalProps) {
       downloadVfsDiagramXmi(model, selectedDiagramView, selectedFileName);
       onClose();
     } else if (format === "json") {
-      // Use exportDiagram instead of downloadVfsDiagramJson to include semantic model
-      await exportDiagram(selectedFileId);
-      onClose();
+      // Use new DiagramIOService for JSON export
+      try {
+        const service = getDiagramIOService();
+        await service.exportDiagram(selectedFileId);
+        onClose();
+      } catch (error) {
+        alert(
+          t("alerts.exportError") ||
+          "Error exporting diagram" +
+          (error instanceof Error ? `: ${error.message}` : "")
+        );
+      }
     }
   };
 

--- a/src/features/diagram/components/modals/VfsEdgeActionModal.tsx
+++ b/src/features/diagram/components/modals/VfsEdgeActionModal.tsx
@@ -19,6 +19,13 @@ const CLASS_RELATION_KINDS: { value: RelationKind; label: string }[] = [
   { value: 'COMPOSITION',    label: 'Composition' },
 ];
 
+const PACKAGE_RELATION_KINDS: { value: RelationKind; label: string; stereotype: string | null; description: string }[] = [
+  { value: 'DEPENDENCY',     label: 'Dependency',      stereotype: null,       description: 'Generic dependency between packages' },
+  { value: 'PACKAGE_IMPORT', label: '«import»',        stereotype: '«import»', description: 'Public namespace import — exported members are visible to importing package' },
+  { value: 'PACKAGE_ACCESS', label: '«access»',        stereotype: '«access»', description: 'Private namespace access — not re-exported to further importers' },
+  { value: 'PACKAGE_MERGE',  label: '«merge»',         stereotype: '«merge»',  description: 'Package merge — elements of target are conceptually merged into source' },
+];
+
 const MULTIPLICITY_KINDS = new Set<RelationKind>([
   'ASSOCIATION', 'AGGREGATION', 'COMPOSITION',
 ]);
@@ -38,6 +45,7 @@ function getElementName(model: SemanticModel, elementId: string): string {
     model.classes[elementId]?.name ??
     model.interfaces[elementId]?.name ??
     model.enums[elementId]?.name ??
+    model.packages[elementId]?.name ??
     elementId
   );
 }
@@ -99,12 +107,15 @@ export default function VfsEdgeActionModal() {
 
   if (!isOpen || !viewEdge || !relation || !activeModel) return null;
 
+  const isPackageRelation =
+    !!(activeModel.packages[relation.sourceId] && activeModel.packages[relation.targetId]);
+
   const sourceName = getElementName(activeModel, relation.sourceId);
   const targetName = getElementName(activeModel, relation.targetId);
   const displaySource = reversed ? targetName : sourceName;
   const displayTarget = reversed ? sourceName : targetName;
 
-  const showMultiplicity = MULTIPLICITY_KINDS.has(kind);
+  const showMultiplicity = !isPackageRelation && MULTIPLICITY_KINDS.has(kind);
   const srcMulValid = isValidMultiplicity(sourceMul);
   const tgtMulValid = isValidMultiplicity(targetMul);
   const canSave = srcMulValid && tgtMulValid;
@@ -178,7 +189,7 @@ export default function VfsEdgeActionModal() {
 
         <div className="px-5 py-3 border-b border-surface-border flex justify-between items-center bg-surface-secondary/50">
           <h2 className="text-sm font-bold text-text-primary uppercase tracking-wide">
-            Editar Relación
+            {isPackageRelation ? t('vfsEdgeAction.titlePackage') : t('vfsEdgeAction.title')}
           </h2>
           <button onClick={closeModals} className="text-text-secondary hover:text-text-primary transition-colors">
             <X className="w-5 h-5" />
@@ -189,17 +200,55 @@ export default function VfsEdgeActionModal() {
 
           <div className="space-y-3">
             <label className="block text-xs font-bold text-text-secondary uppercase tracking-wider">
-              Tipo de Relación
+              {t('vfsEdgeAction.relationType')}
             </label>
-            <select
-              className="w-full bg-surface-secondary border border-surface-border rounded px-3 py-2 text-sm text-text-primary outline-none focus:border-uml-class-border"
-              value={kind}
-              onChange={(e) => setKind(e.target.value as RelationKind)}
-            >
-              {CLASS_RELATION_KINDS.map(({ value, label }) => (
-                <option key={value} value={value}>{label}</option>
-              ))}
-            </select>
+
+            {isPackageRelation ? (
+              <div className="flex flex-col gap-1.5">
+                {PACKAGE_RELATION_KINDS.map(({ value, label, stereotype: stereo }) => (
+                  <button
+                    key={value}
+                    onClick={() => setKind(value)}
+                    className={`w-full flex items-center gap-3 px-3 py-2.5 rounded-lg border text-left transition-all ${
+                      kind === value
+                        ? 'bg-indigo-500/20 border-indigo-500 text-indigo-300'
+                        : 'bg-surface-secondary border-surface-border text-text-secondary hover:border-indigo-400/50 hover:text-text-primary'
+                    }`}
+                  >
+                    <span className="w-20 text-center font-mono text-xs font-bold shrink-0 italic">
+                      {stereo ?? '→'}
+                    </span>
+                    <span className="text-sm font-medium">{label}</span>
+                  </button>
+                ))}
+              </div>
+            ) : (
+              <select
+                className="w-full bg-surface-secondary border border-surface-border rounded px-3 py-2 text-sm text-text-primary outline-none focus:border-uml-class-border"
+                value={kind}
+                onChange={(e) => setKind(e.target.value as RelationKind)}
+              >
+                {CLASS_RELATION_KINDS.map(({ value, label }) => (
+                  <option key={value} value={value}>{label}</option>
+                ))}
+              </select>
+            )}
+
+            {isPackageRelation && (
+              <div className="mt-2 rounded-lg border border-surface-border bg-surface-secondary/30 p-3 space-y-2">
+                <div className="text-[10px] font-bold text-text-muted uppercase tracking-wider mb-2">
+                  {t('vfsEdgeAction.packageLegend.title')}
+                </div>
+                {PACKAGE_RELATION_KINDS.map(({ stereotype: stereo, description }) => (
+                  <div key={description} className="flex items-start gap-2 text-xs text-text-secondary">
+                    <span className="font-mono italic text-indigo-400 w-20 shrink-0 text-center">
+                      {stereo ?? '→'}
+                    </span>
+                    <span>{description}</span>
+                  </div>
+                ))}
+              </div>
+            )}
 
             <div className="flex items-center gap-3 bg-surface-secondary/50 rounded-lg p-3 border border-surface-border">
               <div className="flex-1 text-center min-w-0">

--- a/src/features/diagram/hooks/useVFSCanvasController.ts
+++ b/src/features/diagram/hooks/useVFSCanvasController.ts
@@ -306,26 +306,14 @@ function makeReactFlowNoteNode(
 function computePackageDisplayName(
   viewNode: ViewNode,
   pkg: IRPackage,
-  allViewNodes: ViewNode[],
-  allPackages: Record<string, IRPackage>,
 ): string {
   if (!viewNode.parentPackageId) {
-    // Standalone package — use stored name as-is (may already be full qualified)
+    // Root-level package — show the full stored name (e.g. "com")
     return pkg.name;
   }
-  // Walk parent chain, collecting last segments to build full qualified name
-  const segments: string[] = [];
-  let currentId: string | null | undefined = viewNode.parentPackageId;
-  while (currentId) {
-    const parentVN = allViewNodes.find((vn) => vn.id === currentId);
-    if (!parentVN) break;
-    const parentPkg = allPackages[parentVN.elementId];
-    if (!parentPkg) break;
-    segments.unshift(parentPkg.name.split('.').pop() || parentPkg.name);
-    currentId = parentVN.parentPackageId;
-  }
-  segments.push(pkg.name.split('.').pop() || pkg.name);
-  return segments.join('.');
+  // Nested package — show only the simple name (last segment).
+  // The parent is already visible on the canvas so the prefix is redundant.
+  return pkg.name.split('.').pop() || pkg.name;
 }
 
 function makeReactFlowPackageNode(
@@ -351,7 +339,7 @@ function makeReactFlowPackageNode(
   const viewModel: PackageViewModel = {
     __brand: 'package',
     id: viewNode.id,
-    name: computePackageDisplayName(viewNode, pkg, allViewNodes, allPackages),
+    name: computePackageDisplayName(viewNode, pkg),
     collapsed: viewNode.collapsed ?? false,
     color: viewNode.color,
     childCount,
@@ -634,7 +622,11 @@ export function useVFSCanvasController(): VFSCanvasResult {
       const label = element?.name ?? 'NewClass';
       const displayConfig = VFS_DISPLAY[kind] ?? VFS_DISPLAY.CLASS;
       const sections = element ? buildSections(model, element as IRClass | IRInterface | IREnum, kind) : [];
-      const badge = (element as IRClass | IRInterface | IREnum | null)?.packageName ?? undefined;
+      // Only show the package badge when the element is NOT already visually
+      // inside a package on the canvas — avoids redundant labelling.
+      const badge = viewNode.parentPackageId
+        ? undefined
+        : (element as IRClass | IRInterface | IREnum | null)?.packageName ?? undefined;
 
       const onRename = (name: string, generics?: string) => {
         if (isStandalone && activeTabId) {

--- a/src/features/diagram/hooks/useVFSCanvasController.ts
+++ b/src/features/diagram/hooks/useVFSCanvasController.ts
@@ -320,7 +320,7 @@ function makeReactFlowPackageNode(
   viewNode: ViewNode,
   pkg: IRPackage,
   allViewNodes: ViewNode[],
-  allPackages: Record<string, IRPackage>,
+  _allPackages: Record<string, IRPackage>,
 ) {
   const childCount = allViewNodes.filter(vn => vn.parentPackageId === viewNode.id).length;
 

--- a/src/features/diagram/types/diagram.types.ts
+++ b/src/features/diagram/types/diagram.types.ts
@@ -7,7 +7,10 @@ export type UmlRelationType =
   | "implementation"
   | "dependency"
   | "aggregation"
-  | "composition";
+  | "composition"
+  | "package_import"
+  | "package_access"
+  | "package_merge";
 export type visibility = "+" | "-" | "#" | "~";
 
 export interface UmlAttribute {

--- a/src/hooks/canvas/useCanvasEventHandlers.ts
+++ b/src/hooks/canvas/useCanvasEventHandlers.ts
@@ -209,7 +209,13 @@ export function useCanvasEventHandlers({
 
       const wsState = useWorkspaceStore.getState();
       const rawMode = wsState.connectionModes?.[activeTabId ?? ''] as string | undefined;
-      const kind: RelationKind = TOOL_TO_RELATION_KIND[rawMode ?? ''] ?? 'ASSOCIATION';
+      const activeModel = isStandalone ? getLocalModel(activeTabId) : useModelStore.getState().model;
+      const sourceIsPkg = !!(activeModel?.packages[sourceVN.elementId]);
+      const targetIsPkg = !!(activeModel?.packages[targetVN.elementId]);
+      const kind: RelationKind =
+        sourceIsPkg && targetIsPkg
+          ? 'DEPENDENCY'
+          : (TOOL_TO_RELATION_KIND[rawMode ?? ''] ?? 'ASSOCIATION');
 
       const SELF_LOOP_FORBIDDEN = new Set<RelationKind>(['GENERALIZATION', 'REALIZATION']);
       if (sourceVN.elementId === targetVN.elementId && SELF_LOOP_FORBIDDEN.has(kind)) {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -557,6 +557,7 @@
   },
   "vfsEdgeAction": {
     "title": "Edit Relation",
+    "titlePackage": "Package Relation",
     "relationType": "Relation Type",
     "origin": "Origin",
     "destination": "Destination",
@@ -568,7 +569,10 @@
     "lockAnchors": "Lock connection points",
     "delete": "Delete",
     "cancel": "Cancel",
-    "save": "Save"
+    "save": "Save",
+    "packageLegend": {
+      "title": "UML Package Relation Legend"
+    }
   },
   "globalDeleteModal": {
     "title": "Delete from Project",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -550,6 +550,7 @@
   },
   "vfsEdgeAction": {
     "title": "Editar Relación",
+    "titlePackage": "Relación de Paquetes",
     "relationType": "Tipo de Relación",
     "origin": "Origen",
     "destination": "Destino",
@@ -561,7 +562,10 @@
     "lockAnchors": "Bloquear puntos de conexión",
     "delete": "Eliminar",
     "cancel": "Cancelar",
-    "save": "Guardar"
+    "save": "Guardar",
+    "packageLegend": {
+      "title": "Leyenda de Relaciones de Paquete"
+    }
   },
   "globalDeleteModal": {
     "title": "Eliminar del Proyecto",

--- a/src/services/diagram/DiagramIOService.ts
+++ b/src/services/diagram/DiagramIOService.ts
@@ -48,9 +48,11 @@ export interface ParsedDiagram {
  * Diagram export error
  */
 export class DiagramExportError extends Error {
-  constructor(message: string, public readonly cause?: unknown) {
+  readonly cause?: unknown;
+  constructor(message: string, cause?: unknown) {
     super(message);
     this.name = 'DiagramExportError';
+    this.cause = cause;
   }
 }
 
@@ -58,21 +60,37 @@ export class DiagramExportError extends Error {
  * Diagram import error
  */
 export class DiagramImportError extends Error {
-  constructor(message: string, public readonly cause?: unknown) {
+  readonly cause?: unknown;
+  constructor(message: string, cause?: unknown) {
     super(message);
     this.name = 'DiagramImportError';
+    this.cause = cause;
   }
 }
 
 export class DiagramIOService {
+  private readonly serializer: DiagramSerializer;
+  private readonly deserializer: DiagramDeserializer;
+  private readonly validator: DiagramValidator;
+  private readonly extractor: ModelExtractor;
+  private readonly getVFSStore: () => VFSStore;
+  private readonly getModelStore: () => ModelStore;
+
   constructor(
-    private readonly serializer: DiagramSerializer,
-    private readonly deserializer: DiagramDeserializer,
-    private readonly validator: DiagramValidator,
-    private readonly extractor: ModelExtractor,
-    private readonly getVFSStore: () => VFSStore,
-    private readonly getModelStore: () => ModelStore,
-  ) {}
+    serializer: DiagramSerializer,
+    deserializer: DiagramDeserializer,
+    validator: DiagramValidator,
+    extractor: ModelExtractor,
+    getVFSStore: () => VFSStore,
+    getModelStore: () => ModelStore,
+  ) {
+    this.serializer = serializer;
+    this.deserializer = deserializer;
+    this.validator = validator;
+    this.extractor = extractor;
+    this.getVFSStore = getVFSStore;
+    this.getModelStore = getModelStore;
+  }
 
   /**
    * Exports a single diagram as flat JSON

--- a/src/services/diagram/DiagramIOService.ts
+++ b/src/services/diagram/DiagramIOService.ts
@@ -1,0 +1,276 @@
+/**
+ * DiagramIOService.ts
+ * 
+ * Main service for import/export of single diagrams.
+ * Replaces exportDiagram() and importDiagram() functions from projectIO.service.ts
+ * 
+ * Responsibilities:
+ * - Orchestrate diagram export to flat JSON
+ * - Orchestrate diagram import from JSON/ZIP
+ * - Coordinate validation, extraction and serialization
+ * - Handle errors consistently
+ * - Access stores in a controlled way
+ * 
+ * Export Flow:
+ * 1. Get data from store (VFS + Model)
+ * 2. Validate diagram structure
+ * 3. Extract partial model (only used elements)
+ * 4. Create JSON payload
+ * 5. Serialize to string
+ * 6. Download file
+ * 
+ * Import Flow:
+ * 1. Read file
+ * 2. Detect format (JSON vs ZIP)
+ * 3. Deserialize according to format
+ * 4. Validate structure
+ * 5. Return parsed data
+ */
+
+import type { VFSStore } from '../../store/project-vfs.store';
+import type { ModelStore } from '../../store/model.store';
+import type { VFSFile, DiagramView, SemanticModel } from '../../core/domain/vfs/vfs.types';
+import { DiagramSerializer, type DiagramPayload } from './serialization/DiagramSerializer';
+import { DiagramDeserializer } from './serialization/DiagramDeserializer';
+import { DiagramValidator } from './validation/DiagramValidator';
+import { ModelExtractor } from './extraction/ModelExtractor';
+
+/**
+ * Diagram import result
+ */
+export interface ParsedDiagram {
+  name: string;
+  view: DiagramView;
+  model: SemanticModel;
+}
+
+/**
+ * Diagram export error
+ */
+export class DiagramExportError extends Error {
+  constructor(message: string, public readonly cause?: unknown) {
+    super(message);
+    this.name = 'DiagramExportError';
+  }
+}
+
+/**
+ * Diagram import error
+ */
+export class DiagramImportError extends Error {
+  constructor(message: string, public readonly cause?: unknown) {
+    super(message);
+    this.name = 'DiagramImportError';
+  }
+}
+
+export class DiagramIOService {
+  constructor(
+    private readonly serializer: DiagramSerializer,
+    private readonly deserializer: DiagramDeserializer,
+    private readonly validator: DiagramValidator,
+    private readonly extractor: ModelExtractor,
+    private readonly getVFSStore: () => VFSStore,
+    private readonly getModelStore: () => ModelStore,
+  ) {}
+
+  /**
+   * Exports a single diagram as flat JSON
+   * 
+   * @param fileId - VFS file ID of the diagram
+   * @returns Promise<void> - Downloads the file
+   * @throws DiagramExportError if there are problems
+   * 
+   * @example
+   * ```typescript
+   * const service = getDiagramIOService();
+   * await service.exportDiagram('diagram-123');
+   * // Downloads diagram-123.luml
+   * ```
+   */
+  async exportDiagram(fileId: string): Promise<void> {
+    try {
+      // 1. Get data from store
+      const { file, view, model } = this.getDiagramData(fileId);
+      
+      // 2. Validate structure
+      const validation = this.validator.validate(view, model);
+      if (!validation.isValid) {
+        throw new DiagramExportError(
+          `Diagram validation failed:\n${validation.errors.map(e => `  - ${e}`).join('\n')}`
+        );
+      }
+      
+      // 3. Extract partial model
+      const partialModel = this.extractor.extractPartialModel(view, model);
+      
+      // 4. Create payload
+      const payload: DiagramPayload = DiagramSerializer.createPayload({
+        diagramId: fileId,
+        diagramName: file.name.replace(/\.luml$/i, ''),
+        model: partialModel,
+        view: view,
+      });
+      
+      // 5. Serialize to JSON
+      const json = this.serializer.serialize(payload);
+      
+      // 6. Download
+      await this.downloadFile(json, payload.diagramName);
+    } catch (error) {
+      if (error instanceof DiagramExportError) {
+        throw error;
+      }
+      throw new DiagramExportError(
+        'Failed to export diagram',
+        error
+      );
+    }
+  }
+
+  /**
+   * Imports a diagram from .luml file (JSON or ZIP)
+   * 
+   * @param file - File to import
+   * @returns Promise<ParsedDiagram> - Parsed diagram
+   * @throws DiagramImportError if there are problems
+   * 
+   * @example
+   * ```typescript
+   * const service = getDiagramIOService();
+   * const diagram = await service.importDiagram(file);
+   * // diagram contains name, view, model
+   * ```
+   */
+  async importDiagram(file: File): Promise<ParsedDiagram> {
+    try {
+      // 1. Detect format
+      const format = await this.deserializer.detectFormat(file);
+      
+      // 2. Deserialize according to format
+      const payload = await this.deserializer.deserialize(file, format);
+      
+      // 3. Validate structure
+      const validation = this.validator.validate(payload.view, payload.model);
+      if (!validation.isValid) {
+        throw new DiagramImportError(
+          `Diagram validation failed:\n${validation.errors.map(e => `  - ${e}`).join('\n')}`
+        );
+      }
+      
+      // 4. Return parsed data
+      return {
+        name: payload.diagramName,
+        view: payload.view,
+        model: payload.model as SemanticModel,
+      };
+    } catch (error) {
+      if (error instanceof DiagramImportError) {
+        throw error;
+      }
+      throw new DiagramImportError(
+        'Failed to import diagram',
+        error
+      );
+    }
+  }
+
+  /**
+   * Gets diagram data from stores
+   */
+  private getDiagramData(fileId: string): {
+    file: VFSFile;
+    view: DiagramView;
+    model: SemanticModel;
+  } {
+    const vfsStore = this.getVFSStore();
+    const modelStore = this.getModelStore();
+    
+    const project = vfsStore.project;
+    if (!project) {
+      throw new DiagramExportError('No active project');
+    }
+    
+    const fileNode = project.nodes[fileId];
+    if (!fileNode || fileNode.type !== 'FILE') {
+      throw new DiagramExportError(`Invalid file: ${fileId}`);
+    }
+    
+    const file = fileNode as VFSFile;
+    
+    // Validate that it has content
+    if (!file.content) {
+      throw new DiagramExportError('Diagram has no content');
+    }
+    
+    const view = file.content as DiagramView;
+    
+    // Validate that it has nodes and edges
+    if (!view.nodes || !view.edges) {
+      throw new DiagramExportError('Invalid diagram view: missing nodes or edges');
+    }
+    
+    const model = modelStore.model;
+    if (!model) {
+      throw new DiagramExportError('No semantic model loaded');
+    }
+    
+    return { file, view, model };
+  }
+
+  /**
+   * Downloads file in browser or Electron
+   */
+  private async downloadFile(content: string, fileName: string): Promise<void> {
+    const blob = new Blob([content], { type: 'application/json' });
+    const safeFileName = this.sanitizeFileName(fileName);
+
+    // Electron
+    if (window.electronAPI?.isElectron()) {
+      const dataUrl = await this.blobToDataURL(blob);
+      const result = await window.electronAPI.saveFile(dataUrl, safeFileName, 'json');
+      if (result.canceled) {
+        throw new DiagramExportError('Export canceled by user');
+      }
+      return;
+    }
+
+    // Browser
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = safeFileName;
+    a.style.display = 'none';
+    
+    document.body.appendChild(a);
+    a.click();
+    
+    // Cleanup
+    setTimeout(() => {
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    }, 100);
+  }
+
+  /**
+   * Sanitizes file name
+   */
+  private sanitizeFileName(fileName: string): string {
+    // Remove invalid characters
+    const sanitized = fileName.replace(/[^a-z0-9_-]/gi, '_');
+    // Ensure .luml extension
+    return sanitized.endsWith('.luml') ? sanitized : `${sanitized}.luml`;
+  }
+
+  /**
+   * Converts Blob to Data URL (for Electron)
+   */
+  private blobToDataURL(blob: Blob): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result as string);
+      reader.onerror = reject;
+      reader.readAsDataURL(blob);
+    });
+  }
+}

--- a/src/services/diagram/DiagramIOServiceFactory.ts
+++ b/src/services/diagram/DiagramIOServiceFactory.ts
@@ -1,0 +1,119 @@
+/**
+ * DiagramIOServiceFactory.ts
+ * 
+ * Factory to create DiagramIOService instances with all their dependencies.
+ * 
+ * Responsibilities:
+ * - Create serializer, deserializer, validator, extractor
+ * - Inject store access (VFS, Model)
+ * - Provide singleton instance
+ * - Allow reset for tests
+ * 
+ * Pattern: Singleton Factory
+ * 
+ * Usage:
+ * ```typescript
+ * import { getDiagramIOService } from './DiagramIOServiceFactory';
+ * 
+ * const service = getDiagramIOService();
+ * await service.exportDiagram(fileId);
+ * ```
+ */
+
+import { useVFSStore } from '../../store/project-vfs.store';
+import { useModelStore } from '../../store/model.store';
+import { DiagramIOService } from './DiagramIOService';
+import { DiagramSerializer } from './serialization/DiagramSerializer';
+import { DiagramDeserializer } from './serialization/DiagramDeserializer';
+import { DiagramValidator } from './validation/DiagramValidator';
+import { ModelExtractor } from './extraction/ModelExtractor';
+import { FormatDetector } from './serialization/FormatDetector';
+
+/**
+ * Factory to create DiagramIOService instances
+ */
+class DiagramIOServiceFactory {
+  private instance: DiagramIOService | null = null;
+
+  /**
+   * Creates or returns the singleton service instance
+   * 
+   * @returns DiagramIOService - Service instance
+   * 
+   * @example
+   * ```typescript
+   * const factory = new DiagramIOServiceFactory();
+   * const service = factory.create();
+   * await service.exportDiagram('diagram-123');
+   * ```
+   */
+  create(): DiagramIOService {
+    if (!this.instance) {
+      // Create dependencies
+      const serializer = new DiagramSerializer();
+      const formatDetector = new FormatDetector();
+      const deserializer = new DiagramDeserializer(formatDetector);
+      const validator = new DiagramValidator();
+      const extractor = new ModelExtractor();
+
+      // Create service with store access
+      // We use getters to access current store state
+      this.instance = new DiagramIOService(
+        serializer,
+        deserializer,
+        validator,
+        extractor,
+        () => useVFSStore.getState(),
+        () => useModelStore.getState(),
+      );
+    }
+
+    return this.instance;
+  }
+
+  /**
+   * Resets the instance (useful for tests)
+   * 
+   * @example
+   * ```typescript
+   * // In tests
+   * afterEach(() => {
+   *   diagramIOServiceFactory.reset();
+   * });
+   * ```
+   */
+  reset(): void {
+    this.instance = null;
+  }
+
+  /**
+   * Checks if there is a created instance
+   */
+  hasInstance(): boolean {
+    return this.instance !== null;
+  }
+}
+
+/**
+ * Singleton factory instance
+ */
+export const diagramIOServiceFactory = new DiagramIOServiceFactory();
+
+/**
+ * Helper to get the service directly
+ * 
+ * This is the recommended way to use the service in the application.
+ * 
+ * @returns DiagramIOService - Service instance
+ * 
+ * @example
+ * ```typescript
+ * import { getDiagramIOService } from './services/diagram/DiagramIOServiceFactory';
+ * 
+ * const service = getDiagramIOService();
+ * await service.exportDiagram(fileId);
+ * ```
+ */
+export function getDiagramIOService(): DiagramIOService {
+  return diagramIOServiceFactory.create();
+}

--- a/src/services/diagram/__test__/DiagramDeserializer.test.ts
+++ b/src/services/diagram/__test__/DiagramDeserializer.test.ts
@@ -1,30 +1,24 @@
 /**
  * DiagramDeserializer.test.ts
- * 
+ *
  * Unit tests for DiagramDeserializer service
  */
 
 import { describe, it, expect, vi } from 'vitest';
 import { DiagramDeserializer } from '../serialization/DiagramDeserializer';
-import { FormatDetector } from '../serialization/FormatDetector';
+import type { FormatDetector } from '../serialization/FormatDetector';
 import type { DiagramPayload } from '../serialization/DiagramSerializer';
 
-// Mock FormatDetector
-vi.mock('../serialization/FormatDetector', () => {
-  return {
-    FormatDetector: vi.fn().mockImplementation(() => ({
-      detectFormat: vi.fn(),
-      isJsonFormat: vi.fn(),
-      isZipFormat: vi.fn(),
-    })),
-  };
-});
+const createMockFormatDetector = (): FormatDetector =>
+  ({
+    detect: vi.fn(),
+    detectFormat: vi.fn(),
+    isJsonFormat: vi.fn(),
+    isZipFormat: vi.fn(),
+    detectWithInfo: vi.fn(),
+  }) as unknown as FormatDetector;
 
 describe('DiagramDeserializer', () => {
-  const createMockFormatDetector = () => {
-    return new FormatDetector() as any;
-  };
-
   describe('deserialize - JSON format', () => {
     it('should deserialize valid JSON payload', async () => {
       const payload: DiagramPayload = {
@@ -110,7 +104,7 @@ describe('DiagramDeserializer', () => {
     it('should validate exportType is "diagram"', async () => {
       const wrongTypePayload = {
         _lumlVersion: '2.0',
-        exportType: 'project', // Wrong type
+        exportType: 'project',
         diagramId: 'test-123',
         diagramName: 'Test',
         model: {},
@@ -134,7 +128,7 @@ describe('DiagramDeserializer', () => {
       const file = new File([blob], 'test.luml');
 
       const formatDetector = createMockFormatDetector();
-      formatDetector.detectFormat.mockResolvedValue('json');
+      vi.mocked(formatDetector.detectFormat).mockResolvedValue('json');
 
       const deserializer = new DiagramDeserializer(formatDetector);
       const format = await deserializer.detectFormat(file);

--- a/src/services/diagram/__test__/DiagramDeserializer.test.ts
+++ b/src/services/diagram/__test__/DiagramDeserializer.test.ts
@@ -1,0 +1,146 @@
+/**
+ * DiagramDeserializer.test.ts
+ * 
+ * Unit tests for DiagramDeserializer service
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { DiagramDeserializer } from '../serialization/DiagramDeserializer';
+import { FormatDetector } from '../serialization/FormatDetector';
+import type { DiagramPayload } from '../serialization/DiagramSerializer';
+
+// Mock FormatDetector
+vi.mock('../serialization/FormatDetector', () => {
+  return {
+    FormatDetector: vi.fn().mockImplementation(() => ({
+      detectFormat: vi.fn(),
+      isJsonFormat: vi.fn(),
+      isZipFormat: vi.fn(),
+    })),
+  };
+});
+
+describe('DiagramDeserializer', () => {
+  const createMockFormatDetector = () => {
+    return new FormatDetector() as any;
+  };
+
+  describe('deserialize - JSON format', () => {
+    it('should deserialize valid JSON payload', async () => {
+      const payload: DiagramPayload = {
+        _lumlVersion: '2.0',
+        exportType: 'diagram',
+        diagramId: 'test-123',
+        diagramName: 'Test Diagram',
+        model: {
+          id: 'model-1',
+          name: 'Test Model',
+          version: '1.0.0',
+          packages: {},
+          classes: {},
+          interfaces: {},
+          enums: {},
+          dataTypes: {},
+          attributes: {},
+          operations: {},
+          actors: {},
+          useCases: {},
+          activityNodes: {},
+          objectInstances: {},
+          components: {},
+          nodes: {},
+          artifacts: {},
+          relations: {},
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        },
+        view: {
+          diagramId: 'test-123',
+          nodes: [
+            { id: 'node-1', elementId: 'class-1', x: 100, y: 200 },
+          ],
+          edges: [],
+        },
+      };
+
+      const jsonContent = JSON.stringify(payload);
+      const blob = new Blob([jsonContent], { type: 'application/json' });
+      const file = new File([blob], 'test.luml');
+
+      const formatDetector = createMockFormatDetector();
+      const deserializer = new DiagramDeserializer(formatDetector);
+
+      const result = await deserializer.deserialize(file, 'json');
+
+      expect(result.diagramId).toBe('test-123');
+      expect(result.diagramName).toBe('Test Diagram');
+      expect(result.model).toBeDefined();
+      expect(result.view).toBeDefined();
+      expect(result.view.nodes).toHaveLength(1);
+    });
+
+    it('should throw error for invalid JSON', async () => {
+      const invalidJson = '{ invalid json }';
+      const blob = new Blob([invalidJson]);
+      const file = new File([blob], 'test.luml');
+
+      const formatDetector = createMockFormatDetector();
+      const deserializer = new DiagramDeserializer(formatDetector);
+
+      await expect(deserializer.deserialize(file, 'json')).rejects.toThrow();
+    });
+
+    it('should throw error for missing required fields', async () => {
+      const incompletePayload = {
+        _lumlVersion: '2.0',
+        exportType: 'diagram',
+        // Missing diagramId, diagramName, model, view
+      };
+
+      const jsonContent = JSON.stringify(incompletePayload);
+      const blob = new Blob([jsonContent]);
+      const file = new File([blob], 'test.luml');
+
+      const formatDetector = createMockFormatDetector();
+      const deserializer = new DiagramDeserializer(formatDetector);
+
+      await expect(deserializer.deserialize(file, 'json')).rejects.toThrow();
+    });
+
+    it('should validate exportType is "diagram"', async () => {
+      const wrongTypePayload = {
+        _lumlVersion: '2.0',
+        exportType: 'project', // Wrong type
+        diagramId: 'test-123',
+        diagramName: 'Test',
+        model: {},
+        view: { nodes: [], edges: [] },
+      };
+
+      const jsonContent = JSON.stringify(wrongTypePayload);
+      const blob = new Blob([jsonContent]);
+      const file = new File([blob], 'test.luml');
+
+      const formatDetector = createMockFormatDetector();
+      const deserializer = new DiagramDeserializer(formatDetector);
+
+      await expect(deserializer.deserialize(file, 'json')).rejects.toThrow();
+    });
+  });
+
+  describe('detectFormat', () => {
+    it('should delegate to FormatDetector', async () => {
+      const blob = new Blob(['test']);
+      const file = new File([blob], 'test.luml');
+
+      const formatDetector = createMockFormatDetector();
+      formatDetector.detectFormat.mockResolvedValue('json');
+
+      const deserializer = new DiagramDeserializer(formatDetector);
+      const format = await deserializer.detectFormat(file);
+
+      expect(format).toBe('json');
+      expect(formatDetector.detectFormat).toHaveBeenCalledWith(file);
+    });
+  });
+});

--- a/src/services/diagram/__test__/DiagramIOService.integration.test.ts
+++ b/src/services/diagram/__test__/DiagramIOService.integration.test.ts
@@ -372,7 +372,7 @@ describe('DiagramIOService - Integration', () => {
 
   describe('Round-trip (Export + Import)', () => {
     it('should preserve all data in round-trip', async () => {
-      // Mock download to capture exported content
+      const RealBlob = global.Blob;
       let exportedContent = '';
       global.Blob = class MockBlob {
         constructor(parts: any[]) {
@@ -383,8 +383,8 @@ describe('DiagramIOService - Integration', () => {
       // Export
       await service.exportDiagram('file-1');
 
-      // Parse exported content
-      const exported = JSON.parse(exportedContent);
+      // Restore real Blob before import
+      global.Blob = RealBlob;
 
       // Import
       const blob = new Blob([exportedContent], { type: 'application/json' });

--- a/src/services/diagram/__test__/DiagramIOService.integration.test.ts
+++ b/src/services/diagram/__test__/DiagramIOService.integration.test.ts
@@ -1,0 +1,407 @@
+/**
+ * DiagramIOService.integration.test.ts
+ * 
+ * Integration tests for DiagramIOService
+ * Tests the complete export/import flow
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DiagramIOService } from '../DiagramIOService';
+import { DiagramSerializer } from '../serialization/DiagramSerializer';
+import { DiagramDeserializer } from '../serialization/DiagramDeserializer';
+import { DiagramValidator } from '../validation/DiagramValidator';
+import { ModelExtractor } from '../extraction/ModelExtractor';
+import { FormatDetector } from '../serialization/FormatDetector';
+import type { VFSStore } from '../../../store/project-vfs.store';
+import type { ModelStore } from '../../../store/model.store';
+import type { VFSFile, DiagramView, SemanticModel, LibreUMLProject } from '../../../core/domain/vfs/vfs.types';
+
+describe('DiagramIOService - Integration', () => {
+  let service: DiagramIOService;
+  let mockVFSStore: Partial<VFSStore>;
+  let mockModelStore: Partial<ModelStore>;
+
+  const createMockProject = (): LibreUMLProject => ({
+    id: 'project-1',
+    projectName: 'Test Project',
+    version: '1.0.0',
+    domainModelId: 'model-1',
+    nodes: {
+      'file-1': {
+        id: 'file-1',
+        name: 'TestDiagram.luml',
+        type: 'FILE',
+        parentId: null,
+        diagramType: 'CLASS_DIAGRAM',
+        extension: '.luml',
+        isExternal: false,
+        content: {
+          diagramId: 'file-1',
+          nodes: [
+            { id: 'node-1', elementId: 'class-1', x: 100, y: 200 },
+            { id: 'node-2', elementId: 'class-2', x: 300, y: 200 },
+          ],
+          edges: [
+            { id: 'edge-1', relationId: 'rel-1', waypoints: [] },
+          ],
+        } as DiagramView,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      } as VFSFile,
+    },
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  });
+
+  const createMockModel = (): SemanticModel => ({
+    id: 'model-1',
+    name: 'Test Model',
+    version: '1.0.0',
+    packages: {},
+    classes: {
+      'class-1': {
+        id: 'class-1',
+        kind: 'CLASS',
+        name: 'User',
+        packageName: 'com.example.domain',
+        attributeIds: ['attr-1'],
+        operationIds: ['op-1'],
+        visibility: 'public',
+        isAbstract: false,
+      },
+      'class-2': {
+        id: 'class-2',
+        kind: 'CLASS',
+        name: 'Order',
+        attributeIds: [],
+        operationIds: [],
+        visibility: 'public',
+        isAbstract: false,
+      },
+      'class-3': {
+        id: 'class-3',
+        kind: 'CLASS',
+        name: 'Product',
+        attributeIds: [],
+        operationIds: [],
+        visibility: 'public',
+        isAbstract: false,
+      },
+    },
+    interfaces: {},
+    enums: {},
+    dataTypes: {},
+    attributes: {
+      'attr-1': {
+        id: 'attr-1',
+        kind: 'ATTRIBUTE',
+        name: 'name',
+        type: 'string',
+        visibility: 'private',
+      },
+    },
+    operations: {
+      'op-1': {
+        id: 'op-1',
+        kind: 'OPERATION',
+        name: 'getName',
+        returnType: 'string',
+        visibility: 'public',
+        parameters: [],
+        isReturnArray: false,
+        isStatic: false,
+      },
+    },
+    actors: {},
+    useCases: {},
+    activityNodes: {},
+    objectInstances: {},
+    components: {},
+    nodes: {},
+    artifacts: {},
+    relations: {
+      'rel-1': {
+        id: 'rel-1',
+        kind: 'ASSOCIATION',
+        sourceId: 'class-1',
+        targetId: 'class-2',
+      },
+    },
+    packageNames: ['com.example.domain'],
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  });
+
+  beforeEach(() => {
+    // Setup mock stores
+    mockVFSStore = {
+      project: createMockProject(),
+    };
+
+    mockModelStore = {
+      model: createMockModel(),
+    };
+
+    // Create service with real dependencies
+    const serializer = new DiagramSerializer();
+    const formatDetector = new FormatDetector();
+    const deserializer = new DiagramDeserializer(formatDetector);
+    const validator = new DiagramValidator();
+    const extractor = new ModelExtractor();
+
+    service = new DiagramIOService(
+      serializer,
+      deserializer,
+      validator,
+      extractor,
+      () => mockVFSStore as VFSStore,
+      () => mockModelStore as ModelStore,
+    );
+
+    // Mock browser APIs
+    global.URL.createObjectURL = vi.fn(() => 'blob:mock-url');
+    global.URL.revokeObjectURL = vi.fn();
+    document.createElement = vi.fn((tag) => {
+      if (tag === 'a') {
+        return {
+          href: '',
+          download: '',
+          style: { display: '' },
+          click: vi.fn(),
+        } as any;
+      }
+      return {} as any;
+    });
+    document.body.appendChild = vi.fn();
+    document.body.removeChild = vi.fn();
+  });
+
+  describe('Export Flow', () => {
+    it('should export diagram successfully', async () => {
+      await service.exportDiagram('file-1');
+
+      // Verify download was triggered
+      expect(document.createElement).toHaveBeenCalledWith('a');
+      expect(document.body.appendChild).toHaveBeenCalled();
+    });
+
+    it('should extract only referenced elements', async () => {
+      // Spy on ModelExtractor
+      const extractSpy = vi.spyOn(ModelExtractor.prototype, 'extractPartialModel');
+
+      await service.exportDiagram('file-1');
+
+      expect(extractSpy).toHaveBeenCalled();
+      const result = extractSpy.mock.results[0].value;
+
+      // Should include class-1 and class-2 (referenced in diagram)
+      expect(result.classes['class-1']).toBeDefined();
+      expect(result.classes['class-2']).toBeDefined();
+
+      // Should NOT include class-3 (not referenced)
+      expect(result.classes['class-3']).toBeUndefined();
+    });
+
+    it('should validate diagram before export', async () => {
+      const validateSpy = vi.spyOn(DiagramValidator.prototype, 'validate');
+
+      await service.exportDiagram('file-1');
+
+      expect(validateSpy).toHaveBeenCalled();
+    });
+
+    it('should throw error for invalid diagram', async () => {
+      // Create invalid diagram (orphaned edge)
+      const invalidProject = createMockProject();
+      (invalidProject.nodes['file-1'] as VFSFile).content = {
+        diagramId: 'file-1',
+        nodes: [
+          { id: 'node-1', elementId: 'class-1', x: 100, y: 200 },
+        ],
+        edges: [
+          { id: 'edge-1', relationId: 'rel-999', waypoints: [] }, // Invalid relation
+        ],
+      } as DiagramView;
+
+      mockVFSStore.project = invalidProject;
+
+      await expect(service.exportDiagram('file-1')).rejects.toThrow('validation failed');
+    });
+
+    it('should throw error for non-existent file', async () => {
+      await expect(service.exportDiagram('non-existent')).rejects.toThrow();
+    });
+
+    it('should throw error when no project is loaded', async () => {
+      mockVFSStore.project = null;
+
+      await expect(service.exportDiagram('file-1')).rejects.toThrow('No active project');
+    });
+  });
+
+  describe('Import Flow', () => {
+    it('should import diagram successfully', async () => {
+      // Create a valid JSON file
+      const payload = {
+        _lumlVersion: '2.0',
+        exportType: 'diagram',
+        diagramId: 'imported-diagram',
+        diagramName: 'Imported Diagram',
+        model: {
+          id: 'model-1',
+          name: 'Imported Model',
+          version: '1.0.0',
+          packages: {},
+          classes: {
+            'class-1': {
+              id: 'class-1',
+              kind: 'CLASS',
+              name: 'ImportedClass',
+              attributeIds: [],
+              operationIds: [],
+              visibility: 'public',
+              isAbstract: false,
+            },
+          },
+          interfaces: {},
+          enums: {},
+          dataTypes: {},
+          attributes: {},
+          operations: {},
+          actors: {},
+          useCases: {},
+          activityNodes: {},
+          objectInstances: {},
+          components: {},
+          nodes: {},
+          artifacts: {},
+          relations: {},
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        },
+        view: {
+          diagramId: 'imported-diagram',
+          nodes: [
+            { id: 'node-1', elementId: 'class-1', x: 100, y: 200 },
+          ],
+          edges: [],
+        },
+      };
+
+      const jsonContent = JSON.stringify(payload);
+      const blob = new Blob([jsonContent], { type: 'application/json' });
+      const file = new File([blob], 'imported.luml');
+
+      const result = await service.importDiagram(file);
+
+      expect(result.name).toBe('Imported Diagram');
+      expect(result.view.nodes).toHaveLength(1);
+      expect(result.model.classes['class-1']).toBeDefined();
+    });
+
+    it('should validate imported diagram', async () => {
+      const validateSpy = vi.spyOn(DiagramValidator.prototype, 'validate');
+
+      const payload = {
+        _lumlVersion: '2.0',
+        exportType: 'diagram',
+        diagramId: 'test',
+        diagramName: 'Test',
+        model: createMockModel(),
+        view: {
+          diagramId: 'test',
+          nodes: [{ id: 'node-1', elementId: 'class-1', x: 100, y: 200 }],
+          edges: [],
+        },
+      };
+
+      const jsonContent = JSON.stringify(payload);
+      const blob = new Blob([jsonContent]);
+      const file = new File([blob], 'test.luml');
+
+      await service.importDiagram(file);
+
+      expect(validateSpy).toHaveBeenCalled();
+    });
+
+    it('should throw error for invalid imported diagram', async () => {
+      // Create invalid payload (orphaned node)
+      const invalidPayload = {
+        _lumlVersion: '2.0',
+        exportType: 'diagram',
+        diagramId: 'test',
+        diagramName: 'Test',
+        model: {
+          id: 'model-1',
+          name: 'Test',
+          version: '1.0.0',
+          packages: {},
+          classes: {},
+          interfaces: {},
+          enums: {},
+          dataTypes: {},
+          attributes: {},
+          operations: {},
+          actors: {},
+          useCases: {},
+          activityNodes: {},
+          objectInstances: {},
+          components: {},
+          nodes: {},
+          artifacts: {},
+          relations: {},
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        },
+        view: {
+          diagramId: 'test',
+          nodes: [
+            { id: 'node-1', elementId: 'class-999', x: 100, y: 200 }, // Invalid element
+          ],
+          edges: [],
+        },
+      };
+
+      const jsonContent = JSON.stringify(invalidPayload);
+      const blob = new Blob([jsonContent]);
+      const file = new File([blob], 'invalid.luml');
+
+      await expect(service.importDiagram(file)).rejects.toThrow('validation failed');
+    });
+  });
+
+  describe('Round-trip (Export + Import)', () => {
+    it('should preserve all data in round-trip', async () => {
+      // Mock download to capture exported content
+      let exportedContent = '';
+      global.Blob = class MockBlob {
+        constructor(parts: any[]) {
+          exportedContent = parts[0];
+        }
+      } as any;
+
+      // Export
+      await service.exportDiagram('file-1');
+
+      // Parse exported content
+      const exported = JSON.parse(exportedContent);
+
+      // Import
+      const blob = new Blob([exportedContent], { type: 'application/json' });
+      const file = new File([blob], 'roundtrip.luml');
+      const imported = await service.importDiagram(file);
+
+      // Verify data preservation
+      expect(imported.name).toBe('TestDiagram');
+      expect(imported.view.nodes).toHaveLength(2);
+      expect(imported.view.edges).toHaveLength(1);
+      expect(imported.model.classes['class-1']).toBeDefined();
+      expect(imported.model.classes['class-2']).toBeDefined();
+      expect(imported.model.relations['rel-1']).toBeDefined();
+
+      // Verify visual properties
+      expect(imported.view.nodes[0].x).toBe(100);
+      expect(imported.view.nodes[0].y).toBe(200);
+    });
+  });
+});

--- a/src/services/diagram/__test__/DiagramSerializer.test.ts
+++ b/src/services/diagram/__test__/DiagramSerializer.test.ts
@@ -1,0 +1,247 @@
+/**
+ * DiagramSerializer.test.ts
+ * 
+ * Unit tests for DiagramSerializer service
+ */
+
+import { describe, it, expect } from 'vitest';
+import { DiagramSerializer, LUML_FORMAT_VERSION } from '../serialization/DiagramSerializer';
+import type { DiagramPayload } from '../serialization/DiagramSerializer';
+import type { DiagramView, SemanticModel } from '../../../core/domain/vfs/vfs.types';
+
+describe('DiagramSerializer', () => {
+  const serializer = new DiagramSerializer();
+
+  const createTestPayload = (): DiagramPayload => {
+    const model: SemanticModel = {
+      id: 'model-1',
+      name: 'Test Model',
+      version: '1.0.0',
+      packages: {},
+      classes: {
+        'class-1': {
+          id: 'class-1',
+          kind: 'CLASS',
+          name: 'User',
+          attributeIds: [],
+          operationIds: [],
+          visibility: 'public',
+          isAbstract: false,
+        },
+      },
+      interfaces: {},
+      enums: {},
+      dataTypes: {},
+      attributes: {},
+      operations: {},
+      actors: {},
+      useCases: {},
+      activityNodes: {},
+      objectInstances: {},
+      components: {},
+      nodes: {},
+      artifacts: {},
+      relations: {},
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+
+    const view: DiagramView = {
+      diagramId: 'diagram-1',
+      nodes: [
+        { id: 'node-1', elementId: 'class-1', x: 100, y: 200 },
+      ],
+      edges: [],
+    };
+
+    return DiagramSerializer.createPayload({
+      diagramId: 'diagram-1',
+      diagramName: 'Test Diagram',
+      model,
+      view,
+    });
+  };
+
+  describe('createPayload', () => {
+    it('should create a valid payload', () => {
+      const payload = createTestPayload();
+
+      expect(payload._lumlVersion).toBe(LUML_FORMAT_VERSION);
+      expect(payload.exportType).toBe('diagram');
+      expect(payload.diagramId).toBe('diagram-1');
+      expect(payload.diagramName).toBe('Test Diagram');
+      expect(payload.model).toBeDefined();
+      expect(payload.view).toBeDefined();
+    });
+
+    it('should include all required fields', () => {
+      const payload = createTestPayload();
+
+      expect(payload).toHaveProperty('_lumlVersion');
+      expect(payload).toHaveProperty('exportType');
+      expect(payload).toHaveProperty('diagramId');
+      expect(payload).toHaveProperty('diagramName');
+      expect(payload).toHaveProperty('model');
+      expect(payload).toHaveProperty('view');
+    });
+  });
+
+  describe('serialize', () => {
+    it('should serialize payload to JSON string', () => {
+      const payload = createTestPayload();
+      const json = serializer.serialize(payload);
+
+      expect(typeof json).toBe('string');
+      expect(json.length).toBeGreaterThan(0);
+    });
+
+    it('should produce valid JSON', () => {
+      const payload = createTestPayload();
+      const json = serializer.serialize(payload);
+
+      expect(() => JSON.parse(json)).not.toThrow();
+    });
+
+    it('should preserve all data when serialized and parsed', () => {
+      const payload = createTestPayload();
+      const json = serializer.serialize(payload);
+      const parsed = JSON.parse(json);
+
+      expect(parsed._lumlVersion).toBe(payload._lumlVersion);
+      expect(parsed.exportType).toBe(payload.exportType);
+      expect(parsed.diagramId).toBe(payload.diagramId);
+      expect(parsed.diagramName).toBe(payload.diagramName);
+      expect(parsed.model.classes['class-1'].name).toBe('User');
+      expect(parsed.view.nodes[0].x).toBe(100);
+      expect(parsed.view.nodes[0].y).toBe(200);
+    });
+
+    it('should format JSON with indentation', () => {
+      const payload = createTestPayload();
+      const json = serializer.serialize(payload);
+
+      // Should contain newlines (formatted)
+      expect(json).toContain('\n');
+      // Should contain indentation
+      expect(json).toMatch(/\n  /);
+    });
+
+    it('should handle complex model structures', () => {
+      const complexModel: SemanticModel = {
+        id: 'model-1',
+        name: 'Complex Model',
+        version: '1.0.0',
+        packages: {},
+        classes: {
+          'class-1': {
+            id: 'class-1',
+            kind: 'CLASS',
+            name: 'User',
+            packageName: 'com.example.domain',
+            attributeIds: ['attr-1'],
+            operationIds: ['op-1'],
+            visibility: 'public',
+            isAbstract: false,
+          },
+        },
+        interfaces: {
+          'interface-1': {
+            id: 'interface-1',
+            kind: 'INTERFACE',
+            name: 'IRepository',
+            operationIds: ['op-2'],
+            visibility: 'public',
+          },
+        },
+        enums: {
+          'enum-1': {
+            id: 'enum-1',
+            kind: 'ENUM',
+            name: 'Status',
+            literals: [{ name: 'ACTIVE' }, { name: 'INACTIVE' }],
+            visibility: 'public',
+          },
+        },
+        dataTypes: {},
+        attributes: {
+          'attr-1': {
+            id: 'attr-1',
+            kind: 'ATTRIBUTE',
+            name: 'name',
+            type: 'string',
+            visibility: 'private',
+          },
+        },
+        operations: {
+          'op-1': {
+            id: 'op-1',
+            kind: 'OPERATION',
+            name: 'getName',
+            returnType: 'string',
+            visibility: 'public',
+            parameters: [],
+            isReturnArray: false,
+            isStatic: false,
+          },
+          'op-2': {
+            id: 'op-2',
+            kind: 'OPERATION',
+            name: 'save',
+            returnType: 'void',
+            visibility: 'public',
+            parameters: [{ name: 'entity', type: 'Object', isArray: false }],
+            isReturnArray: false,
+            isStatic: false,
+          },
+        },
+        actors: {},
+        useCases: {},
+        activityNodes: {},
+        objectInstances: {},
+        components: {},
+        nodes: {},
+        artifacts: {},
+        relations: {
+          'rel-1': {
+            id: 'rel-1',
+            kind: 'REALIZATION',
+            sourceId: 'class-1',
+            targetId: 'interface-1',
+          },
+        },
+        packageNames: ['com.example.domain'],
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      };
+
+      const view: DiagramView = {
+        diagramId: 'diagram-1',
+        nodes: [
+          { id: 'pkg-1', elementId: '', x: 0, y: 0, width: 500, height: 500, packageName: 'com.example.domain' },
+          { id: 'node-1', elementId: 'class-1', x: 100, y: 100, parentPackageId: 'pkg-1' },
+          { id: 'node-2', elementId: 'interface-1', x: 300, y: 100 },
+          { id: 'node-3', elementId: 'enum-1', x: 100, y: 300 },
+        ],
+        edges: [
+          { id: 'edge-1', relationId: 'rel-1', waypoints: [] },
+        ],
+      };
+
+      const payload = DiagramSerializer.createPayload({
+        diagramId: 'diagram-1',
+        diagramName: 'Complex Diagram',
+        model: complexModel,
+        view,
+      });
+
+      const json = serializer.serialize(payload);
+      const parsed = JSON.parse(json);
+
+      expect(parsed.model.classes['class-1'].packageName).toBe('com.example.domain');
+      expect(parsed.model.interfaces['interface-1'].name).toBe('IRepository');
+      expect(parsed.model.enums['enum-1'].literals).toHaveLength(2);
+      expect(parsed.view.nodes).toHaveLength(4);
+      expect(parsed.view.nodes[1].parentPackageId).toBe('pkg-1');
+    });
+  });
+});

--- a/src/services/diagram/__test__/DiagramValidator.test.ts
+++ b/src/services/diagram/__test__/DiagramValidator.test.ts
@@ -1,0 +1,234 @@
+/**
+ * DiagramValidator.test.ts
+ * 
+ * Unit tests for DiagramValidator service
+ */
+
+import { describe, it, expect } from 'vitest';
+import { DiagramValidator } from '../validation/DiagramValidator';
+import type { DiagramView, SemanticModel } from '../../../core/domain/vfs/vfs.types';
+
+describe('DiagramValidator', () => {
+  const validator = new DiagramValidator();
+
+  const createValidModel = (): SemanticModel => ({
+    id: 'model-1',
+    name: 'Test Model',
+    version: '1.0.0',
+    packages: {},
+    classes: {
+      'class-1': {
+        id: 'class-1',
+        kind: 'CLASS',
+        name: 'User',
+        attributeIds: [],
+        operationIds: [],
+        visibility: 'public',
+        isAbstract: false,
+      },
+    },
+    interfaces: {},
+    enums: {},
+    dataTypes: {},
+    attributes: {},
+    operations: {},
+    actors: {},
+    useCases: {},
+    activityNodes: {},
+    objectInstances: {},
+    components: {},
+    nodes: {},
+    artifacts: {},
+    relations: {
+      'rel-1': {
+        id: 'rel-1',
+        kind: 'ASSOCIATION',
+        sourceId: 'class-1',
+        targetId: 'class-1',
+      },
+    },
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  });
+
+  describe('validate', () => {
+    it('should validate a correct diagram', () => {
+      const view: DiagramView = {
+        diagramId: 'test-diagram',
+        nodes: [
+          { id: 'node-1', elementId: 'class-1', x: 100, y: 100 },
+        ],
+        edges: [
+          { id: 'edge-1', relationId: 'rel-1', waypoints: [] },
+        ],
+      };
+
+      const model = createValidModel();
+      const result = validator.validate(view, model);
+
+      expect(result.isValid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+      expect(result.warnings).toHaveLength(0);
+    });
+
+    it('should detect missing nodes array', () => {
+      const view = {
+        diagramId: 'test-diagram',
+        edges: [],
+      } as unknown as DiagramView;
+
+      const model = createValidModel();
+      const result = validator.validate(view, model);
+
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContain('View must have a nodes array');
+    });
+
+    it('should detect missing edges array', () => {
+      const view = {
+        diagramId: 'test-diagram',
+        nodes: [],
+      } as unknown as DiagramView;
+
+      const model = createValidModel();
+      const result = validator.validate(view, model);
+
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContain('View must have an edges array');
+    });
+
+    it('should detect orphaned nodes (elementId not in model)', () => {
+      const view: DiagramView = {
+        diagramId: 'test-diagram',
+        nodes: [
+          { id: 'node-1', elementId: 'class-1', x: 100, y: 100 },
+          { id: 'node-2', elementId: 'class-999', x: 200, y: 200 },
+        ],
+        edges: [],
+      };
+
+      const model = createValidModel();
+      const result = validator.validate(view, model);
+
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContain('Node node-2 references non-existent element class-999');
+    });
+
+    it('should detect orphaned edges (relationId not in model)', () => {
+      const view: DiagramView = {
+        diagramId: 'test-diagram',
+        nodes: [
+          { id: 'node-1', elementId: 'class-1', x: 100, y: 100 },
+        ],
+        edges: [
+          { id: 'edge-1', relationId: 'rel-999', waypoints: [] },
+        ],
+      };
+
+      const model = createValidModel();
+      const result = validator.validate(view, model);
+
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContain('Edge edge-1 references non-existent relation rel-999');
+    });
+
+    it('should allow nodes without elementId (notes)', () => {
+      const view: DiagramView = {
+        diagramId: 'test-diagram',
+        nodes: [
+          { id: 'node-1', elementId: '', x: 100, y: 100, content: 'This is a note' },
+        ],
+        edges: [],
+      };
+
+      const model = createValidModel();
+      const result = validator.validate(view, model);
+
+      expect(result.isValid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should detect duplicate node IDs', () => {
+      const view: DiagramView = {
+        diagramId: 'test-diagram',
+        nodes: [
+          { id: 'node-1', elementId: 'class-1', x: 100, y: 100 },
+          { id: 'node-1', elementId: 'class-1', x: 200, y: 200 },
+        ],
+        edges: [],
+      };
+
+      const model = createValidModel();
+      const result = validator.validate(view, model);
+
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContain('Duplicate node ID: node-1');
+    });
+
+    it('should detect duplicate edge IDs', () => {
+      const view: DiagramView = {
+        diagramId: 'test-diagram',
+        nodes: [
+          { id: 'node-1', elementId: 'class-1', x: 100, y: 100 },
+        ],
+        edges: [
+          { id: 'edge-1', relationId: 'rel-1', waypoints: [] },
+          { id: 'edge-1', relationId: 'rel-1', waypoints: [] },
+        ],
+      };
+
+      const model = createValidModel();
+      const result = validator.validate(view, model);
+
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContain('Duplicate edge ID: edge-1');
+    });
+
+    it('should warn about empty diagram', () => {
+      const view: DiagramView = {
+        diagramId: 'test-diagram',
+        nodes: [],
+        edges: [],
+      };
+
+      const model = createValidModel();
+      const result = validator.validate(view, model);
+
+      expect(result.isValid).toBe(true);
+      expect(result.warnings).toContain('Diagram is empty (no nodes)');
+    });
+
+    it('should validate nodes with package hierarchy', () => {
+      const view: DiagramView = {
+        diagramId: 'test-diagram',
+        nodes: [
+          { id: 'pkg-1', elementId: '', x: 0, y: 0, width: 500, height: 500, packageName: 'com.example' },
+          { id: 'node-1', elementId: 'class-1', x: 100, y: 100, parentPackageId: 'pkg-1' },
+        ],
+        edges: [],
+      };
+
+      const model = createValidModel();
+      const result = validator.validate(view, model);
+
+      expect(result.isValid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should detect invalid parentPackageId', () => {
+      const view: DiagramView = {
+        diagramId: 'test-diagram',
+        nodes: [
+          { id: 'node-1', elementId: 'class-1', x: 100, y: 100, parentPackageId: 'pkg-999' },
+        ],
+        edges: [],
+      };
+
+      const model = createValidModel();
+      const result = validator.validate(view, model);
+
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContain('Node node-1 references non-existent parent package pkg-999');
+    });
+  });
+});

--- a/src/services/diagram/__test__/FormatDetector.test.ts
+++ b/src/services/diagram/__test__/FormatDetector.test.ts
@@ -1,0 +1,123 @@
+/**
+ * FormatDetector.test.ts
+ * 
+ * Unit tests for FormatDetector service
+ */
+
+import { describe, it, expect } from 'vitest';
+import { FormatDetector } from '../serialization/FormatDetector';
+
+describe('FormatDetector', () => {
+  const detector = new FormatDetector();
+
+  describe('detectFormat', () => {
+    it('should detect JSON format', async () => {
+      const jsonContent = JSON.stringify({
+        _lumlVersion: '2.0',
+        exportType: 'diagram',
+        diagramId: 'test-123',
+        diagramName: 'Test Diagram',
+        model: {},
+        view: { nodes: [], edges: [] },
+      });
+
+      const blob = new Blob([jsonContent], { type: 'application/json' });
+      const file = new File([blob], 'test.luml', { type: 'application/json' });
+
+      const format = await detector.detectFormat(file);
+
+      expect(format).toBe('json');
+    });
+
+    it('should detect ZIP format', async () => {
+      // Create a minimal ZIP file signature
+      // ZIP files start with PK\x03\x04
+      const zipSignature = new Uint8Array([0x50, 0x4B, 0x03, 0x04]);
+      const blob = new Blob([zipSignature], { type: 'application/zip' });
+      const file = new File([blob], 'test.luml', { type: 'application/zip' });
+
+      const format = await detector.detectFormat(file);
+
+      expect(format).toBe('zip');
+    });
+
+    it('should throw error for invalid format', async () => {
+      const invalidContent = 'This is not JSON or ZIP';
+      const blob = new Blob([invalidContent], { type: 'text/plain' });
+      const file = new File([blob], 'test.txt', { type: 'text/plain' });
+
+      await expect(detector.detectFormat(file)).rejects.toThrow();
+    });
+
+    it('should throw error for empty file', async () => {
+      const blob = new Blob([], { type: 'application/octet-stream' });
+      const file = new File([blob], 'empty.luml');
+
+      await expect(detector.detectFormat(file)).rejects.toThrow();
+    });
+  });
+
+  describe('isJsonFormat', () => {
+    it('should return true for valid JSON', async () => {
+      const jsonContent = JSON.stringify({ test: 'data' });
+      const blob = new Blob([jsonContent]);
+      const file = new File([blob], 'test.json');
+
+      const result = await detector.isJsonFormat(file);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false for invalid JSON', async () => {
+      const invalidJson = '{ invalid json }';
+      const blob = new Blob([invalidJson]);
+      const file = new File([blob], 'test.json');
+
+      const result = await detector.isJsonFormat(file);
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false for non-JSON content', async () => {
+      const content = 'Plain text content';
+      const blob = new Blob([content]);
+      const file = new File([blob], 'test.txt');
+
+      const result = await detector.isJsonFormat(file);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('isZipFormat', () => {
+    it('should return true for ZIP signature', async () => {
+      const zipSignature = new Uint8Array([0x50, 0x4B, 0x03, 0x04]);
+      const blob = new Blob([zipSignature]);
+      const file = new File([blob], 'test.zip');
+
+      const result = await detector.isZipFormat(file);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false for non-ZIP content', async () => {
+      const content = new Uint8Array([0x00, 0x01, 0x02, 0x03]);
+      const blob = new Blob([content]);
+      const file = new File([blob], 'test.bin');
+
+      const result = await detector.isZipFormat(file);
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false for file smaller than 4 bytes', async () => {
+      const content = new Uint8Array([0x50, 0x4B]);
+      const blob = new Blob([content]);
+      const file = new File([blob], 'test.bin');
+
+      const result = await detector.isZipFormat(file);
+
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/src/services/diagram/__test__/ModelExtractor.test.ts
+++ b/src/services/diagram/__test__/ModelExtractor.test.ts
@@ -1,0 +1,332 @@
+/**
+ * ModelExtractor.test.ts
+ * 
+ * Unit tests for ModelExtractor service
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ModelExtractor } from '../extraction/ModelExtractor';
+import type { DiagramView, SemanticModel } from '../../../core/domain/vfs/vfs.types';
+
+describe('ModelExtractor', () => {
+  const extractor = new ModelExtractor();
+
+  describe('extractPartialModel', () => {
+    it('should extract only elements referenced in the diagram', () => {
+      const view: DiagramView = {
+        diagramId: 'test-diagram',
+        nodes: [
+          { id: 'node-1', elementId: 'class-1', x: 100, y: 100 },
+          { id: 'node-2', elementId: 'class-2', x: 200, y: 200 },
+        ],
+        edges: [
+          { id: 'edge-1', relationId: 'rel-1', waypoints: [] },
+        ],
+      };
+
+      const model: SemanticModel = {
+        id: 'model-1',
+        name: 'Test Model',
+        version: '1.0.0',
+        packages: {},
+        classes: {
+          'class-1': {
+            id: 'class-1',
+            kind: 'CLASS',
+            name: 'User',
+            attributeIds: ['attr-1'],
+            operationIds: ['op-1'],
+            visibility: 'public',
+            isAbstract: false,
+          },
+          'class-2': {
+            id: 'class-2',
+            kind: 'CLASS',
+            name: 'Order',
+            attributeIds: [],
+            operationIds: [],
+            visibility: 'public',
+            isAbstract: false,
+          },
+          'class-3': {
+            id: 'class-3',
+            kind: 'CLASS',
+            name: 'Product',
+            attributeIds: [],
+            operationIds: [],
+            visibility: 'public',
+            isAbstract: false,
+          },
+        },
+        interfaces: {},
+        enums: {},
+        dataTypes: {},
+        attributes: {
+          'attr-1': {
+            id: 'attr-1',
+            kind: 'ATTRIBUTE',
+            name: 'name',
+            type: 'string',
+            visibility: 'private',
+          },
+        },
+        operations: {
+          'op-1': {
+            id: 'op-1',
+            kind: 'OPERATION',
+            name: 'getName',
+            returnType: 'string',
+            visibility: 'public',
+            parameters: [],
+            isReturnArray: false,
+            isStatic: false,
+          },
+        },
+        actors: {},
+        useCases: {},
+        activityNodes: {},
+        objectInstances: {},
+        components: {},
+        nodes: {},
+        artifacts: {},
+        relations: {
+          'rel-1': {
+            id: 'rel-1',
+            kind: 'ASSOCIATION',
+            sourceId: 'class-1',
+            targetId: 'class-2',
+          },
+        },
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      };
+
+      const result = extractor.extractPartialModel(view, model);
+
+      // Should include class-1 and class-2 (referenced in nodes)
+      expect(result.classes['class-1']).toBeDefined();
+      expect(result.classes['class-2']).toBeDefined();
+      
+      // Should NOT include class-3 (not referenced)
+      expect(result.classes['class-3']).toBeUndefined();
+
+      // Should include attr-1 and op-1 (members of class-1)
+      expect(result.attributes['attr-1']).toBeDefined();
+      expect(result.operations['op-1']).toBeDefined();
+
+      // Should include rel-1 (referenced in edges)
+      expect(result.relations['rel-1']).toBeDefined();
+    });
+
+    it('should handle interfaces', () => {
+      const view: DiagramView = {
+        diagramId: 'test-diagram',
+        nodes: [
+          { id: 'node-1', elementId: 'interface-1', x: 100, y: 100 },
+        ],
+        edges: [],
+      };
+
+      const model: SemanticModel = {
+        id: 'model-1',
+        name: 'Test Model',
+        version: '1.0.0',
+        packages: {},
+        classes: {},
+        interfaces: {
+          'interface-1': {
+            id: 'interface-1',
+            kind: 'INTERFACE',
+            name: 'IRepository',
+            operationIds: ['op-1'],
+            visibility: 'public',
+          },
+        },
+        enums: {},
+        dataTypes: {},
+        attributes: {},
+        operations: {
+          'op-1': {
+            id: 'op-1',
+            kind: 'OPERATION',
+            name: 'save',
+            returnType: 'void',
+            visibility: 'public',
+            parameters: [],
+            isReturnArray: false,
+            isStatic: false,
+          },
+        },
+        actors: {},
+        useCases: {},
+        activityNodes: {},
+        objectInstances: {},
+        components: {},
+        nodes: {},
+        artifacts: {},
+        relations: {},
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      };
+
+      const result = extractor.extractPartialModel(view, model);
+
+      expect(result.interfaces['interface-1']).toBeDefined();
+      expect(result.operations['op-1']).toBeDefined();
+    });
+
+    it('should handle enums', () => {
+      const view: DiagramView = {
+        diagramId: 'test-diagram',
+        nodes: [
+          { id: 'node-1', elementId: 'enum-1', x: 100, y: 100 },
+        ],
+        edges: [],
+      };
+
+      const model: SemanticModel = {
+        id: 'model-1',
+        name: 'Test Model',
+        version: '1.0.0',
+        packages: {},
+        classes: {},
+        interfaces: {},
+        enums: {
+          'enum-1': {
+            id: 'enum-1',
+            kind: 'ENUM',
+            name: 'Status',
+            literals: [
+              { name: 'ACTIVE' },
+              { name: 'INACTIVE' },
+            ],
+            visibility: 'public',
+          },
+        },
+        dataTypes: {},
+        attributes: {},
+        operations: {},
+        actors: {},
+        useCases: {},
+        activityNodes: {},
+        objectInstances: {},
+        components: {},
+        nodes: {},
+        artifacts: {},
+        relations: {},
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      };
+
+      const result = extractor.extractPartialModel(view, model);
+
+      expect(result.enums['enum-1']).toBeDefined();
+      expect(result.enums['enum-1'].literals).toHaveLength(2);
+    });
+
+    it('should handle nodes without elementId (notes)', () => {
+      const view: DiagramView = {
+        diagramId: 'test-diagram',
+        nodes: [
+          { id: 'node-1', elementId: '', x: 100, y: 100, content: 'This is a note' },
+        ],
+        edges: [],
+      };
+
+      const model: SemanticModel = {
+        id: 'model-1',
+        name: 'Test Model',
+        version: '1.0.0',
+        packages: {},
+        classes: {},
+        interfaces: {},
+        enums: {},
+        dataTypes: {},
+        attributes: {},
+        operations: {},
+        actors: {},
+        useCases: {},
+        activityNodes: {},
+        objectInstances: {},
+        components: {},
+        nodes: {},
+        artifacts: {},
+        relations: {},
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      };
+
+      const result = extractor.extractPartialModel(view, model);
+
+      // Should not throw, should return empty model
+      expect(Object.keys(result.classes)).toHaveLength(0);
+      expect(Object.keys(result.interfaces)).toHaveLength(0);
+      expect(Object.keys(result.enums)).toHaveLength(0);
+    });
+
+    it('should extract package names from elements', () => {
+      const view: DiagramView = {
+        diagramId: 'test-diagram',
+        nodes: [
+          { id: 'node-1', elementId: 'class-1', x: 100, y: 100 },
+          { id: 'node-2', elementId: 'class-2', x: 200, y: 200 },
+        ],
+        edges: [],
+      };
+
+      const model: SemanticModel = {
+        id: 'model-1',
+        name: 'Test Model',
+        version: '1.0.0',
+        packages: {},
+        classes: {
+          'class-1': {
+            id: 'class-1',
+            kind: 'CLASS',
+            name: 'User',
+            packageName: 'com.example.domain',
+            attributeIds: [],
+            operationIds: [],
+            visibility: 'public',
+            isAbstract: false,
+          },
+          'class-2': {
+            id: 'class-2',
+            kind: 'CLASS',
+            name: 'Order',
+            packageName: 'com.example.orders',
+            attributeIds: [],
+            operationIds: [],
+            visibility: 'public',
+            isAbstract: false,
+          },
+        },
+        interfaces: {},
+        enums: {},
+        dataTypes: {},
+        attributes: {},
+        operations: {},
+        actors: {},
+        useCases: {},
+        activityNodes: {},
+        objectInstances: {},
+        components: {},
+        nodes: {},
+        artifacts: {},
+        relations: {},
+        packageNames: ['com.example.domain', 'com.example.orders', 'com.example.unused'],
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      };
+
+      const result = extractor.extractPartialModel(view, model);
+
+      // Should include package names from referenced elements
+      expect(result.packageNames).toContain('com.example.domain');
+      expect(result.packageNames).toContain('com.example.orders');
+      
+      // Should NOT include unused package
+      expect(result.packageNames).not.toContain('com.example.unused');
+    });
+  });
+});

--- a/src/services/diagram/extraction/ModelExtractor.ts
+++ b/src/services/diagram/extraction/ModelExtractor.ts
@@ -1,0 +1,253 @@
+/**
+ * ModelExtractor.ts
+ * 
+ * Extracts a partial semantic model from the complete model based on
+ * the elements referenced in a DiagramView.
+ * 
+ * Responsibilities:
+ * - Extract only elements referenced in the diagram
+ * - Extract attributes and operations of those elements
+ * - Extract relations between those elements
+ * - Maintain referential integrity
+ * 
+ * Strategy:
+ * - Only include elements that appear in view.nodes
+ * - Only include relations that connect visible elements
+ * - Include dependencies (attributes, operations, packages)
+ */
+
+import type {
+  SemanticModel,
+  DiagramView,
+  IRClass,
+  IRInterface,
+  IREnum,
+  IRPackage,
+} from '../../../core/domain/vfs/vfs.types';
+
+/**
+ * Partial semantic model (only diagram elements)
+ */
+export interface PartialSemanticModel {
+  id: string;
+  name: string;
+  version: string;
+  packages: Record<string, IRPackage>;
+  classes: Record<string, IRClass>;
+  interfaces: Record<string, IRInterface>;
+  enums: Record<string, IREnum>;
+  dataTypes: Record<string, any>;
+  attributes: Record<string, any>;
+  operations: Record<string, any>;
+  relations: Record<string, any>;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export class ModelExtractor {
+  /**
+   * Extracts partial model based on the DiagramView
+   * 
+   * @param view - Diagram view with nodes and edges
+   * @param fullModel - Complete semantic model
+   * @returns PartialSemanticModel - Model with only used elements
+   * 
+   * @example
+   * ```typescript
+   * const extractor = new ModelExtractor();
+   * const partial = extractor.extractPartialModel(view, fullModel);
+   * // partial solo contiene elementos referenciados en view.nodes
+   * ```
+   */
+  extractPartialModel(
+    view: DiagramView,
+    fullModel: SemanticModel,
+  ): PartialSemanticModel {
+    // 1. Collect referenced element IDs
+    const elementIds = new Set(
+      view.nodes
+        .map(n => n.elementId)
+        .filter(id => id !== '') // Exclude notes (empty elementId)
+    );
+    
+    // 2. Collect referenced relation IDs
+    const relationIds = new Set(
+      view.edges.map(e => e.relationId)
+    );
+    
+    // 3. Create empty partial model
+    const partial = this.createEmptyModel(fullModel);
+    
+    // 4. Extract elements
+    for (const elementId of elementIds) {
+      this.extractElement(elementId, fullModel, partial);
+    }
+    
+    // 5. Extract relations (only those connecting visible elements)
+    for (const relationId of relationIds) {
+      const relation = fullModel.relations[relationId];
+      if (relation) {
+        // Verify both ends are in the diagram
+        if (elementIds.has(relation.sourceId) && elementIds.has(relation.targetId)) {
+          partial.relations[relationId] = relation;
+        }
+      }
+    }
+    
+    return partial;
+  }
+
+  /**
+   * Creates an empty partial model with metadata from the complete model
+   */
+  private createEmptyModel(fullModel: SemanticModel): PartialSemanticModel {
+    return {
+      id: fullModel.id,
+      name: 'Diagram Snapshot',
+      version: fullModel.version,
+      packages: {},
+      classes: {},
+      interfaces: {},
+      enums: {},
+      dataTypes: {},
+      attributes: {},
+      operations: {},
+      relations: {},
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+  }
+
+  /**
+   * Extracts an element and its dependencies from the complete model
+   * 
+   * @param elementId - ID of the element to extract
+   * @param fullModel - Complete model
+   * @param partial - Partial model where to add the element
+   */
+  private extractElement(
+    elementId: string,
+    fullModel: SemanticModel,
+    partial: PartialSemanticModel,
+  ): void {
+    // Extract class
+    if (fullModel.classes[elementId]) {
+      this.extractClass(elementId, fullModel, partial);
+      return;
+    }
+    
+    // Extract interface
+    if (fullModel.interfaces[elementId]) {
+      this.extractInterface(elementId, fullModel, partial);
+      return;
+    }
+    
+    // Extract enum
+    if (fullModel.enums[elementId]) {
+      this.extractEnum(elementId, fullModel, partial);
+      return;
+    }
+    
+    // Extract package
+    if (fullModel.packages[elementId]) {
+      this.extractPackage(elementId, fullModel, partial);
+      return;
+    }
+  }
+
+  /**
+   * Extracts a class with its attributes and operations
+   */
+  private extractClass(
+    classId: string,
+    fullModel: SemanticModel,
+    partial: PartialSemanticModel,
+  ): void {
+    const cls = fullModel.classes[classId];
+    if (!cls) return;
+
+    // Add the class
+    partial.classes[classId] = cls;
+    
+    // Extract attributes
+    for (const attrId of cls.attributeIds) {
+      if (fullModel.attributes[attrId]) {
+        partial.attributes[attrId] = fullModel.attributes[attrId];
+      }
+    }
+    
+    // Extract operations
+    for (const opId of cls.operationIds) {
+      if (fullModel.operations[opId]) {
+        partial.operations[opId] = fullModel.operations[opId];
+      }
+    }
+    
+    // Extract package if exists
+    if (cls.packageId && fullModel.packages[cls.packageId]) {
+      partial.packages[cls.packageId] = fullModel.packages[cls.packageId];
+    }
+  }
+
+  /**
+   * Extracts an interface with its operations
+   */
+  private extractInterface(
+    interfaceId: string,
+    fullModel: SemanticModel,
+    partial: PartialSemanticModel,
+  ): void {
+    const iface = fullModel.interfaces[interfaceId];
+    if (!iface) return;
+
+    // Add the interface
+    partial.interfaces[interfaceId] = iface;
+    
+    // Extract operations
+    for (const opId of iface.operationIds) {
+      if (fullModel.operations[opId]) {
+        partial.operations[opId] = fullModel.operations[opId];
+      }
+    }
+    
+    // Extract package if exists
+    if (iface.packageId && fullModel.packages[iface.packageId]) {
+      partial.packages[iface.packageId] = fullModel.packages[iface.packageId];
+    }
+  }
+
+  /**
+   * Extracts an enum
+   */
+  private extractEnum(
+    enumId: string,
+    fullModel: SemanticModel,
+    partial: PartialSemanticModel,
+  ): void {
+    const enm = fullModel.enums[enumId];
+    if (!enm) return;
+
+    // Add the enum
+    partial.enums[enumId] = enm;
+    
+    // Extract package if exists
+    if (enm.packageId && fullModel.packages[enm.packageId]) {
+      partial.packages[enm.packageId] = fullModel.packages[enm.packageId];
+    }
+  }
+
+  /**
+   * Extracts a package
+   */
+  private extractPackage(
+    packageId: string,
+    fullModel: SemanticModel,
+    partial: PartialSemanticModel,
+  ): void {
+    const pkg = fullModel.packages[packageId];
+    if (!pkg) return;
+
+    // Add the package
+    partial.packages[packageId] = pkg;
+  }
+}

--- a/src/services/diagram/extraction/ModelExtractor.ts
+++ b/src/services/diagram/extraction/ModelExtractor.ts
@@ -39,7 +39,15 @@ export interface PartialSemanticModel {
   dataTypes: Record<string, any>;
   attributes: Record<string, any>;
   operations: Record<string, any>;
+  actors?: Record<string, any>;
+  useCases?: Record<string, any>;
+  activityNodes?: Record<string, any>;
+  objectInstances?: Record<string, any>;
+  components?: Record<string, any>;
+  nodes?: Record<string, any>;
+  artifacts?: Record<string, any>;
   relations: Record<string, any>;
+  packageNames?: string[];
   createdAt: number;
   updatedAt: number;
 }

--- a/src/services/diagram/extraction/ModelExtractor.ts
+++ b/src/services/diagram/extraction/ModelExtractor.ts
@@ -95,13 +95,27 @@ export class ModelExtractor {
     for (const relationId of relationIds) {
       const relation = fullModel.relations[relationId];
       if (relation) {
-        // Verify both ends are in the diagram
         if (elementIds.has(relation.sourceId) && elementIds.has(relation.targetId)) {
           partial.relations[relationId] = relation;
         }
       }
     }
-    
+
+    // 6. Collect packageNames from extracted elements
+    const packageNames = new Set<string>();
+    for (const cls of Object.values(partial.classes)) {
+      if (cls.packageName) packageNames.add(cls.packageName);
+    }
+    for (const iface of Object.values(partial.interfaces)) {
+      if (iface.packageName) packageNames.add(iface.packageName);
+    }
+    for (const enm of Object.values(partial.enums)) {
+      if (enm.packageName) packageNames.add(enm.packageName);
+    }
+    if (packageNames.size > 0) {
+      partial.packageNames = Array.from(packageNames);
+    }
+
     return partial;
   }
 

--- a/src/services/diagram/index.ts
+++ b/src/services/diagram/index.ts
@@ -1,0 +1,38 @@
+/**
+ * diagram/index.ts
+ * 
+ * Main entry point for the diagram I/O module
+ * 
+ * Exports:
+ * - DiagramIOService (main service)
+ * - getDiagramIOService (helper to get instance)
+ * - Types and errors
+ */
+
+// Main service
+export { DiagramIOService } from './DiagramIOService';
+export type { ParsedDiagram } from './DiagramIOService';
+export { DiagramExportError, DiagramImportError } from './DiagramIOService';
+
+// Factory
+export { getDiagramIOService, diagramIOServiceFactory } from './DiagramIOServiceFactory';
+
+// Serialization
+export { DiagramSerializer, LUML_FORMAT_VERSION } from './serialization/DiagramSerializer';
+export type { DiagramPayload } from './serialization/DiagramSerializer';
+export { SerializationError } from './serialization/DiagramSerializer';
+
+export { DiagramDeserializer } from './serialization/DiagramDeserializer';
+export { DeserializationError } from './serialization/DiagramDeserializer';
+
+export { FormatDetector } from './serialization/FormatDetector';
+export type { DiagramFormat, DetectedFormatInfo } from './serialization/FormatDetector';
+export { FormatDetectionError } from './serialization/FormatDetector';
+
+// Validation
+export { DiagramValidator } from './validation/DiagramValidator';
+export type { ValidationResult } from './validation/DiagramValidator';
+
+// Extraction
+export { ModelExtractor } from './extraction/ModelExtractor';
+export type { PartialSemanticModel } from './extraction/ModelExtractor';

--- a/src/services/diagram/serialization/DiagramDeserializer.ts
+++ b/src/services/diagram/serialization/DiagramDeserializer.ts
@@ -23,16 +23,20 @@ import { FormatDetector, type DiagramFormat } from './FormatDetector';
  * Error de deserialización
  */
 export class DeserializationError extends Error {
-  constructor(message: string, public readonly cause?: unknown) {
+  readonly cause?: unknown;
+  constructor(message: string, cause?: unknown) {
     super(message);
     this.name = 'DeserializationError';
+    this.cause = cause;
   }
 }
 
 export class DiagramDeserializer {
-  constructor(
-    private readonly formatDetector: FormatDetector,
-  ) {}
+  private readonly formatDetector: FormatDetector;
+
+  constructor(formatDetector: FormatDetector) {
+    this.formatDetector = formatDetector;
+  }
 
   /**
    * Detecta el formato del archivo
@@ -41,7 +45,7 @@ export class DiagramDeserializer {
    * @returns Promise<DiagramFormat> - Formato detectado
    */
   async detectFormat(file: File | Blob): Promise<DiagramFormat> {
-    return this.formatDetector.detect(file);
+    return this.formatDetector.detectFormat(file);
   }
 
   /**
@@ -148,7 +152,7 @@ export class DiagramDeserializer {
         );
       }
       
-      return payload as DiagramPayload;
+      return payload as unknown as DiagramPayload;
     } catch (error) {
       if (error instanceof DeserializationError) {
         throw error;

--- a/src/services/diagram/serialization/DiagramDeserializer.ts
+++ b/src/services/diagram/serialization/DiagramDeserializer.ts
@@ -1,0 +1,253 @@
+/**
+ * DiagramDeserializer.ts
+ * 
+ * Deserializa diagramas desde JSON plano (v2.0) o ZIP (legacy)
+ * 
+ * Responsabilidades:
+ * - Detectar formato automáticamente
+ * - Parsear JSON plano
+ * - Parsear ZIP legacy (retrocompatibilidad)
+ * - Validar estructura básica
+ * - Retornar payload normalizado
+ * 
+ * Formatos soportados:
+ * - JSON plano v2.0 (nuevo)
+ * - ZIP v2.0 (legacy, retrocompatibilidad)
+ */
+
+import JSZip from 'jszip';
+import type { DiagramPayload } from './DiagramSerializer';
+import { FormatDetector, type DiagramFormat } from './FormatDetector';
+
+/**
+ * Error de deserialización
+ */
+export class DeserializationError extends Error {
+  constructor(message: string, public readonly cause?: unknown) {
+    super(message);
+    this.name = 'DeserializationError';
+  }
+}
+
+export class DiagramDeserializer {
+  constructor(
+    private readonly formatDetector: FormatDetector,
+  ) {}
+
+  /**
+   * Detecta el formato del archivo
+   * 
+   * @param file - Archivo a analizar
+   * @returns Promise<DiagramFormat> - Formato detectado
+   */
+  async detectFormat(file: File | Blob): Promise<DiagramFormat> {
+    return this.formatDetector.detect(file);
+  }
+
+  /**
+   * Deserializa un archivo según su formato
+   * 
+   * @param file - Archivo a deserializar
+   * @param format - Formato detectado (opcional, se detecta automáticamente si no se provee)
+   * @returns Promise<DiagramPayload> - Payload normalizado
+   * @throws DeserializationError si hay problemas
+   * 
+   * @example
+   * ```typescript
+   * const deserializer = new DiagramDeserializer(formatDetector);
+   * const payload = await deserializer.deserialize(file);
+   * // payload está normalizado a formato v2.0
+   * ```
+   */
+  async deserialize(
+    file: File | Blob,
+    format?: DiagramFormat,
+  ): Promise<DiagramPayload> {
+    try {
+      // Detectar formato si no se provee
+      const detectedFormat = format ?? await this.detectFormat(file);
+      
+      if (detectedFormat === 'json') {
+        return await this.deserializeJSON(file);
+      } else {
+        return await this.deserializeZIP(file);
+      }
+    } catch (error) {
+      if (error instanceof DeserializationError) {
+        throw error;
+      }
+      throw new DeserializationError(
+        'Failed to deserialize diagram file',
+        error
+      );
+    }
+  }
+
+  /**
+   * Deserializa JSON plano (formato v2.0)
+   */
+  private async deserializeJSON(file: File | Blob): Promise<DiagramPayload> {
+    try {
+      // Leer contenido del archivo
+      const text = await this.readAsText(file);
+      
+      // Parsear JSON
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(text);
+      } catch (error) {
+        throw new DeserializationError(
+          'Invalid JSON format: file contains malformed JSON',
+          error
+        );
+      }
+      
+      // Validar estructura básica
+      if (!parsed || typeof parsed !== 'object') {
+        throw new DeserializationError(
+          'Invalid JSON format: root must be an object'
+        );
+      }
+      
+      const payload = parsed as Record<string, unknown>;
+      
+      // Validar campos requeridos
+      if (!payload._lumlVersion) {
+        throw new DeserializationError(
+          'Invalid format: missing _lumlVersion field'
+        );
+      }
+      
+      if (payload.exportType !== 'diagram') {
+        throw new DeserializationError(
+          `Invalid format: exportType must be "diagram", got "${payload.exportType}"`
+        );
+      }
+      
+      if (!payload.diagramId || typeof payload.diagramId !== 'string') {
+        throw new DeserializationError(
+          'Invalid format: missing or invalid diagramId'
+        );
+      }
+      
+      if (!payload.diagramName || typeof payload.diagramName !== 'string') {
+        throw new DeserializationError(
+          'Invalid format: missing or invalid diagramName'
+        );
+      }
+      
+      if (!payload.model || typeof payload.model !== 'object') {
+        throw new DeserializationError(
+          'Invalid format: missing or invalid model'
+        );
+      }
+      
+      if (!payload.view || typeof payload.view !== 'object') {
+        throw new DeserializationError(
+          'Invalid format: missing or invalid view'
+        );
+      }
+      
+      return payload as DiagramPayload;
+    } catch (error) {
+      if (error instanceof DeserializationError) {
+        throw error;
+      }
+      throw new DeserializationError(
+        'Failed to deserialize JSON diagram',
+        error
+      );
+    }
+  }
+
+  /**
+   * Deserializa ZIP legacy (retrocompatibilidad con formato viejo)
+   * 
+   * Estructura ZIP:
+   * - project.json: { exportType, diagramId, diagramName }
+   * - domain.model: SemanticModel parcial
+   * - diagrams/{id}.json: DiagramView
+   */
+  private async deserializeZIP(file: File | Blob): Promise<DiagramPayload> {
+    try {
+      // Abrir ZIP
+      const zip = await JSZip.loadAsync(file);
+      
+      // Leer project.json
+      const projectEntry = zip.file('project.json');
+      if (!projectEntry) {
+        throw new DeserializationError(
+          'Invalid ZIP format: missing project.json'
+        );
+      }
+      
+      const manifestText = await projectEntry.async('string');
+      const manifest = JSON.parse(manifestText) as Record<string, unknown>;
+      
+      // Validar manifest
+      if (!manifest.diagramId || typeof manifest.diagramId !== 'string') {
+        throw new DeserializationError(
+          'Invalid ZIP format: project.json missing diagramId'
+        );
+      }
+      
+      if (!manifest.diagramName || typeof manifest.diagramName !== 'string') {
+        throw new DeserializationError(
+          'Invalid ZIP format: project.json missing diagramName'
+        );
+      }
+      
+      // Leer domain.model
+      const modelEntry = zip.file('domain.model');
+      if (!modelEntry) {
+        throw new DeserializationError(
+          'Invalid ZIP format: missing domain.model'
+        );
+      }
+      
+      const modelText = await modelEntry.async('string');
+      const model = JSON.parse(modelText);
+      
+      // Leer diagrams/{id}.json
+      const diagramEntry = zip.file(`diagrams/${manifest.diagramId}.json`);
+      if (!diagramEntry) {
+        throw new DeserializationError(
+          `Invalid ZIP format: missing diagrams/${manifest.diagramId}.json`
+        );
+      }
+      
+      const viewText = await diagramEntry.async('string');
+      const view = JSON.parse(viewText);
+      
+      // Normalizar a formato v2.0
+      return {
+        _lumlVersion: '2.0',
+        exportType: 'diagram',
+        diagramId: manifest.diagramId as string,
+        diagramName: manifest.diagramName as string,
+        model: model,
+        view: view,
+      };
+    } catch (error) {
+      if (error instanceof DeserializationError) {
+        throw error;
+      }
+      throw new DeserializationError(
+        'Failed to deserialize ZIP diagram',
+        error
+      );
+    }
+  }
+
+  /**
+   * Lee un archivo como texto
+   */
+  private async readAsText(file: File | Blob): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result as string);
+      reader.onerror = () => reject(new Error('Failed to read file'));
+      reader.readAsText(file);
+    });
+  }
+}

--- a/src/services/diagram/serialization/DiagramSerializer.ts
+++ b/src/services/diagram/serialization/DiagramSerializer.ts
@@ -45,9 +45,11 @@ export interface DiagramPayload {
  * Serialization error
  */
 export class SerializationError extends Error {
-  constructor(message: string, public readonly cause?: unknown) {
+  readonly cause?: unknown;
+  constructor(message: string, cause?: unknown) {
     super(message);
     this.name = 'SerializationError';
+    this.cause = cause;
   }
 }
 

--- a/src/services/diagram/serialization/DiagramSerializer.ts
+++ b/src/services/diagram/serialization/DiagramSerializer.ts
@@ -1,0 +1,175 @@
+/**
+ * DiagramSerializer.ts
+ * 
+ * Serializes a diagram to flat JSON format v2.0
+ * 
+ * Responsibilities:
+ * - Convert DiagramPayload to JSON string
+ * - Apply consistent formatting (2 spaces)
+ * - Preserve ALL visual information (x, y, width, height, parentPackageId)
+ * - Maintain flat and readable structure
+ * - Validate that payload has all required fields
+ * 
+ * Output format:
+ * {
+ *   "_lumlVersion": "2.0",
+ *   "exportType": "diagram",
+ *   "diagramId": "...",
+ *   "diagramName": "...",
+ *   "model": { ... },
+ *   "view": { ... }
+ * }
+ */
+
+import type { DiagramView } from '../../../core/domain/vfs/vfs.types';
+import type { PartialSemanticModel } from '../extraction/ModelExtractor';
+
+/**
+ * LUML format version
+ */
+export const LUML_FORMAT_VERSION = '2.0' as const;
+
+/**
+ * Export payload structure
+ */
+export interface DiagramPayload {
+  _lumlVersion: typeof LUML_FORMAT_VERSION;
+  exportType: 'diagram';
+  diagramId: string;
+  diagramName: string;
+  model: PartialSemanticModel;
+  view: DiagramView;
+}
+
+/**
+ * Serialization error
+ */
+export class SerializationError extends Error {
+  constructor(message: string, public readonly cause?: unknown) {
+    super(message);
+    this.name = 'SerializationError';
+  }
+}
+
+export class DiagramSerializer {
+  /**
+   * Serializes a diagram payload to JSON string
+   * 
+   * @param payload - Diagram data to serialize
+   * @returns string - JSON formatted with 2 spaces
+   * @throws SerializationError if payload is invalid
+   * 
+   * @example
+   * ```typescript
+   * const serializer = new DiagramSerializer();
+   * const json = serializer.serialize(payload);
+   * // json is a formatted JSON string
+   * ```
+   */
+  serialize(payload: DiagramPayload): string {
+    // Validate that payload has all required fields
+    this.validatePayload(payload);
+    
+    try {
+      // Serialize with consistent formatting (2 spaces)
+      return JSON.stringify(payload, null, 2);
+    } catch (error) {
+      throw new SerializationError(
+        'Failed to serialize diagram payload',
+        error
+      );
+    }
+  }
+
+  /**
+   * Validates that payload has all required fields
+   * 
+   * @throws SerializationError if any required field is missing
+   */
+  private validatePayload(payload: DiagramPayload): void {
+    const errors: string[] = [];
+
+    if (!payload._lumlVersion) {
+      errors.push('Missing _lumlVersion');
+    } else if (payload._lumlVersion !== LUML_FORMAT_VERSION) {
+      errors.push(`Invalid _lumlVersion: expected "${LUML_FORMAT_VERSION}", got "${payload._lumlVersion}"`);
+    }
+
+    if (!payload.exportType) {
+      errors.push('Missing exportType');
+    } else if (payload.exportType !== 'diagram') {
+      errors.push(`Invalid exportType: expected "diagram", got "${payload.exportType}"`);
+    }
+
+    if (!payload.diagramId) {
+      errors.push('Missing diagramId');
+    }
+
+    if (!payload.diagramName) {
+      errors.push('Missing diagramName');
+    }
+
+    if (!payload.model) {
+      errors.push('Missing model');
+    } else {
+      // Validate basic model structure
+      if (typeof payload.model !== 'object') {
+        errors.push('model must be an object');
+      } else {
+        if (!payload.model.id) errors.push('model.id is required');
+        if (!payload.model.name) errors.push('model.name is required');
+        if (!payload.model.version) errors.push('model.version is required');
+        if (!payload.model.classes) errors.push('model.classes is required');
+        if (!payload.model.interfaces) errors.push('model.interfaces is required');
+        if (!payload.model.enums) errors.push('model.enums is required');
+        if (!payload.model.relations) errors.push('model.relations is required');
+      }
+    }
+
+    if (!payload.view) {
+      errors.push('Missing view');
+    } else {
+      // Validate basic view structure
+      if (typeof payload.view !== 'object') {
+        errors.push('view must be an object');
+      } else {
+        if (!Array.isArray(payload.view.nodes)) {
+          errors.push('view.nodes must be an array');
+        }
+        if (!Array.isArray(payload.view.edges)) {
+          errors.push('view.edges must be an array');
+        }
+      }
+    }
+
+    if (errors.length > 0) {
+      throw new SerializationError(
+        `Invalid diagram payload:\n${errors.map(e => `  - ${e}`).join('\n')}`
+      );
+    }
+  }
+
+  /**
+   * Creates a valid payload from individual data
+   * 
+   * Helper to facilitate payload creation
+   * 
+   * @param params - Payload parameters
+   * @returns DiagramPayload - Valid payload
+   */
+  static createPayload(params: {
+    diagramId: string;
+    diagramName: string;
+    model: PartialSemanticModel;
+    view: DiagramView;
+  }): DiagramPayload {
+    return {
+      _lumlVersion: LUML_FORMAT_VERSION,
+      exportType: 'diagram',
+      diagramId: params.diagramId,
+      diagramName: params.diagramName,
+      model: params.model,
+      view: params.view,
+    };
+  }
+}

--- a/src/services/diagram/serialization/FormatDetector.ts
+++ b/src/services/diagram/serialization/FormatDetector.ts
@@ -1,75 +1,51 @@
 /**
  * FormatDetector.ts
- * 
- * Detecta automáticamente el formato de un archivo .luml
- * 
- * Responsabilidades:
- * - Distinguir entre JSON plano y ZIP
- * - Validar que sea un formato soportado
- * - Retornar formato para deserialización
- * 
- * Estrategia de detección:
- * 1. Leer primeros 4 bytes del archivo
- * 2. Si empieza con 'PK' (0x50 0x4B) → ZIP
- * 3. Si empieza con '{' (0x7B) → JSON
- * 4. Sino → Error
- * 
- * Magic numbers:
- * - ZIP: 0x50 0x4B 0x03 0x04 (PK..)
- * - JSON: 0x7B ({)
+ *
+ * Detects the format of a .luml file automatically.
+ *
+ * Detection strategy:
+ * 1. Read the first 4 bytes
+ * 2. If starts with 'PK' (0x50 0x4B 0x03 0x04) → ZIP
+ * 3. If starts with '{' (0x7B) → JSON
+ * 4. Otherwise → Error
  */
 
-/**
- * Formatos soportados
- */
 export type DiagramFormat = 'json' | 'zip';
 
-/**
- * Error de detección de formato
- */
 export class FormatDetectionError extends Error {
-  constructor(message: string, public readonly cause?: unknown) {
+  readonly cause?: unknown;
+  constructor(message: string, cause?: unknown) {
     super(message);
     this.name = 'FormatDetectionError';
+    this.cause = cause;
   }
 }
 
 export class FormatDetector {
   /**
-   * Detecta el formato del archivo
-   * 
-   * @param file - Archivo a analizar
-   * @returns Promise<DiagramFormat> - Formato detectado ('json' | 'zip')
-   * @throws FormatDetectionError si el formato no es soportado
-   * 
-   * @example
-   * ```typescript
-   * const detector = new FormatDetector();
-   * const format = await detector.detect(file);
-   * if (format === 'json') {
-   *   // Procesar como JSON
-   * } else {
-   *   // Procesar como ZIP
-   * }
-   * ```
+   * Detects the file format (alias for detectFormat).
    */
   async detect(file: File | Blob): Promise<DiagramFormat> {
+    return this.detectFormat(file);
+  }
+
+  /**
+   * Detects the file format.
+   *
+   * @throws FormatDetectionError if the format is not supported
+   */
+  async detectFormat(file: File | Blob): Promise<DiagramFormat> {
     try {
-      // Leer primeros 4 bytes
       const header = await this.readHeader(file, 4);
-      
-      // ZIP magic number: 0x50 0x4B 0x03 0x04 (PK..)
-      // Solo verificamos los primeros 2 bytes (PK) para mayor compatibilidad
+
       if (header[0] === 0x50 && header[1] === 0x4B) {
         return 'zip';
       }
-      
-      // JSON: empieza con '{'
-      if (header[0] === 0x7B) { // 0x7B = '{'
+
+      if (header[0] === 0x7B) {
         return 'json';
       }
-      
-      // Formato no reconocido
+
       throw new FormatDetectionError(
         `Unsupported file format. Expected JSON or ZIP.\n` +
         `File header: [${Array.from(header).map(b => `0x${b.toString(16).padStart(2, '0')}`).join(', ')}]`
@@ -78,45 +54,59 @@ export class FormatDetector {
       if (error instanceof FormatDetectionError) {
         throw error;
       }
-      throw new FormatDetectionError(
-        'Failed to detect file format',
-        error
-      );
+      throw new FormatDetectionError('Failed to detect file format', error);
     }
   }
 
   /**
-   * Lee los primeros N bytes de un archivo
-   * 
-   * @param file - Archivo a leer
-   * @param bytes - Número de bytes a leer
-   * @returns Promise<Uint8Array> - Bytes leídos
+   * Returns true only if the file starts with '{' AND is valid JSON.
    */
-  private async readHeader(file: File | Blob, bytes: number): Promise<Uint8Array> {
+  async isJsonFormat(file: File | Blob): Promise<boolean> {
     try {
-      const slice = file.slice(0, bytes);
-      const buffer = await slice.arrayBuffer();
-      return new Uint8Array(buffer);
-    } catch (error) {
-      throw new FormatDetectionError(
-        'Failed to read file header',
-        error
+      const header = await this.readHeader(file, 1);
+      if (header.length < 1 || header[0] !== 0x7B) return false;
+      const text = await this.readAsText(file);
+      JSON.parse(text);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private readAsText(file: File | Blob): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result as string);
+      reader.onerror = () => reject(new Error('Failed to read file as text'));
+      reader.readAsText(file);
+    });
+  }
+
+  /**
+   * Returns true only if the file has the ZIP magic number (all 4 bytes) and is at least 4 bytes.
+   */
+  async isZipFormat(file: File | Blob): Promise<boolean> {
+    try {
+      if (file.size < 4) return false;
+      const header = await this.readHeader(file, 4);
+      return (
+        header[0] === 0x50 &&
+        header[1] === 0x4B &&
+        header[2] === 0x03 &&
+        header[3] === 0x04
       );
+    } catch {
+      return false;
     }
   }
 
   /**
-   * Detecta el formato y retorna información adicional
-   * 
-   * Útil para debugging y logging
-   * 
-   * @param file - Archivo a analizar
-   * @returns Promise<DetectedFormatInfo> - Información del formato detectado
+   * Detects the format and returns additional debug info.
    */
   async detectWithInfo(file: File | Blob): Promise<DetectedFormatInfo> {
     const header = await this.readHeader(file, 4);
-    const format = await this.detect(file);
-    
+    const format = await this.detectFormat(file);
+
     return {
       format,
       fileSize: file.size,
@@ -125,11 +115,29 @@ export class FormatDetector {
       headerHex: Array.from(header).map(b => `0x${b.toString(16).padStart(2, '0')}`).join(' '),
     };
   }
+
+  private readHeader(file: File | Blob, bytes: number): Promise<Uint8Array> {
+    return new Promise((resolve, reject) => {
+      try {
+        const slice = file.slice(0, bytes);
+        const reader = new FileReader();
+        reader.onload = () => {
+          if (reader.result instanceof ArrayBuffer) {
+            resolve(new Uint8Array(reader.result));
+          } else {
+            reject(new FormatDetectionError('Failed to read file header'));
+          }
+        };
+        reader.onerror = () =>
+          reject(new FormatDetectionError('Failed to read file header', reader.error));
+        reader.readAsArrayBuffer(slice);
+      } catch (error) {
+        reject(new FormatDetectionError('Failed to read file header', error));
+      }
+    });
+  }
 }
 
-/**
- * Información detallada del formato detectado
- */
 export interface DetectedFormatInfo {
   format: DiagramFormat;
   fileSize: number;

--- a/src/services/diagram/serialization/FormatDetector.ts
+++ b/src/services/diagram/serialization/FormatDetector.ts
@@ -1,0 +1,139 @@
+/**
+ * FormatDetector.ts
+ * 
+ * Detecta automáticamente el formato de un archivo .luml
+ * 
+ * Responsabilidades:
+ * - Distinguir entre JSON plano y ZIP
+ * - Validar que sea un formato soportado
+ * - Retornar formato para deserialización
+ * 
+ * Estrategia de detección:
+ * 1. Leer primeros 4 bytes del archivo
+ * 2. Si empieza con 'PK' (0x50 0x4B) → ZIP
+ * 3. Si empieza con '{' (0x7B) → JSON
+ * 4. Sino → Error
+ * 
+ * Magic numbers:
+ * - ZIP: 0x50 0x4B 0x03 0x04 (PK..)
+ * - JSON: 0x7B ({)
+ */
+
+/**
+ * Formatos soportados
+ */
+export type DiagramFormat = 'json' | 'zip';
+
+/**
+ * Error de detección de formato
+ */
+export class FormatDetectionError extends Error {
+  constructor(message: string, public readonly cause?: unknown) {
+    super(message);
+    this.name = 'FormatDetectionError';
+  }
+}
+
+export class FormatDetector {
+  /**
+   * Detecta el formato del archivo
+   * 
+   * @param file - Archivo a analizar
+   * @returns Promise<DiagramFormat> - Formato detectado ('json' | 'zip')
+   * @throws FormatDetectionError si el formato no es soportado
+   * 
+   * @example
+   * ```typescript
+   * const detector = new FormatDetector();
+   * const format = await detector.detect(file);
+   * if (format === 'json') {
+   *   // Procesar como JSON
+   * } else {
+   *   // Procesar como ZIP
+   * }
+   * ```
+   */
+  async detect(file: File | Blob): Promise<DiagramFormat> {
+    try {
+      // Leer primeros 4 bytes
+      const header = await this.readHeader(file, 4);
+      
+      // ZIP magic number: 0x50 0x4B 0x03 0x04 (PK..)
+      // Solo verificamos los primeros 2 bytes (PK) para mayor compatibilidad
+      if (header[0] === 0x50 && header[1] === 0x4B) {
+        return 'zip';
+      }
+      
+      // JSON: empieza con '{'
+      if (header[0] === 0x7B) { // 0x7B = '{'
+        return 'json';
+      }
+      
+      // Formato no reconocido
+      throw new FormatDetectionError(
+        `Unsupported file format. Expected JSON or ZIP.\n` +
+        `File header: [${Array.from(header).map(b => `0x${b.toString(16).padStart(2, '0')}`).join(', ')}]`
+      );
+    } catch (error) {
+      if (error instanceof FormatDetectionError) {
+        throw error;
+      }
+      throw new FormatDetectionError(
+        'Failed to detect file format',
+        error
+      );
+    }
+  }
+
+  /**
+   * Lee los primeros N bytes de un archivo
+   * 
+   * @param file - Archivo a leer
+   * @param bytes - Número de bytes a leer
+   * @returns Promise<Uint8Array> - Bytes leídos
+   */
+  private async readHeader(file: File | Blob, bytes: number): Promise<Uint8Array> {
+    try {
+      const slice = file.slice(0, bytes);
+      const buffer = await slice.arrayBuffer();
+      return new Uint8Array(buffer);
+    } catch (error) {
+      throw new FormatDetectionError(
+        'Failed to read file header',
+        error
+      );
+    }
+  }
+
+  /**
+   * Detecta el formato y retorna información adicional
+   * 
+   * Útil para debugging y logging
+   * 
+   * @param file - Archivo a analizar
+   * @returns Promise<DetectedFormatInfo> - Información del formato detectado
+   */
+  async detectWithInfo(file: File | Blob): Promise<DetectedFormatInfo> {
+    const header = await this.readHeader(file, 4);
+    const format = await this.detect(file);
+    
+    return {
+      format,
+      fileSize: file.size,
+      fileName: file instanceof File ? file.name : 'blob',
+      header: Array.from(header),
+      headerHex: Array.from(header).map(b => `0x${b.toString(16).padStart(2, '0')}`).join(' '),
+    };
+  }
+}
+
+/**
+ * Información detallada del formato detectado
+ */
+export interface DetectedFormatInfo {
+  format: DiagramFormat;
+  fileSize: number;
+  fileName: string;
+  header: number[];
+  headerHex: string;
+}

--- a/src/services/diagram/validation/DiagramValidator.ts
+++ b/src/services/diagram/validation/DiagramValidator.ts
@@ -1,0 +1,241 @@
+/**
+ * DiagramValidator.ts
+ * 
+ * Valida la estructura de un diagrama antes de export/import.
+ * 
+ * Responsabilidades:
+ * - Validar que view.nodes tenga datos válidos
+ * - Validar que parentPackageId apunte a nodos existentes
+ * - Validar que elementId exista en el modelo
+ * - Validar posiciones y dimensiones
+ * - Validar integridad referencial
+ * 
+ * Reglas de validación:
+ * 1. Estructura básica: nodes y edges son arrays
+ * 2. ViewNode: tiene id, x, y válidos
+ * 3. Posiciones no negativas
+ * 4. parentPackageId apunta a nodo existente
+ * 5. elementId existe en el modelo (excepto notas)
+ * 6. Dimensiones no negativas
+ * 7. No hay ciclos en parentPackageId
+ */
+
+import type {
+  DiagramView,
+  SemanticModel,
+  ViewNode,
+  ViewEdge,
+} from '../../../core/domain/vfs/vfs.types';
+import type { PartialSemanticModel } from '../extraction/ModelExtractor';
+
+/**
+ * Validation result
+ */
+export interface ValidationResult {
+  isValid: boolean;
+  errors: string[];
+}
+
+export class DiagramValidator {
+  /**
+   * Validates a complete diagram
+   * 
+   * @param view - Diagram view
+   * @param model - Semantic model (complete or partial)
+   * @returns ValidationResult - Result with errors if any
+   * 
+   * @example
+   * ```typescript
+   * const validator = new DiagramValidator();
+   * const result = validator.validate(view, model);
+   * if (!result.isValid) {
+   *   console.error('Validation errors:', result.errors);
+   * }
+   * ```
+   */
+  validate(
+    view: DiagramView,
+    model: SemanticModel | PartialSemanticModel,
+  ): ValidationResult {
+    const errors: string[] = [];
+    
+    // 1. Validate basic structure
+    if (!view.nodes || !Array.isArray(view.nodes)) {
+      errors.push('view.nodes must be an array');
+    }
+    if (!view.edges || !Array.isArray(view.edges)) {
+      errors.push('view.edges must be an array');
+    }
+    
+    // If basic structure is invalid, don't continue
+    if (errors.length > 0) {
+      return { isValid: false, errors };
+    }
+    
+    // 2. Validate each node
+    this.validateNodes(view.nodes, model, errors);
+    
+    // 3. Validate each edge
+    this.validateEdges(view.edges, model, errors);
+    
+    // 4. Validate package hierarchy (no cycles)
+    this.validatePackageHierarchy(view.nodes, errors);
+    
+    return {
+      isValid: errors.length === 0,
+      errors,
+    };
+  }
+
+  /**
+   * Validates all diagram nodes
+   */
+  private validateNodes(
+    nodes: ViewNode[],
+    model: SemanticModel | PartialSemanticModel,
+    errors: string[],
+  ): void {
+    const nodeIds = new Set(nodes.map(n => n.id));
+    
+    for (const node of nodes) {
+      // Validate required fields
+      if (!node.id) {
+        errors.push('Node missing id');
+        continue;
+      }
+      
+      if (node.x === undefined || node.x === null) {
+        errors.push(`Node ${node.id} missing x coordinate`);
+      }
+      
+      if (node.y === undefined || node.y === null) {
+        errors.push(`Node ${node.id} missing y coordinate`);
+      }
+      
+      // Validate non-negative positions
+      if (typeof node.x === 'number' && node.x < 0) {
+        errors.push(`Node ${node.id} has negative x position: ${node.x}`);
+      }
+      
+      if (typeof node.y === 'number' && node.y < 0) {
+        errors.push(`Node ${node.id} has negative y position: ${node.y}`);
+      }
+      
+      // Validate non-negative dimensions (if they exist)
+      if (node.width !== undefined && node.width < 0) {
+        errors.push(`Node ${node.id} has negative width: ${node.width}`);
+      }
+      
+      if (node.height !== undefined && node.height < 0) {
+        errors.push(`Node ${node.id} has negative height: ${node.height}`);
+      }
+      
+      // Validate parentPackageId points to existing node
+      if (node.parentPackageId && !nodeIds.has(node.parentPackageId)) {
+        errors.push(
+          `Node ${node.id} has invalid parentPackageId: ${node.parentPackageId} (node does not exist)`
+        );
+      }
+      
+      // Validate elementId exists in model (except notes with empty elementId)
+      if (node.elementId && !this.elementExistsInModel(node.elementId, model)) {
+        errors.push(
+          `Node ${node.id} references non-existent element: ${node.elementId}`
+        );
+      }
+    }
+  }
+
+  /**
+   * Validates all diagram edges
+   */
+  private validateEdges(
+    edges: ViewEdge[],
+    model: SemanticModel | PartialSemanticModel,
+    errors: string[],
+  ): void {
+    for (const edge of edges) {
+      // Validate required fields
+      if (!edge.id) {
+        errors.push('Edge missing id');
+        continue;
+      }
+      
+      if (!edge.relationId) {
+        errors.push(`Edge ${edge.id} missing relationId`);
+        continue;
+      }
+      
+      // Validate relationId exists in model
+      if (!model.relations[edge.relationId]) {
+        errors.push(
+          `Edge ${edge.id} references non-existent relation: ${edge.relationId}`
+        );
+      }
+    }
+  }
+
+  /**
+   * Validates that there are no cycles in the package hierarchy
+   * 
+   * A cycle would be: A.parentPackageId = B, B.parentPackageId = A
+   */
+  private validatePackageHierarchy(
+    nodes: ViewNode[],
+    errors: string[],
+  ): void {
+    const nodeMap = new Map(nodes.map(n => [n.id, n]));
+    
+    for (const node of nodes) {
+      if (!node.parentPackageId) continue;
+      
+      // Detect cycles by following the parentPackageId chain
+      const visited = new Set<string>([node.id]);
+      let currentId: string | null | undefined = node.parentPackageId;
+      
+      while (currentId) {
+        if (visited.has(currentId)) {
+          errors.push(
+            `Circular package hierarchy detected: node ${node.id} has a cycle in its parent chain`
+          );
+          break;
+        }
+        
+        visited.add(currentId);
+        const parent = nodeMap.get(currentId);
+        if (!parent) break;
+        
+        currentId = parent.parentPackageId;
+        
+        // Protection against infinite loops
+        if (visited.size > nodes.length) {
+          errors.push(
+            `Package hierarchy too deep for node ${node.id} (possible infinite loop)`
+          );
+          break;
+        }
+      }
+    }
+  }
+
+  /**
+   * Verifies if an element exists in the model
+   */
+  private elementExistsInModel(
+    elementId: string,
+    model: SemanticModel | PartialSemanticModel,
+  ): boolean {
+    return !!(
+      model.classes[elementId] ||
+      model.interfaces[elementId] ||
+      model.enums[elementId] ||
+      model.packages[elementId] ||
+      model.dataTypes?.[elementId] ||
+      model.actors?.[elementId] ||
+      model.useCases?.[elementId] ||
+      model.components?.[elementId] ||
+      model.nodes?.[elementId] ||
+      model.artifacts?.[elementId]
+    );
+  }
+}

--- a/src/services/diagram/validation/DiagramValidator.ts
+++ b/src/services/diagram/validation/DiagramValidator.ts
@@ -1,23 +1,17 @@
 /**
  * DiagramValidator.ts
- * 
- * Valida la estructura de un diagrama antes de export/import.
- * 
- * Responsabilidades:
- * - Validar que view.nodes tenga datos válidos
- * - Validar que parentPackageId apunte a nodos existentes
- * - Validar que elementId exista en el modelo
- * - Validar posiciones y dimensiones
- * - Validar integridad referencial
- * 
- * Reglas de validación:
- * 1. Estructura básica: nodes y edges son arrays
- * 2. ViewNode: tiene id, x, y válidos
- * 3. Posiciones no negativas
- * 4. parentPackageId apunta a nodo existente
- * 5. elementId existe en el modelo (excepto notas)
- * 6. Dimensiones no negativas
- * 7. No hay ciclos en parentPackageId
+ *
+ * Validates a diagram structure before export/import.
+ *
+ * Validation rules:
+ * 1. nodes and edges must be arrays
+ * 2. No duplicate node IDs
+ * 3. No duplicate edge IDs
+ * 4. parentPackageId must point to an existing node
+ * 5. elementId must exist in the model (except notes with empty elementId)
+ * 6. Positions and dimensions must not be negative
+ * 7. No cycles in parentPackageId chain
+ * 8. Warn when diagram has no nodes
  */
 
 import type {
@@ -28,171 +22,151 @@ import type {
 } from '../../../core/domain/vfs/vfs.types';
 import type { PartialSemanticModel } from '../extraction/ModelExtractor';
 
-/**
- * Validation result
- */
 export interface ValidationResult {
   isValid: boolean;
   errors: string[];
+  warnings: string[];
 }
 
 export class DiagramValidator {
-  /**
-   * Validates a complete diagram
-   * 
-   * @param view - Diagram view
-   * @param model - Semantic model (complete or partial)
-   * @returns ValidationResult - Result with errors if any
-   * 
-   * @example
-   * ```typescript
-   * const validator = new DiagramValidator();
-   * const result = validator.validate(view, model);
-   * if (!result.isValid) {
-   *   console.error('Validation errors:', result.errors);
-   * }
-   * ```
-   */
   validate(
     view: DiagramView,
     model: SemanticModel | PartialSemanticModel,
   ): ValidationResult {
     const errors: string[] = [];
-    
-    // 1. Validate basic structure
+    const warnings: string[] = [];
+
     if (!view.nodes || !Array.isArray(view.nodes)) {
-      errors.push('view.nodes must be an array');
+      errors.push('View must have a nodes array');
     }
     if (!view.edges || !Array.isArray(view.edges)) {
-      errors.push('view.edges must be an array');
+      errors.push('View must have an edges array');
     }
-    
-    // If basic structure is invalid, don't continue
+
     if (errors.length > 0) {
-      return { isValid: false, errors };
+      return { isValid: false, errors, warnings };
     }
-    
-    // 2. Validate each node
+
     this.validateNodes(view.nodes, model, errors);
-    
-    // 3. Validate each edge
     this.validateEdges(view.edges, model, errors);
-    
-    // 4. Validate package hierarchy (no cycles)
     this.validatePackageHierarchy(view.nodes, errors);
-    
+
+    if (view.nodes.length === 0) {
+      warnings.push('Diagram is empty (no nodes)');
+    }
+
     return {
       isValid: errors.length === 0,
       errors,
+      warnings,
     };
   }
 
-  /**
-   * Validates all diagram nodes
-   */
   private validateNodes(
     nodes: ViewNode[],
     model: SemanticModel | PartialSemanticModel,
     errors: string[],
   ): void {
-    const nodeIds = new Set(nodes.map(n => n.id));
-    
+    const nodeIds = new Set<string>();
+
     for (const node of nodes) {
-      // Validate required fields
       if (!node.id) {
         errors.push('Node missing id');
         continue;
       }
-      
+
+      if (nodeIds.has(node.id)) {
+        errors.push(`Duplicate node ID: ${node.id}`);
+      } else {
+        nodeIds.add(node.id);
+      }
+
       if (node.x === undefined || node.x === null) {
         errors.push(`Node ${node.id} missing x coordinate`);
       }
-      
+
       if (node.y === undefined || node.y === null) {
         errors.push(`Node ${node.id} missing y coordinate`);
       }
-      
-      // Validate non-negative positions
+
       if (typeof node.x === 'number' && node.x < 0) {
         errors.push(`Node ${node.id} has negative x position: ${node.x}`);
       }
-      
+
       if (typeof node.y === 'number' && node.y < 0) {
         errors.push(`Node ${node.id} has negative y position: ${node.y}`);
       }
-      
-      // Validate non-negative dimensions (if they exist)
+
       if (node.width !== undefined && node.width < 0) {
         errors.push(`Node ${node.id} has negative width: ${node.width}`);
       }
-      
+
       if (node.height !== undefined && node.height < 0) {
         errors.push(`Node ${node.id} has negative height: ${node.height}`);
       }
-      
-      // Validate parentPackageId points to existing node
+
       if (node.parentPackageId && !nodeIds.has(node.parentPackageId)) {
-        errors.push(
-          `Node ${node.id} has invalid parentPackageId: ${node.parentPackageId} (node does not exist)`
-        );
+        // Check in full node list (nodeIds may not have all nodes yet due to iteration order)
+        const allIds = new Set(nodes.map(n => n.id));
+        if (!allIds.has(node.parentPackageId)) {
+          errors.push(
+            `Node ${node.id} references non-existent parent package ${node.parentPackageId}`
+          );
+        }
       }
-      
-      // Validate elementId exists in model (except notes with empty elementId)
+
       if (node.elementId && !this.elementExistsInModel(node.elementId, model)) {
         errors.push(
-          `Node ${node.id} references non-existent element: ${node.elementId}`
+          `Node ${node.id} references non-existent element ${node.elementId}`
         );
       }
     }
   }
 
-  /**
-   * Validates all diagram edges
-   */
   private validateEdges(
     edges: ViewEdge[],
     model: SemanticModel | PartialSemanticModel,
     errors: string[],
   ): void {
+    const edgeIds = new Set<string>();
+
     for (const edge of edges) {
-      // Validate required fields
       if (!edge.id) {
         errors.push('Edge missing id');
         continue;
       }
-      
+
+      if (edgeIds.has(edge.id)) {
+        errors.push(`Duplicate edge ID: ${edge.id}`);
+      } else {
+        edgeIds.add(edge.id);
+      }
+
       if (!edge.relationId) {
         errors.push(`Edge ${edge.id} missing relationId`);
         continue;
       }
-      
-      // Validate relationId exists in model
+
       if (!model.relations[edge.relationId]) {
         errors.push(
-          `Edge ${edge.id} references non-existent relation: ${edge.relationId}`
+          `Edge ${edge.id} references non-existent relation ${edge.relationId}`
         );
       }
     }
   }
 
-  /**
-   * Validates that there are no cycles in the package hierarchy
-   * 
-   * A cycle would be: A.parentPackageId = B, B.parentPackageId = A
-   */
   private validatePackageHierarchy(
     nodes: ViewNode[],
     errors: string[],
   ): void {
     const nodeMap = new Map(nodes.map(n => [n.id, n]));
-    
+
     for (const node of nodes) {
       if (!node.parentPackageId) continue;
-      
-      // Detect cycles by following the parentPackageId chain
+
       const visited = new Set<string>([node.id]);
       let currentId: string | null | undefined = node.parentPackageId;
-      
+
       while (currentId) {
         if (visited.has(currentId)) {
           errors.push(
@@ -200,14 +174,13 @@ export class DiagramValidator {
           );
           break;
         }
-        
+
         visited.add(currentId);
         const parent = nodeMap.get(currentId);
         if (!parent) break;
-        
+
         currentId = parent.parentPackageId;
-        
-        // Protection against infinite loops
+
         if (visited.size > nodes.length) {
           errors.push(
             `Package hierarchy too deep for node ${node.id} (possible infinite loop)`
@@ -218,9 +191,6 @@ export class DiagramValidator {
     }
   }
 
-  /**
-   * Verifies if an element exists in the model
-   */
   private elementExistsInModel(
     elementId: string,
     model: SemanticModel | PartialSemanticModel,

--- a/src/services/openFileService.ts
+++ b/src/services/openFileService.ts
@@ -47,6 +47,7 @@ import { useToastStore } from '../store/toast.store';
 import { standaloneModelOps } from '../store/standaloneModelOps';
 import { XmiImporterService } from './xmiImporter.service';
 import { parseLumlFile, loadParsedProject } from './projectIO.service';
+import { getDiagramIOService } from './diagram';
 
 // ─── Shared helpers ───────────────────────────────────────────────────────────
 
@@ -162,6 +163,26 @@ function findDiagramsFolderId(): string | null {
  *   "diagram"  → injects the single diagram based on mode
  */
 export async function openLumlFile(file: File, mode: OpenMode): Promise<void> {
+  // Try new DiagramIOService first for single diagram imports
+  try {
+    const diagramService = getDiagramIOService();
+    const parsed = await diagramService.importDiagram(file);
+    
+    // Successfully parsed as diagram - inject it
+    await injectDiagramIntoVFS(
+      parsed.view,
+      parsed.model,
+      parsed.name,
+      mode,
+    );
+    return;
+  } catch (error) {
+    // If it's not a diagram format, fall back to legacy parser
+    // This handles full project imports
+    console.info('[LibreUML] Falling back to legacy parser for project import');
+  }
+
+  // Legacy path: use parseLumlFile for full project imports
   const result = await parseLumlFile(file);
 
   if (result.exportType === 'project') {

--- a/src/services/openFileService.ts
+++ b/src/services/openFileService.ts
@@ -48,6 +48,7 @@ import { standaloneModelOps } from '../store/standaloneModelOps';
 import { XmiImporterService } from './xmiImporter.service';
 import { parseLumlFile, loadParsedProject } from './projectIO.service';
 import { getDiagramIOService } from './diagram';
+import type { ParsedDiagram } from './diagram';
 
 // ─── Shared helpers ───────────────────────────────────────────────────────────
 
@@ -157,32 +158,212 @@ function findDiagramsFolderId(): string | null {
 // ─── .luml routing ────────────────────────────────────────────────────────────
 
 /**
+ * Injects a diagram parsed by DiagramIOService, preserving the original layout.
+ *
+ * Unlike injectDiagramIntoVFS (legacy), this function:
+ * - Preserves x/y positions from the exported view (no grid reset)
+ * - Correctly remaps parentPackageId when node IDs are regenerated
+ *
+ * Used for the new v2.0 JSON format and legacy single-diagram ZIPs that pass
+ * through DiagramIOService successfully.
+ */
+async function injectParsedDiagram(
+  parsed: ParsedDiagram,
+  mode: OpenMode,
+): Promise<void> {
+  const { view, model: partialModel, name } = parsed;
+  ensureContext(mode, name);
+
+  // Build a node ID map first so parentPackageId can be remapped correctly
+  const nodeIdMap = new Map<string, string>();
+  for (const node of view.nodes) {
+    nodeIdMap.set(node.id, crypto.randomUUID());
+  }
+
+  if (mode === 'standalone') {
+    const fileId = useVFSStore.getState().createFile(
+      null,
+      name,
+      'CLASS_DIAGRAM',
+      '.luml',
+      false,
+      true,
+    );
+
+    const ops = standaloneModelOps(fileId);
+    const idMap = new Map<string, string>();
+
+    for (const [oldId, cls] of Object.entries(partialModel.classes)) {
+      const newAttrs: IRAttribute[] = cls.attributeIds
+        .map((id) => partialModel.attributes[id])
+        .filter(Boolean)
+        .map((a) => ({ ...a, id: crypto.randomUUID() }));
+      const newOps: IROperation[] = cls.operationIds
+        .map((id) => partialModel.operations[id])
+        .filter(Boolean)
+        .map((o) => ({ ...o, id: crypto.randomUUID(), parameters: o.parameters ?? [] }));
+      const newId = cls.isAbstract
+        ? ops.createAbstractClass({ name: cls.name, packageName: cls.packageName, attributeIds: [], operationIds: [], visibility: cls.visibility })
+        : ops.createClass({ name: cls.name, packageName: cls.packageName, attributeIds: [], operationIds: [], visibility: cls.visibility, isAbstract: false });
+      ops.setElementMembers(newId, newAttrs, newOps);
+      idMap.set(oldId, newId);
+    }
+
+    for (const [oldId, iface] of Object.entries(partialModel.interfaces)) {
+      const newOps: IROperation[] = iface.operationIds
+        .map((id) => partialModel.operations[id])
+        .filter(Boolean)
+        .map((o) => ({ ...o, id: crypto.randomUUID(), parameters: o.parameters ?? [] }));
+      const newId = ops.createInterface({ name: iface.name, packageName: iface.packageName, operationIds: [], visibility: iface.visibility });
+      ops.setElementMembers(newId, [], newOps);
+      idMap.set(oldId, newId);
+    }
+
+    for (const [oldId, enm] of Object.entries(partialModel.enums)) {
+      const newId = ops.createEnum({ name: enm.name, packageName: enm.packageName, literals: [...(enm.literals ?? [])], visibility: enm.visibility });
+      idMap.set(oldId, newId);
+    }
+
+    for (const [oldRelId, rel] of Object.entries(partialModel.relations)) {
+      const newSourceId = idMap.get(rel.sourceId);
+      const newTargetId = idMap.get(rel.targetId);
+      if (!newSourceId || !newTargetId) continue;
+      const { id: _id, ...relData } = rel;
+      const newRelId = ops.createRelation({
+        ...relData,
+        sourceId: newSourceId,
+        targetId: newTargetId,
+        ...(rel.sourceEnd ? { sourceEnd: { ...rel.sourceEnd, elementId: newSourceId } } : {}),
+        ...(rel.targetEnd ? { targetEnd: { ...rel.targetEnd, elementId: newTargetId } } : {}),
+      });
+      idMap.set(oldRelId, newRelId);
+    }
+
+    for (const pkgName of (partialModel.packageNames ?? [])) {
+      if (pkgName) ops.addPackageName(pkgName);
+    }
+
+    // Preserve original positions; remap node and parentPackage IDs
+    const viewNodes: ViewNode[] = view.nodes.flatMap((n) => {
+      const newId = nodeIdMap.get(n.id)!;
+      const newParentId = n.parentPackageId ? (nodeIdMap.get(n.parentPackageId) ?? null) : null;
+      if (!n.elementId) {
+        return [{ ...n, id: newId, parentPackageId: newParentId }];
+      }
+      if (!idMap.has(n.elementId)) return [];
+      return [{ ...n, id: newId, elementId: idMap.get(n.elementId)!, parentPackageId: newParentId }];
+    });
+
+    const viewEdges: ViewEdge[] = view.edges
+      .filter((e) => idMap.has(e.relationId))
+      .map((e) => ({ ...e, id: crypto.randomUUID(), relationId: idMap.get(e.relationId)! }));
+
+    useVFSStore.getState().updateFileContent(fileId, { diagramId: fileId, nodes: viewNodes, edges: viewEdges });
+    useWorkspaceStore.getState().openTab(fileId);
+    useToastStore.getState().show(`"${name}" opened as standalone`);
+    return;
+  }
+
+  // Project path
+  const modelStore = useModelStore.getState();
+  const idMap = new Map<string, string>();
+
+  for (const [oldId, cls] of Object.entries(partialModel.classes)) {
+    const newAttrs: IRAttribute[] = cls.attributeIds
+      .map((id) => partialModel.attributes[id])
+      .filter(Boolean)
+      .map((a) => ({ ...a, id: crypto.randomUUID() }));
+    const newOps: IROperation[] = cls.operationIds
+      .map((id) => partialModel.operations[id])
+      .filter(Boolean)
+      .map((o) => ({ ...o, id: crypto.randomUUID(), parameters: o.parameters ?? [] }));
+    const newId = cls.isAbstract
+      ? modelStore.createAbstractClass({ name: cls.name, packageName: cls.packageName, attributeIds: [], operationIds: [], visibility: cls.visibility })
+      : modelStore.createClass({ name: cls.name, packageName: cls.packageName, attributeIds: [], operationIds: [], visibility: cls.visibility, isAbstract: false });
+    modelStore.setElementMembers(newId, newAttrs, newOps);
+    idMap.set(oldId, newId);
+  }
+
+  for (const [oldId, iface] of Object.entries(partialModel.interfaces)) {
+    const newOps: IROperation[] = iface.operationIds
+      .map((id) => partialModel.operations[id])
+      .filter(Boolean)
+      .map((o) => ({ ...o, id: crypto.randomUUID(), parameters: o.parameters ?? [] }));
+    const newId = modelStore.createInterface({ name: iface.name, packageName: iface.packageName, operationIds: [], visibility: iface.visibility });
+    modelStore.setElementMembers(newId, [], newOps);
+    idMap.set(oldId, newId);
+  }
+
+  for (const [oldId, enm] of Object.entries(partialModel.enums)) {
+    const newId = modelStore.createEnum({ name: enm.name, packageName: enm.packageName, literals: [...(enm.literals ?? [])], visibility: enm.visibility });
+    idMap.set(oldId, newId);
+  }
+
+  for (const pkgName of (partialModel.packageNames ?? [])) {
+    if (pkgName) modelStore.addPackageName(pkgName);
+  }
+
+  for (const [oldRelId, rel] of Object.entries(partialModel.relations)) {
+    const newSourceId = idMap.get(rel.sourceId);
+    const newTargetId = idMap.get(rel.targetId);
+    if (!newSourceId || !newTargetId) continue;
+    const newRelId = modelStore.createRelation({
+      kind: rel.kind,
+      sourceId: newSourceId,
+      targetId: newTargetId,
+      name: rel.name,
+      stereotypes: rel.stereotypes,
+      ...(rel.sourceEnd || rel.targetEnd
+        ? {
+            sourceEnd: rel.sourceEnd ? { ...rel.sourceEnd, elementId: newSourceId } : undefined,
+            targetEnd: rel.targetEnd ? { ...rel.targetEnd, elementId: newTargetId } : undefined,
+          }
+        : {}),
+    });
+    idMap.set(oldRelId, newRelId);
+  }
+
+  const parentId = findDiagramsFolderId();
+  const fileId = useVFSStore.getState().createFile(parentId, name, 'CLASS_DIAGRAM', '.luml', false);
+
+  // Preserve original positions; remap node and parentPackage IDs
+  const viewNodes: ViewNode[] = view.nodes.flatMap((n) => {
+    const newId = nodeIdMap.get(n.id)!;
+    const newParentId = n.parentPackageId ? (nodeIdMap.get(n.parentPackageId) ?? null) : null;
+    if (!n.elementId) {
+      return [{ ...n, id: newId, parentPackageId: newParentId }];
+    }
+    if (!idMap.has(n.elementId)) return [];
+    return [{ ...n, id: newId, elementId: idMap.get(n.elementId)!, parentPackageId: newParentId }];
+  });
+
+  const viewEdges: ViewEdge[] = view.edges
+    .filter((e) => idMap.has(e.relationId))
+    .map((e) => ({ ...e, id: crypto.randomUUID(), relationId: idMap.get(e.relationId)! }));
+
+  useVFSStore.getState().updateFileContent(fileId, { diagramId: fileId, nodes: viewNodes, edges: viewEdges });
+  useWorkspaceStore.getState().openTab(fileId);
+}
+
+/**
  * Opens a .luml file, routing by its embedded exportType:
  *
  *   "project"  → loads the full workspace (mode is ignored)
  *   "diagram"  → injects the single diagram based on mode
  */
 export async function openLumlFile(file: File, mode: OpenMode): Promise<void> {
-  // Try new DiagramIOService first for single diagram imports
+  // New format path: DiagramIOService handles JSON v2.0 and legacy single-diagram ZIPs.
+  // Uses injectParsedDiagram to preserve layout and remap parentPackageId correctly.
   try {
     const diagramService = getDiagramIOService();
     const parsed = await diagramService.importDiagram(file);
-    
-    // Successfully parsed as diagram - inject it
-    await injectDiagramIntoVFS(
-      parsed.view,
-      parsed.model,
-      parsed.name,
-      mode,
-    );
+    await injectParsedDiagram(parsed, mode);
     return;
-  } catch (error) {
-    // If it's not a diagram format, fall back to legacy parser
-    // This handles full project imports
-    console.info('[LibreUML] Falling back to legacy parser for project import');
+  } catch {
+    // Falls through to the legacy parser for full project ZIPs and v1 JSON
   }
 
-  // Legacy path: use parseLumlFile for full project imports
+  // Legacy path: handles full project ZIPs and very old v1 JSON format
   const result = await parseLumlFile(file);
 
   if (result.exportType === 'project') {

--- a/src/services/projectIO.service.ts
+++ b/src/services/projectIO.service.ts
@@ -480,6 +480,21 @@ export async function downloadProject(): Promise<void> {
  * Exports just the active diagram as a standalone .luml file.
  * Sets exportType: "diagram" and bundles only the semantic elements
  * referenced by that diagram — does NOT include the rest of the workspace.
+ * 
+ * @deprecated Use DiagramIOService.exportDiagram() instead.
+ * This function is kept for backward compatibility but will be removed in a future version.
+ * 
+ * Migration:
+ * ```typescript
+ * // Old way
+ * import { exportDiagram } from './projectIO.service';
+ * await exportDiagram(fileId);
+ * 
+ * // New way
+ * import { getDiagramIOService } from './diagram';
+ * const service = getDiagramIOService();
+ * await service.exportDiagram(fileId);
+ * ```
  */
 export async function exportDiagram(fileId: string): Promise<void> {
   const project = useVFSStore.getState().project;

--- a/src/store/model.store.ts
+++ b/src/store/model.store.ts
@@ -59,6 +59,8 @@ interface ModelStoreState {
   setElementPackage: (elementId: string, packageName: string | undefined) => void;
 }
 
+export type ModelStore = ModelStoreState;
+
 export const useModelStore = create<ModelStoreState>()(
   persist(
     immer((set) => ({

--- a/src/store/project-vfs.store.ts
+++ b/src/store/project-vfs.store.ts
@@ -60,6 +60,8 @@ interface VFSStoreState {
   updateLocalModel: (fileId: string, updater: (draft: SemanticModel) => void) => void;
 }
 
+export type VFSStore = VFSStoreState;
+
 export const useVFSStore = create<VFSStoreState>()(
   persist(
     immer((set) => ({

--- a/src/util/__tests__/connectionValidator.test.ts
+++ b/src/util/__tests__/connectionValidator.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { validateConnection } from '../connectionValidator';
+
+describe('validateConnection — package relations', () => {
+  it('allows generic dependency between packages', () => {
+    expect(validateConnection('package', 'package', 'dependency')).toBe(true);
+  });
+
+  it('allows package_import between packages', () => {
+    expect(validateConnection('package', 'package', 'package_import')).toBe(true);
+  });
+
+  it('allows package_access between packages', () => {
+    expect(validateConnection('package', 'package', 'package_access')).toBe(true);
+  });
+
+  it('allows package_merge between packages', () => {
+    expect(validateConnection('package', 'package', 'package_merge')).toBe(true);
+  });
+
+  it('rejects association between packages', () => {
+    expect(validateConnection('package', 'package', 'association')).toBe(false);
+  });
+
+  it('rejects inheritance between packages', () => {
+    expect(validateConnection('package', 'package', 'inheritance')).toBe(false);
+  });
+
+  it('rejects aggregation between packages', () => {
+    expect(validateConnection('package', 'package', 'aggregation')).toBe(false);
+  });
+
+  it('rejects package_import from class to package', () => {
+    expect(validateConnection('class', 'package', 'package_import')).toBe(false);
+  });
+
+  it('rejects package_import from package to class', () => {
+    expect(validateConnection('package', 'class', 'package_import')).toBe(false);
+  });
+
+  it('rejects package_access from class to class', () => {
+    expect(validateConnection('class', 'class', 'package_access')).toBe(false);
+  });
+
+  it('rejects package_merge from interface to package', () => {
+    expect(validateConnection('interface', 'package', 'package_merge')).toBe(false);
+  });
+});
+
+describe('validateConnection — note bypass', () => {
+  it('allows any relation to/from note', () => {
+    expect(validateConnection('note', 'class', 'association')).toBe(true);
+    expect(validateConnection('class', 'note', 'inheritance')).toBe(true);
+    expect(validateConnection('note', 'package', 'package_import')).toBe(true);
+  });
+});
+
+describe('validateConnection — class relations', () => {
+  it('allows class→class inheritance', () => {
+    expect(validateConnection('class', 'class', 'inheritance')).toBe(true);
+  });
+
+  it('rejects class→interface inheritance', () => {
+    expect(validateConnection('class', 'interface', 'inheritance')).toBe(false);
+  });
+
+  it('allows class→interface implementation', () => {
+    expect(validateConnection('class', 'interface', 'implementation')).toBe(true);
+  });
+
+  it('rejects interface→class implementation', () => {
+    expect(validateConnection('interface', 'class', 'implementation')).toBe(false);
+  });
+
+  it('allows class→class dependency', () => {
+    expect(validateConnection('class', 'class', 'dependency')).toBe(true);
+  });
+
+  it('allows class→package dependency', () => {
+    expect(validateConnection('class', 'package', 'dependency')).toBe(true);
+  });
+});

--- a/src/util/connectionValidator.ts
+++ b/src/util/connectionValidator.ts
@@ -1,10 +1,12 @@
 import type { stereotype, UmlRelationType } from "../features/diagram/types/diagram.types";
 
-/**
- * Definition of allowed relationships based on UML 2.5 standards and Java semantics.
- * Key: The relationship type.
- * Value: A set of rules defining valid source and target stereotypes.
- */
+const PACKAGE_RELATION_TYPES = new Set<UmlRelationType>([
+  "dependency",
+  "package_import",
+  "package_access",
+  "package_merge",
+]);
+
 const RELATIONSHIP_RULES: Record<
   UmlRelationType,
   {
@@ -14,13 +16,10 @@ const RELATIONSHIP_RULES: Record<
   }
 > = {
   inheritance: {
-    // Class extends Class, Interface extends Interface
     sources: ["class", "abstract", "interface"],
     targets: ["class", "abstract", "interface"],
     validator: (source, target) => {
-      const isSourceInterface = source === "interface";
-      const isTargetInterface = target === "interface";
-      return isSourceInterface === isTargetInterface;
+      return (source === "interface") === (target === "interface");
     },
   },
   implementation: {
@@ -43,14 +42,22 @@ const RELATIONSHIP_RULES: Record<
     sources: ["class", "abstract", "interface", "enum"],
     targets: ["class", "abstract", "interface", "enum"],
   },
+  package_import: {
+    sources: ["package"],
+    targets: ["package"],
+  },
+  package_access: {
+    sources: ["package"],
+    targets: ["package"],
+  },
+  package_merge: {
+    sources: ["package"],
+    targets: ["package"],
+  },
 };
 
 /**
  * Validates if a connection is semantically correct according to UML rules.
- * @param sourceStereotype The stereotype of the source node.
- * @param targetStereotype The stereotype of the target node.
- * @param relationType The type of relationship being attempted.
- * @returns {boolean} True if the connection is valid, false otherwise.
  */
 export const validateConnection = (
   sourceStereotype: stereotype,
@@ -60,7 +67,7 @@ export const validateConnection = (
   if (sourceStereotype === "note" || targetStereotype === "note") return true;
 
   if (sourceStereotype === "package" && targetStereotype === "package") {
-    return relationType === "dependency";
+    return PACKAGE_RELATION_TYPES.has(relationType);
   }
 
   const rule = RELATIONSHIP_RULES[relationType];


### PR DESCRIPTION
## 🚀 Overview
This PR introduces the massive v0.9.0 architecture refactor to the canvas and brings LibreUML to the **v0.9.0** milestone. It completely separates the Semantic Model (IR) from the Visual Representation (DiagramView), establishing a robust Single Source of Truth (SSOT) across the application. 

Additionally, it implements advanced package nesting, fully syncing the canvas drag-and-drop hierarchy with the sidebar explorers, and introduces atomic transactions for safe standalone mode execution.

## 🛠️ Key Architectural Changes
* **Semantic vs. Visual Layer Separation:** * Implemented the new `SemanticModel` (handling `IRPackage`, `IRClass`, `IRRelation`).
  * Implemented `DiagramView` (handling `ViewNode`, `ViewEdge`, and coordinates).
* **Advanced Package Nesting:**
  * Packages can now be visually nested inside other packages on the canvas via Drag & Drop.
  * Sidebar trees (Package Explorer & Model Explorer) now dynamically calculate `effectivePaths` (e.g., `Parent.ChildPackage`) to perfectly mirror the canvas hierarchy.
* **Atomic Mutations & Standalone Safety:**
  * Rewrote deletion logic using `undoTransaction`.
  * Deletions now trigger a full cascade (removing the package, filtering nested sub-packages, un-assigning/deleting elements, and cleaning up `parentPackageId` orphans on the canvas).
  * Safely handles both Global Model and Standalone (local file) scopes.

## 🐛 Bug Fixes & Refinements
* **Explorer Sync:** Fixed the critical bug where visually nested packages appeared at the root level in the sidebar. The UI now respects `ViewNode.parentPackageId`.
* **Export Preservations:** Fixed diagram export issues to properly preserve layout and nested bounding boxes (resolving the `fix/diagram-export-preserve-layout` branch focus).

## 🧪 Testing Performed
* [x] Dragging a class into a package updates both the canvas bounds and the sidebar tree.
* [x] Dragging a package into another package updates the `effectivePath`.
* [x] Deleting a parent package successfully cascades to its children and cleans up the UI.
* [x] `Ctrl+Z` (Undo) successfully restores deeply nested packages and their relationships in Standalone mode.

**Target Release:** `v0.9.0` 🏷️