### PR TITLE
hotfix(notes): disable inline editing and connection anchors on note nodes

### DIFF
--- a/src/canvas/KonvaCanvas.tsx
+++ b/src/canvas/KonvaCanvas.tsx
@@ -484,19 +484,11 @@ export default function KonvaCanvas() {
     const pos = positionOverrides.get(shape.id) ?? { x: shape.x, y: shape.y };
     const transform = stage.getAbsoluteTransform().copy();
 
-    if (isNoteViewModel(shape.data)) {
-      const NOTE_H_PAD = 8;
-      const NOTE_V_PAD = 8;
-      const titleY = NOTE_V_PAD / 2 + 2;
-      const screenPos = transform.point({ x: pos.x + NOTE_H_PAD, y: pos.y + titleY });
-      updateEditorPosition({ x: screenPos.x, y: screenPos.y });
-    } else {
-      const H_PAD = 10;
-      const layout = getClassShapeSize(shape.data as NodeViewModel);
-      const nameY = layout.height * 0.15;
-      const screenPos = transform.point({ x: pos.x + H_PAD, y: pos.y + nameY });
-      updateEditorPosition({ x: screenPos.x, y: screenPos.y });
-    }
+    const H_PAD = 10;
+    const layout = getClassShapeSize(shape.data as NodeViewModel);
+    const nameY = layout.height * 0.15;
+    const screenPos = transform.point({ x: pos.x + H_PAD, y: pos.y + nameY });
+    updateEditorPosition({ x: screenPos.x, y: screenPos.y });
   }, [viewport, isEditing, activeNodeId, shapes, positionOverrides, stageRef, updateEditorPosition]);
 
   const handleClassDblClick = useCallback(
@@ -535,48 +527,6 @@ export default function KonvaCanvas() {
           { x: screenPos.x, y: screenPos.y },
           { width: textWidth, height: textHeight },
           onRename,
-        );
-      }
-    },
-    [shapes, stageRef, startInlineEditing],
-  );
-
-  const handleNoteDblClick = useCallback(
-    (shapeId: string, e: KonvaEventObject<MouseEvent>) => {
-      const shape = shapes.find((s) => s.id === shapeId);
-      if (!shape || !isNoteViewModel(shape.data)) return;
-
-      const vm = shape.data;
-      const stage = stageRef.current;
-      if (!stage) return;
-
-      const groupNode = e.target.findAncestor('Group');
-      if (!groupNode) return;
-
-      const NOTE_H_PAD = 8;
-      const NOTE_V_PAD = 8;
-      const NOTE_TITLE_H = 32;
-      const NOTE_W = 224;
-
-      const groupPos = groupNode.getAbsolutePosition();
-      const titleY = NOTE_V_PAD / 2 + 2;
-      
-      const transform = stage.getAbsoluteTransform().copy();
-      const screenPos = transform.point({ x: groupPos.x + NOTE_H_PAD, y: groupPos.y + titleY });
-      
-      const textWidth = NOTE_W - 2 * NOTE_H_PAD - 12;
-      const textHeight = NOTE_TITLE_H - NOTE_V_PAD;
-
-      const onSave = vm.onSave;
-      
-      if (onSave) {
-        startInlineEditing(
-          shapeId,
-          vm.title ?? '',
-          'title',
-          { x: screenPos.x, y: screenPos.y },
-          { width: textWidth, height: textHeight },
-          (newTitle) => onSave({ title: newTitle }),
         );
       }
     },
@@ -1167,7 +1117,6 @@ export default function KonvaCanvas() {
                       onDragMove={handleDragMove}
                       onDragEnd={handleDragEnd}
                       onNodeClick={onNodeClick}
-                      onDblClick={(e) => handleNoteDblClick(shape.id, e)}
                       onContextMenu={handleNodeContextMenu}
                       visible={isVisible && !isDescendantOfCollapsed}
                     />

--- a/src/canvas/interactions/useConnectionDraw.ts
+++ b/src/canvas/interactions/useConnectionDraw.ts
@@ -210,12 +210,21 @@ export function useConnectionDraw({
 
   // ── Refs (event-handler safe, no stale closure issues) ────────────────────
   const isConnectingRef = useRef(false);
+  /** Set of node IDs that are notes — excluded from anchor detection entirely. */
+  const noteIdsRef = useRef<Set<string>>(new Set());
   /** True when cursor is near any anchor — read by KonvaCanvas to suppress drag. */
   const nearAnchorRef = useRef(false);
   /** Source anchor that the connection draw started from. */
   const sourceRef = useRef<AnchorDot | null>(null);
   /** Tracks which node is currently hovered to avoid unnecessary state thrashing. */
   const hoverNodeIdRef = useRef<string | null>(null);
+
+  // Keep noteIdsRef in sync so mouse handlers never anchor onto note nodes.
+  useEffect(() => {
+    noteIdsRef.current = new Set(
+      nodes.filter((n) => isNoteViewModel(n.data)).map((n) => n.id),
+    );
+  }, [nodes]);
 
   // ── Reset helper ──────────────────────────────────────────────────────────
 
@@ -242,12 +251,17 @@ export function useConnectionDraw({
       const pos = stage.getRelativePointerPosition();
       if (!pos) return;
 
+      const noteIds = noteIdsRef.current;
+      const connectableBounds = new Map(
+        [...boundsMapRef.current.entries()].filter(([id]) => !noteIds.has(id)),
+      );
+
       if (isConnectingRef.current) {
         // ── Drawing mode: update temp line + find snap target ─────────────
         const src = sourceRef.current;
         if (!src) return;
 
-        const snap = findNearest(pos, boundsMapRef.current, ANCHOR_SNAP_R, src.nodeId);
+        const snap = findNearest(pos, connectableBounds, ANCHOR_SNAP_R, src.nodeId);
         const endX = snap ? snap.x : pos.x;
         const endY = snap ? snap.y : pos.y;
 
@@ -255,15 +269,15 @@ export function useConnectionDraw({
         setSnapTargetDot(snap);
       } else {
         // ── Hover mode: update nearAnchorRef + visible anchor dots ────────
-        const near = findNearest(pos, boundsMapRef.current, ANCHOR_DETECT_R);
+        const near = findNearest(pos, connectableBounds, ANCHOR_DETECT_R);
         nearAnchorRef.current = !!near;
 
         // Only update hovered-node anchors when the hovered node changes.
-        const hoveredId = findHoveredNode(pos, boundsMapRef.current);
+        const hoveredId = findHoveredNode(pos, connectableBounds);
         if (hoveredId !== hoverNodeIdRef.current) {
           hoverNodeIdRef.current = hoveredId;
           if (hoveredId) {
-            const b = boundsMapRef.current.get(hoveredId);
+            const b = connectableBounds.get(hoveredId);
             setHoveredNodeAnchors(b ? getAnchorDots(hoveredId, b) : []);
           } else {
             setHoveredNodeAnchors([]);
@@ -287,7 +301,11 @@ export function useConnectionDraw({
       const pos = stage.getRelativePointerPosition();
       if (!pos) return;
 
-      const nearest = findNearest(pos, boundsMapRef.current, ANCHOR_DETECT_R);
+      const noteIds = noteIdsRef.current;
+      const connectableBounds = new Map(
+        [...boundsMapRef.current.entries()].filter(([id]) => !noteIds.has(id)),
+      );
+      const nearest = findNearest(pos, connectableBounds, ANCHOR_DETECT_R);
       if (!nearest) {
         nearAnchorRef.current = false;
         return;
@@ -321,7 +339,11 @@ export function useConnectionDraw({
       if (stage && src) {
         const pos = stage.getRelativePointerPosition();
         if (pos) {
-          const snap = findNearest(pos, boundsMapRef.current, ANCHOR_SNAP_R, src.nodeId);
+          const noteIds = noteIdsRef.current;
+          const connectableBounds = new Map(
+            [...boundsMapRef.current.entries()].filter(([id]) => !noteIds.has(id)),
+          );
+          const snap = findNearest(pos, connectableBounds, ANCHOR_SNAP_R, src.nodeId);
           if (snap) {
             // ── Validate via connectionValidator.ts ───────────────────────
             const srcNode = nodes.find((n) => n.id === src.nodeId);

--- a/src/util/connectionValidator.ts
+++ b/src/util/connectionValidator.ts
@@ -64,7 +64,7 @@ export const validateConnection = (
   targetStereotype: stereotype,
   relationType: UmlRelationType
 ): boolean => {
-  if (sourceStereotype === "note" || targetStereotype === "note") return true;
+  if (sourceStereotype === "note" || targetStereotype === "note") return false;
 
   if (sourceStereotype === "package" && targetStereotype === "package") {
     return PACKAGE_RELATION_TYPES.has(relationType);


### PR DESCRIPTION
Notes are display-only elements — they cannot be renamed via double-click nor used as source or target of any UML relation.

- Remove handleNoteDblClick and onDblClick prop from NoteShape
- Filter note IDs out of the bounds map before anchor detection in useConnectionDraw
- connectionValidator now returns false when either endpoint is a note