### PR TITLE
fix(diagram): improve active diagram validation and optimize view node returns

### DIFF
--- a/src/features/diagram/components/layout/DiagramEditor.tsx
+++ b/src/features/diagram/components/layout/DiagramEditor.tsx
@@ -52,6 +52,11 @@ function EditorLogic() {
   
   const { project } = useVFSStore();
   const activeTabId = useWorkspaceStore((s) => s.activeTabId);
+  const openTabs = useWorkspaceStore((s) => s.openTabs);
+  const hasActiveDiagram =
+    !!activeTabId &&
+    openTabs.includes(activeTabId) &&
+    !!project?.nodes[activeTabId];
   const { isLeftPanelOpen, isRightPanelOpen, isBottomPanelOpen } = useLayoutStore();
   const { activeModal, editingId, closeModals } = useUiStore();
   const javaImportPreference = useSettingsStore((s) => s.javaImportPreference);
@@ -159,7 +164,7 @@ function EditorLogic() {
           <TabBar />
           <div className="flex flex-1 min-h-0 overflow-hidden">
             <div className="flex-1 overflow-hidden">
-              {activeTabId ? <KonvaCanvas /> : <SleepScreen />}
+              {hasActiveDiagram ? <KonvaCanvas /> : <SleepScreen />}
             </div>
             <div
               className={`overflow-hidden transition-all duration-200 ease-in-out shrink-0 ${

--- a/src/features/diagram/components/layout/PackageExplorer.tsx
+++ b/src/features/diagram/components/layout/PackageExplorer.tsx
@@ -20,6 +20,7 @@ import type { DeletePackageState, TreeNode } from "./packageExplorer/types";
 import type { SemanticModel, VFSFile, ViewNode } from "../../../../core/domain/vfs/vfs.types";
 
 const SIDEBAR_DND_TYPE = 'application/libreuml-sidebar-class';
+const EMPTY_VIEW_NODES: ViewNode[] = [];
 
 
 function irVisToSymbol(v: string | undefined): UmlVisibility {
@@ -166,11 +167,11 @@ export default function PackageExplorer() {
   const activeModel = isStandalone ? localModel : model;
 
   const viewNodes = useVFSStore((s): ViewNode[] => {
-    if (!activeTabId || !s.project) return [];
+    if (!activeTabId || !s.project) return EMPTY_VIEW_NODES;
     const node = s.project.nodes[activeTabId];
-    if (!node || node.type !== 'FILE') return [];
+    if (!node || node.type !== 'FILE') return EMPTY_VIEW_NODES;
     const content = (node as VFSFile).content;
-    if (!isDiagramView(content)) return [];
+    if (!isDiagramView(content)) return EMPTY_VIEW_NODES;
     return content.nodes;
   });
 


### PR DESCRIPTION
- Add comprehensive active diagram check combining activeTabId, openTabs, and project node existence
- Replace inline empty array returns with EMPTY_VIEW_NODES constant to prevent unnecessary allocations
- Update canvas rendering condition to use hasActiveDiagram for more robust tab state validation
- Ensures canvas only renders when diagram is truly available and prevents stale tab references